### PR TITLE
feat(upload): add sign-in option on upload page (#32)

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import TicketUploadForm from "@/components/ticket-upload-form";
+import SignInForm from "@/components/sign-in-form";
 
 export default async function UploadPage() {
   const session = await auth();
@@ -8,6 +9,9 @@ export default async function UploadPage() {
       <main className="mx-auto max-w-3xl px-6 py-16">
         <h1 className="text-2xl font-semibold">Sign in to upload</h1>
         <p className="mt-2 text-slate-600">You need an account to upload and verify tickets.</p>
+          <div className="mt-6">
+              <SignInForm />
+          </div>
       </main>
     );
   }


### PR DESCRIPTION
### Problem
Upload page allowed access without authentication, but users should sign in before uploading tickets.

### Solution
- Added a sign-in option to the upload page.  
- If the user is not authenticated, the page now displays a message prompting them to sign in.  
- When signed in, the ticket upload form is displayed as before.

### Related issue
Closes #32