### PR TITLE
fix: dynamically update ticket banner season

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import {
   UserPlus,
   Quote,
 } from "lucide-react";
-
+import TicketVerificationBanner from "@/components/ticket-verification-banner";
 import VerifiedTicket from "@/components/illustrations/VerifiedTicket";
 import SmartMatching from "@/components/illustrations/SmartMatching";
 import PrivateMessaging from "@/components/illustrations/PrivateMessaging";
@@ -31,7 +31,7 @@ export default function HomePage() {
               <div className="text-slate-900 dark:text-white">
                 <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 dark:bg-white/10 px-4 py-1 text-sm text-slate-600 dark:text-gray-200 backdrop-blur">
                   <span className="h-2 w-2 rounded-full bg-emerald-500" />
-                  Now verifying tickets for fall trips
+                  <TicketVerificationBanner />
                 </div>
 
                 <h1 className="mt-6 text-4xl font-bold leading-tight md:text-6xl">

--- a/src/components/ticket-verification-banner.tsx
+++ b/src/components/ticket-verification-banner.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getCurrentSeason } from "@/lib/season";
+
+export default function TicketVerificationBanner() {
+  const [season, setSeason] = useState<string>("upcoming");
+
+  useEffect(() => {
+    setSeason(getCurrentSeason());
+  }, []);
+
+  return <>Now verifying tickets for {season} trips</>;
+}

--- a/src/lib/season.test.ts
+++ b/src/lib/season.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getCurrentSeason } from "./season";
+
+describe("getCurrentSeason", () => {
+  it("returns winter for January", () => {
+    expect(getCurrentSeason(new Date("2026-01-15"))).toBe("winter");
+  });
+
+  it("returns winter for February", () => {
+    expect(getCurrentSeason(new Date("2026-02-15"))).toBe("winter");
+  });
+
+  it("returns spring for March, April, and May", () => {
+    expect(getCurrentSeason(new Date("2026-03-15"))).toBe("spring");
+    expect(getCurrentSeason(new Date("2026-04-15"))).toBe("spring");
+    expect(getCurrentSeason(new Date("2026-05-15"))).toBe("spring");
+  });
+
+  it("returns summer for June, July, and August", () => {
+    expect(getCurrentSeason(new Date("2026-06-15"))).toBe("summer");
+    expect(getCurrentSeason(new Date("2026-07-15"))).toBe("summer");
+    expect(getCurrentSeason(new Date("2026-08-15"))).toBe("summer");
+  });
+
+  it("returns fall for September, October, and November", () => {
+    expect(getCurrentSeason(new Date("2026-09-15"))).toBe("fall");
+    expect(getCurrentSeason(new Date("2026-10-15"))).toBe("fall");
+    expect(getCurrentSeason(new Date("2026-11-15"))).toBe("fall");
+  });
+
+  it("returns winter for December", () => {
+    expect(getCurrentSeason(new Date("2026-12-15"))).toBe("winter");
+  });
+});

--- a/src/lib/season.ts
+++ b/src/lib/season.ts
@@ -1,0 +1,19 @@
+export type Season = "spring" | "summer" | "fall" | "winter";
+
+export function getCurrentSeason(date: Date = new Date()): Season {
+  const month = date.getMonth(); // 0 = January, 11 = December
+
+  if (month >= 2 && month <= 4) {
+    return "spring";
+  }
+
+  if (month >= 5 && month <= 7) {
+    return "summer";
+  }
+
+  if (month >= 8 && month <= 10) {
+    return "fall";
+  }
+
+  return "winter";
+}


### PR DESCRIPTION
## fix #169 

## Description

This PR replaces the hardcoded season in the homepage ticket verification banner with a dynamic value based on the current month.

Previously, the banner always displayed:

> "Now verifying tickets for fall trips"

With this change, the displayed season is determined automatically using the current date, following the mapping specified in the issue:

- Spring: March – May
- Summer: June – August
- Fall: September – November
- Winter: December – February

This eliminates the need for manual seasonal updates and ensures the homepage always displays the correct message.

Additionally, the season calculation logic has been separated into a reusable utility function, making it easier to maintain and test.

Closes #169.

---

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

---

## Screenshots

### Before

```
Now verifying tickets for fall trips
```

### After (Example)

```
Now verifying tickets for summer trips
```
<img width="1382" height="514" alt="Screenshot 2026-07-02 121343" src="https://github.com/user-attachments/assets/5ac1fdc1-9792-4346-9240-4c15c272964c" />


<img width="1385" height="655" alt="Screenshot 2026-07-02 121921" src="https://github.com/user-attachments/assets/7b3bab31-adac-4169-a51b-9b089f602c2d" />
<img width="1374" height="732" alt="Screenshot 2026-07-02 121933" src="https://github.com/user-attachments/assets/e1cf7ba1-b620-4df9-aae0-3c4af421d300" />
<img width="1382" height="779" alt="Screenshot 2026-07-02 121941" src="https://github.com/user-attachments/assets/a99aecb6-41dc-4716-9cc4-2cc6884dad2b" />


---

## Dependencies

No new dependencies were added.

The implementation uses the existing project setup and JavaScript `Date` API for determining the current season.

---

## Checklist

- [x] Lints pass (`npm run lint`)
- [x] Builds locally (`npm run build`)
- [x] Tests added/updated (if changing logic)
- [ ] Docs updated (README/CONTRIBUTING as needed)
- [x] I have tested my changes across major browsers/devices
- [x] My changes do not generate new console warnings or errors. I ran `npm run build` and attached the build screenshot in this PR.
- [x] This is an already assigned issue to me, not an unassigned issue.