### PR TITLE
Fix: header navigation links not working on /upload page

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -38,10 +38,10 @@ export default function SiteHeader({session}: Props) {
         </div>
 
         <nav className="hidden items-center text-sm text-slate-800 dark:text-slate-400 hover:*:opacity-80 gap-6 md:flex">
-          <Link href="#features">Features</Link>
-          <Link href="#how-it-works">How it works</Link>
-          <Link href="#testimonials">Stories</Link>
-          <Link href="#faq">FAQ</Link>
+          <Link href="/#features">Features</Link>
+          <Link href="/#how-it-works">How it works</Link>
+          <Link href="/#testimonials">Stories</Link>
+          <Link href="/#faq">FAQ</Link>
           <Link href="/upload">Upload</Link>
         </nav>
 
@@ -81,10 +81,10 @@ export default function SiteHeader({session}: Props) {
         <motion.div initial={{maxHeight: 0}} exit={{maxHeight:0}}  animate={{maxHeight: 500}} transition={{duration: 0.2}} className="overflow-hidden z-20 absolute left-0 right-0 border border-slate-200/60 dark:border-slate-800/60 bg-white dark:bg-slate-900 md:hidden transition duration-150">
           <div className=" mx-auto max-w-6xl px-6 py-3">
             <div className="grid gap-2 dark:*:text-slate-200">
-              <Link href="#features" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Features</Link>
-              <Link href="#how-it-works" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>How it works</Link>
-              <Link href="#testimonials" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Stories</Link>
-              <Link href="#faq" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>FAQ</Link>
+              <Link href="/#features" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Features</Link>
+              <Link href="/#how-it-works" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>How it works</Link>
+              <Link href="/#testimonials" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Stories</Link>
+              <Link href="/#faq" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>FAQ</Link>
               <Link href="/upload" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Upload</Link>
               <div className="flex pl-2 pr-8 py-2 justify-between">
                 <p>Dark Theme</p>


### PR DESCRIPTION
### Problem
When visiting the /upload page, header navigation links (Features, How it works, Stories, FAQ) did not work. 
They were pointing to relative anchors like `#features`, which only work from the homepage.

### Fix
- Updated header navigation links to use absolute paths (`/#features`, `/#how-it-works`, `/#testimonials`, `/#faq`).
- Works now from any page, including /upload.

### Related issue
Closes #22