### PR TITLE
fix: remove duplicate links from footer sections

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -39,28 +39,6 @@ export default function SiteFooter() {
             </p>
 
             <div className="flex flex-col gap-2">
-              <div className="flex flex-col gap-2">
-                <Link
-                  href="/#faq"
-                  className="text-slate-600 dark:text-slate-400 hover:text-slate-300 dark:hover:text-slate-200 transition-colors duration-200"
-                >
-                  FAQ
-                </Link>
-
-                <Link
-                  href="/contact"
-                  className="text-slate-600 dark:text-slate-400 hover:text-slate-300 dark:hover:text-slate-200 transition-colors duration-200"
-                >
-                  Contact
-                </Link>
-
-                <Link
-                  href="/about"
-                  className="text-slate-600 dark:text-slate-400 hover:text-slate-300 dark:hover:text-slate-200 transition-colors duration-200"
-                >
-                  About
-                </Link>
-
                 <Link
                   href="/signin"
                   className="text-slate-600 dark:text-slate-400 hover:text-slate-300 dark:hover:text-slate-200 transition-colors duration-200"
@@ -74,9 +52,6 @@ export default function SiteFooter() {
                 >
                   Get started
                 </Link>
-              </div>
-
-
             </div>
           </div>
 
@@ -110,20 +85,6 @@ export default function SiteFooter() {
                 className="text-slate-600 dark:text-slate-400 hover:text-slate-300 dark:hover:text-slate-200 transition-colors duration-200"
               >
                 About
-              </Link>
-
-              <Link
-                href="/signin"
-                className="text-slate-600 dark:text-slate-400 hover:text-slate-300 dark:hover:text-slate-200 transition-colors duration-200"
-              >
-                Sign in
-              </Link>
-
-              <Link
-                href="/signup"
-                className="text-slate-600 dark:text-slate-400 hover:text-slate-300 dark:hover:text-slate-200 transition-colors duration-200"
-              >
-                Get started
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Fixes #91 

### Summary
The Product and Support footer sections contained identical links (FAQ, Contact, About, Sign in, Get started). This PR differentiates them by keeping navigation links in Product and support-specific links in Support.

### Changes
```
src/components/site-footer.tsx | 39 ---------
1 file changed, 39 deletions(-)
```

---
<sub>If this fix isn't quite right, please leave feedback and I'll revise it.</sub>