### PR TITLE
fix: add missing SendHorizontal icon to chat send button

### DIFF
--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { MessageCircle } from "lucide-react";
+import { MessageCircle, SendHorizonal } from "lucide-react";
 
 type Message = {
   role: "user" | "bot";
@@ -207,7 +207,9 @@ hover:scale-110
               <button
                 onClick={sendMessage}
                 disabled={loading}
-className="h-14 w-14 rounded-full bg-blue-600 text-white shadow-md flex items-center justify-center transition-all duration-300 hover:scale-110">              </button>
+className="h-14 w-14 rounded-full bg-blue-600 text-white shadow-md flex items-center justify-center transition-all duration-300 hover:scale-110">              
+  <SendHorizonal size={22} />
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
fix: add missing SendHorizontal icon to chat send button

## fix #158

## Description
The send button in the TravelBox chat component was rendering as a plain  blue circle with no icon inside it, giving users no visual cue that the button submits their message. This fix adds the missing SendHorizontal icon from lucide-react inside the send button.

## Type of Change
- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Screenshots
<img width="336" height="433" alt="Screenshot 2026-06-17 at 16 14 50" src="https://github.com/user-attachments/assets/ccb2762d-6af1-41bb-9a9d-08bb2a26d31b" /> <img width="332" height="426" alt="Screenshot 2026-06-17 at 16 16 07" src="https://github.com/user-attachments/assets/03c42b98-34d3-4c17-ba63-50e4c9f38693" />
<img width="298" height="87" alt="Screenshot 2026-06-17 at 16 30 31" src="https://github.com/user-attachments/assets/8e67802e-62d4-4a3e-b138-d3c10f383d2d" />


## Dependencies
No new dependencies added. Uses lucide-react which is already installed in the project.

## Checklist
- [x] Lints pass (`npm run lint`)
- [x] Builds locally (`npm run build`)
- [ ] Tests added/updated (if changing logic)
- [ ] Docs updated (README/CONTRIBUTING as needed)
- [x] I have tested my changes across major browsers/devices
- [x] My changes do not generate new console warnings or errors, I ran `npm run build` and attached screenshot in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.