### PR TITLE
Improve auth page UI consistency

### DIFF
--- a/src/app/routes/new/page.tsx
+++ b/src/app/routes/new/page.tsx
@@ -1,5 +1,5 @@
-import { auth } from "@/lib/auth";
 import SignInForm from "@/components/sign-in-form";
+import { auth } from "@/lib/auth";
 import NewRouteClient from "./new-route-client";
 
 export default async function NewRoutePage() {
@@ -7,16 +7,20 @@ export default async function NewRoutePage() {
 
   if (!session?.user?.id) {
     return (
-      <main className="min-h-screen py-16 px-6">
-        <div className="mx-auto max-w-[1800px]">
-          <h1 className="text-2xl font-semibold">Sign in to Create Routes</h1>
-          <p className="mt-2 text-slate-600">
-            You need an account to Create, View, and Manage Routes.
+      <main className="flex flex-col items-center py-6">
+        <div className="mx-auto max-w-md text-center px-6 mb-6">
+          <span className="inline-block rounded-full bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 px-4 py-1 text-xs font-medium tracking-wide text-slate-500 dark:text-slate-400 uppercase">
+            Create Route
+          </span>
+          <h1 className="mt-5 text-3xl font-bold text-slate-900 dark:text-white">
+            Sign in to create your route
+          </h1>
+          <p className="mt-3 text-slate-600 dark:text-slate-400">
+            You need an account to create, view, and manage routes.
           </p>
-          <div className="mt-6">
-            <SignInForm />
-          </div>
         </div>
+
+        <SignInForm />
       </main>
     );
   }

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -1,5 +1,5 @@
-import { auth } from "@/lib/auth";
 import SignInForm from "@/components/sign-in-form";
+import { auth } from "@/lib/auth";
 import RoutesClient from "./routes-client";
 
 export default async function RoutesPage() {
@@ -7,16 +7,20 @@ export default async function RoutesPage() {
 
   if (!session?.user?.id) {
     return (
-      <main className="min-h-screen py-16 px-6">
-        <div className="mx-auto max-w-[1800px]">
-          <h1 className="text-2xl font-semibold">Sign in to Create Routes</h1>
-          <p className="mt-2 text-slate-600">
-            You need an account to Create, View, and Manage Routes.
+      <main className="flex flex-col items-center py-6">
+        <div className="mx-auto max-w-md text-center px-6 mb-6">
+          <span className="inline-block rounded-full bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 px-4 py-1 text-xs font-medium tracking-wide text-slate-500 dark:text-slate-400 uppercase">
+            Routes
+          </span>
+          <h1 className="mt-5 text-3xl font-bold text-slate-900 dark:text-white">
+            Create & manage your routes
+          </h1>
+          <p className="mt-3 text-slate-600 dark:text-slate-400">
+            Sign in to create, view, edit, and manage your travel routes.
           </p>
-          <div className="mt-6">
-            <SignInForm />
-          </div>
         </div>
+
+        <SignInForm />
       </main>
     );
   }

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,28 +1,37 @@
-import { auth } from "@/lib/auth";
-import TicketUploadForm from "@/components/ticket-upload-form";
 import SignInForm from "@/components/sign-in-form";
+import TicketUploadForm from "@/components/ticket-upload-form";
+import { auth } from "@/lib/auth";
 
 export default async function UploadPage() {
   const session = await auth();
   if (!session?.user?.id) {
     return (
-      <main className="min-h-screen py-16 px-6 ">
-        
-        <div className="mx-auto max-w-[1800px]">  
-        <h1 className="text-2xl font-semibold">Sign in to upload</h1>
-        <p className="mt-2 text-slate-600 ">You need an account to upload and verify tickets.</p>
-          <div className="mt-6">
-              <SignInForm />
-              </div>
-          </div>
+      <main className="flex flex-col items-center py-6">
+        <div className="mx-auto max-w-md text-center px-6 mb-6">
+          <span className="inline-block rounded-full bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 px-4 py-1 text-xs font-medium tracking-wide text-slate-500 dark:text-slate-400 uppercase">
+            Upload
+          </span>
+          <h1 className="mt-5 text-3xl font-bold text-slate-900 dark:text-white">
+            Sign in to upload
+          </h1>
+          <p className="mt-3 text-slate-600 dark:text-slate-400">
+            You need an account to upload and verify tickets.
+          </p>
+        </div>
+
+        <SignInForm />
       </main>
     );
   }
 
   return (
     <main className="mx-auto max-w-2xl px-6 py-12">
-      <h1 className="text-2xl font-semibold">Upload your ticket</h1>
-      <p className="mt-2 text-slate-600 dark:text-slate-400">We only show verified users who uploaded a destination ticket.</p>
+      <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">
+        Upload your ticket
+      </h1>
+      <p className="mt-2 text-slate-600 dark:text-slate-400">
+        We only show verified users who uploaded a destination ticket.
+      </p>
       <div className="mt-8">
         <TicketUploadForm />
       </div>

--- a/src/components/sign-in-form.tsx
+++ b/src/components/sign-in-form.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import Image from "next/image";
-import { useState, FormEvent } from "react";
-import Link from "next/link";
 import { signIn } from "next-auth/react";
-import { Mail } from "lucide-react";
-import { FaEye, FaEyeSlash, FaApple } from "react-icons/fa";
-
+import Image from "next/image";
+import Link from "next/link";
+import { FormEvent, useState } from "react";
+import { FaApple, FaEye, FaEyeSlash } from "react-icons/fa";
 
 export default function SignInForm() {
   const [loading, setLoading] = useState(false);
@@ -33,7 +31,7 @@ export default function SignInForm() {
         setError(
           res?.error === "CredentialsSignin"
             ? "Invalid email or password"
-            : res?.error || "Failed to sign in"
+            : res?.error || "Failed to sign in",
         );
         setLoading(false);
         return;
@@ -52,18 +50,14 @@ export default function SignInForm() {
       className="
         relative
         w-full
-        max-w-[1800px]
+        max-w-[1600px]
         mx-auto
-        rounded-[32px]
-        overflow-hidden
-        bg-[#0a1929]
-        grid
-        grid-cols-1
-        xl:grid-cols-2
+        my-2
+    px-6
+    lg:px-8
       "
     >
-      
-
+      <div className="rounded-[32px] overflow-hidden bg-[#0a1929] grid grid-cols-1 xl:grid-cols-2">
       {/* LEFT IMAGE */}
       <div className="relative w-full h-64 xl:h-auto xl:min-h-full overflow-hidden">
         <Image
@@ -72,101 +66,126 @@ export default function SignInForm() {
           fill
           className="object-cover animate-kenburns"
           priority
-          
         />
         <div className="absolute inset-0 bg-black/25" />
       </div>
 
       {/* RIGHT FORM */}
-      <div className="flex items-center justify-center px-6 py-12">
-        <div className="w-full max-w-[420px]">
+    <div className="flex items-center justify-center xl:pl-12 xl:pr-8 py-12">
+        <div className="w-full max-w-[560px] px-8 lg:px-12">
+          <div className="mb-8 text-center">
+            <div className="text-white font-semibold text-2xl">
+              ✈️ travellersmeet
+            </div>
 
-          <div className="mb-8 text-center text-white font-semibold text-2xl">
-            ✈️ travellersmeet
+            <h1 className="mt-5 text-3xl font-bold text-white">Welcome Back</h1>
+
+            <p className="mt-2 text-white/70 text-sm">
+              Sign in to continue your travel journey.
+            </p>
           </div>
-
-          <div className="rounded-3xl border border-white/10 bg-[#122b45]/70 backdrop-blur-xl p-8 min-h-[420px] flex flex-col justify-between">
-
-
+          <div className="mx-8 rounded-xl border border-white/10 bg-[#122b45]/70 backdrop-blur-xl p-10 shadow-2xl flex flex-col justify-between">
             {/* Social Buttons */}
-            <div className="space-y-3 mb-6">
+            <div className="space-y-2 mb-4">
               <button
                 type="button"
-                onClick={() => signIn("google", {callbackUrl: "/dashboard"})}
+                onClick={() => signIn("google", { callbackUrl: "/dashboard" })}
                 className="flex items-center justify-center gap-3 w-full h-[46px] rounded-xl bg-white text-gray-800 font-semibold"
               >
                 <GoogleIcon />
                 Continue with Google
               </button>
 
-              <button 
-              type="button"
-              onClick={() => signIn("apple", {callbackUrl: "/dashboard"})}
-              className="flex items-center justify-center gap-3 w-full h-[46px] rounded-xl bg-white text-gray-800 font-semibold">
+              <button
+                type="button"
+                onClick={() => signIn("apple", { callbackUrl: "/dashboard" })}
+                className="flex items-center justify-center gap-3 w-full h-[46px] rounded-xl bg-white text-gray-800 font-semibold"
+              >
                 <FaApple size={18} />
                 Continue with Apple
               </button>
+            </div>
+            <div className="relative my-7">
+              <div className="border-t border-white/10"></div>
 
-
+              <span className="absolute left-1/2 -translate-x-1/2 -top-3 bg-[#122b45] px-3 text-xs text-white/50">
+                OR
+              </span>
             </div>
 
             {/* Form */}
 
             <form onSubmit={onSubmit} className="space-y-4">
               <div>
-                <label className="text-sm text-white/80">Email</label>
+                <label className="block mb-2 text-sm font-medium text-white/80">
+                  Email
+                </label>
                 <input
                   type="email"
                   name="email"
                   required
                   placeholder="you@example.com"
-                  className="mt-1 h-[46px] w-full rounded-xl bg-transparent border border-white/20 px-4 text-white outline-none focus:border-blue-400"
+                  className="mt-1 h-10 w-full rounded-xl bg-white/5 border border-white/15 px-4 text-white placeholder:text-white/40 outline-none focus:border-blue-400 transition"
                 />
               </div>
 
               <div className="relative">
-                    <label className="text-sm text-white/80">Password</label>
-                    <input
-                      name="password"
-                      type={showPassword ? "text" : "password"}
-                      required
-                      minLength={8}
-                      className="mt-1 h-[46px] w-full rounded-xl bg-transparent border border-white/20 px-4 pr-10 text-white outline-none focus:border-blue-400"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-3 top-9 text-white/60 mt-[5px]"
-                    >
-                      {showPassword ? <FaEyeSlash size={18} /> : <FaEye size={18} />}
+                <label className="block mb-2 text-sm font-medium text-white/80">
+                  Password
+                </label>
+                <input
+                  name="password"
+                  type={showPassword ? "text" : "password"}
+                  required
+                  minLength={8}
+                  className="mt-1 h-10 w-full rounded-xl bg-white/5 border border-white/15 px-4 text-white placeholder:text-white/40 outline-none focus:border-blue-400 transition"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute inset-y-0 right-4 top-7 flex items-center text-white/60 hover:text-white"
+                >
+                  {showPassword ? (
+                    <FaEyeSlash size={18} />
+                  ) : (
+                    <FaEye size={18} />
+                  )}
+                </button>
+              </div>
 
-                    </button>
-                  </div>
-
-              {error && (
-                <p className="text-sm text-red-400">{error}</p>
-              )}
+              {error && <p className="text-sm text-red-400">{error}</p>}
+              <div className="flex justify-end">
+                <Link
+                  href="/forgot-password"
+                  className="text-sm text-blue-300 hover:text-blue-200"
+                >
+                  Forgot password?
+                </Link>
+              </div>
 
               <button
                 type="submit"
                 disabled={loading}
-                className="mt-5 w-full h-[46px] rounded-xl bg-blue-500 hover:bg-blue-600 text-white font-bold transition disabled:opacity-60"
+                className="mt-6 w-full h-[46px] rounded-xl bg-blue-500 hover:bg-blue-600 text-white font-bold transition disabled:opacity-60"
               >
                 {loading ? "Signing in..." : "Sign in"}
               </button>
             </form>
           </div>
 
-          <p className="mt-5 text-center text-sm text-white/70">
+          <p className="mt-8 text-center text-sm text-white/70">
             No account yet?{" "}
-            <Link href="/signup" className="font-semibold text-white hover:underline">
+            <Link
+              href="/signup"
+              className="font-semibold text-white hover:underline"
+            >
               Sign up
             </Link>
           </p>
-
         </div>
       </div>
-    </div>
+      </div>
+</div>
   );
 }
 
@@ -175,10 +194,22 @@ function GoogleIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 48 48">
       <g>
-        <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
-        <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
-        <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
-        <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+        <path
+          fill="#EA4335"
+          d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+        />
+        <path
+          fill="#4285F4"
+          d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+        />
+        <path
+          fill="#34A853"
+          d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+        />
       </g>
     </svg>
   );

--- a/src/components/sign-up-form.tsx
+++ b/src/components/sign-up-form.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import Image from "next/image";
-import { useState, FormEvent } from "react";
-import Link from "next/link";
 import { signIn } from "next-auth/react";
-import { Mail } from "lucide-react";
-import { FaEye, FaEyeSlash, FaApple } from "react-icons/fa";
+import Image from "next/image";
+import Link from "next/link";
+import { FormEvent, useState } from "react";
+import { FaCheck, FaEye, FaEyeSlash, FaTimes } from "react-icons/fa";
 
 export default function SignUpForm() {
   const [loading, setLoading] = useState(false);
@@ -16,6 +15,7 @@ export default function SignUpForm() {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [otp, setOtp] = useState("");
+  const [resending, setResending] = useState(false);
 
   async function onSignup(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -99,7 +99,7 @@ export default function SignUpForm() {
   }
 
   async function resendOTP() {
-    setLoading(true);
+    setResending(true);
     setError("");
     setSuccess("");
 
@@ -121,118 +121,202 @@ export default function SignUpForm() {
     } catch {
       setError("Network error. Please try again.");
     } finally {
-      setLoading(false);
+      setResending(false);
     }
   }
 
-  const passwordRules = {
-    length: password.length >= 8,
-    number: /\d/.test(password),
-    lower: /[a-z]/.test(password),
-    upper: /[A-Z]/.test(password),
-    special: /[!@#$%^&*(){}]/.test(password),
-  };
+  const passwordRules = [
+    { label: "At least 8 characters", valid: password.length >= 8 },
+    { label: "One number", valid: /\d/.test(password) },
+    { label: "One lowercase letter", valid: /[a-z]/.test(password) },
+    { label: "One uppercase letter", valid: /[A-Z]/.test(password) },
+    { label: "One special character", valid: /[!@#$%^&*(){}]/.test(password) },
+  ];
 
-  const passwordValid = Object.values(passwordRules).every(Boolean);
+  const passwordValid = passwordRules.every((r) => r.valid);
 
   return (
-    <div className="relative w-full max-w-[1800px] mx-auto rounded-[32px] overflow-hidden bg-[#0a1929] grid grid-cols-1 xl:grid-cols-2">
+    <div className="relative w-full max-w-[1600px] mx-auto my-2 px-6 lg:px-8">
+      <div className="rounded-[32px] overflow-hidden bg-[#0a1929] grid grid-cols-1 xl:grid-cols-2">
+        {/* LEFT IMAGE */}
+        <div className="relative w-full h-64 xl:h-auto xl:min-h-full overflow-hidden">
+          <Image
+            src="/travel.jpg"
+            alt="Travel"
+            fill
+            className="object-cover animate-kenburns"
+            priority
+          />
+          <div className="absolute inset-0 bg-black/25" />
+        </div>
 
-      {/* LEFT IMAGE */}
-      <div className="relative w-full h-64 xl:h-auto xl:min-h-full overflow-hidden">
-        <Image
-          src="/travel.jpg"
-          alt="Travel"
-          fill
-          className="object-cover"
-          priority
-        />
-        <div className="absolute inset-0 bg-black/25" />
-      </div>
+        {/* RIGHT FORM */}
+        <div className="flex items-center justify-center xl:pl-12 xl:pr-8 py-12">
+          <div className="w-full max-w-[560px] px-8 lg:px-12">
+            <div className="mb-8 text-center">
+              <div className="text-white font-semibold text-2xl">
+                ✈️ travellersmeet
+              </div>
 
-      {/* RIGHT FORM */}
-      <div className="flex items-center justify-center px-6 py-12">
-        <div className="w-full max-w-[420px]">
+              <h1 className="mt-5 text-3xl font-bold text-white">
+                {step === "signup" ? "Create your account" : "Verify your email"}
+              </h1>
 
-          <div className="mb-8 text-center text-white font-semibold text-2xl">
-            ✈️ travellersmeet
-          </div>
+              <p className="mt-2 text-white/70 text-sm">
+                {step === "signup"
+                  ? "Join travellers exploring the world together."
+                  : `We sent a 6-digit code to ${email}`}
+              </p>
+            </div>
 
-          <div className="rounded-3xl border border-white/10 bg-[#122b45]/70 backdrop-blur-xl p-8">
+            <div className="mx-8 rounded-xl border border-white/10 bg-[#122b45]/70 backdrop-blur-xl p-10 shadow-2xl">
+              {error && (
+                <div className="mb-4 p-3 rounded-lg bg-red-500/20 border border-red-500/50 text-red-200 text-sm">
+                  {error}
+                </div>
+              )}
+              {success && (
+                <div className="mb-4 p-3 rounded-lg bg-green-500/20 border border-green-500/50 text-green-200 text-sm">
+                  {success}
+                </div>
+              )}
 
-            {step === "signup" ? (
-              <>
-                {error && <div className="mb-4 p-3 rounded-lg bg-red-500/20 border border-red-500/50 text-red-200 text-sm">{error}</div>}
-                {success && <div className="mb-4 p-3 rounded-lg bg-green-500/20 border border-green-500/50 text-green-200 text-sm">{success}</div>}
-
-                <form onSubmit={onSignup} className="space-y-4">
+              {step === "signup" ? (
+                <form onSubmit={onSignup} className="space-y-5">
                   <div>
-                    <label className="text-sm text-white/80">Name</label>
-                    <input name="name" required className="mt-1 h-[46px] w-full rounded-xl bg-transparent border border-white/20 px-4 text-white" />
-                  </div>
-
-                  <div>
-                    <label className="text-sm text-white/80">Email</label>
-                    <input name="email" type="email" required className="mt-1 h-[46px] w-full rounded-xl bg-transparent border border-white/20 px-4 text-white" />
-                  </div>
-
-                  <div className="relative">
-                    <label className="text-sm text-white/80">Password</label>
+                    <label className="block mb-2.5 text-sm font-medium text-white/80">
+                      Name
+                    </label>
                     <input
-                      name="password"
-                      type={showPassword ? "text" : "password"}
+                      name="name"
                       required
-                      minLength={8}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      className="mt-1 h-[46px] w-full rounded-xl bg-transparent border border-white/20 px-4 pr-10 text-white"
+                      placeholder="Jane Doe"
+                      className="h-12 w-full rounded-xl bg-white/5 border border-white/15 px-4 text-base text-white placeholder:text-white/40 outline-none focus:border-blue-400 transition"
                     />
-
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-3 top-9 text-white/60"
-                    >
-                      {showPassword ? <FaEyeSlash size={18} /> : <FaEye size={18} />}
-                    </button>
                   </div>
+
+                  <div>
+                    <label className="block mb-2.5 text-sm font-medium text-white/80">
+                      Email
+                    </label>
+                    <input
+                      name="email"
+                      type="email"
+                      required
+                      placeholder="you@example.com"
+                      className="h-12 w-full rounded-xl bg-white/5 border border-white/15 px-4 text-base text-white placeholder:text-white/40 outline-none focus:border-blue-400 transition"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block mb-2.5 text-sm font-medium text-white/80">
+                      Password
+                    </label>
+                    <div className="relative">
+                      <input
+                        name="password"
+                        type={showPassword ? "text" : "password"}
+                        required
+                        minLength={8}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className="h-12 w-full rounded-xl bg-white/5 border border-white/15 px-4 pr-12 text-base text-white placeholder:text-white/40 outline-none focus:border-blue-400 transition"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-4 top-1/2 -translate-y-1/2 text-white/60 hover:text-white"
+                      >
+                        {showPassword ? <FaEyeSlash size={18} /> : <FaEye size={18} />}
+                      </button>
+                    </div>
+                  </div>
+
+                  {password.length > 0 && (
+                    <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 pt-1">
+                      {passwordRules.map((rule) => (
+                        <li
+                          key={rule.label}
+                          className={`flex items-center gap-2 text-xs transition-colors ${
+                            rule.valid ? "text-green-400" : "text-white/40"
+                          }`}
+                        >
+                          {rule.valid ? (
+                            <FaCheck size={10} />
+                          ) : (
+                            <FaTimes size={10} />
+                          )}
+                          {rule.label}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
 
                   <button
                     disabled={loading || !passwordValid}
-                    className="mt-5 w-full h-[46px] rounded-xl bg-blue-500 hover:bg-blue-600 disabled:bg-blue-500/50 text-white font-bold transition"
+                    className="mt-6 w-full h-[46px] rounded-xl bg-blue-500 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold transition"
                   >
                     {loading ? "Creating..." : "Create account"}
                   </button>
                 </form>
-              </>
-            ) : (
-              <>
-                {error && <div className="mb-4 p-3 rounded-lg bg-red-500/20 border border-red-500/50 text-red-200 text-sm">{error}</div>}
-                {success && <div className="mb-4 p-3 rounded-lg bg-green-500/20 border border-green-500/50 text-green-200 text-sm">{success}</div>}
-
-                <form onSubmit={onVerifyOTP} className="space-y-4">
+              ) : (
+                <form onSubmit={onVerifyOTP} className="space-y-5">
                   <div>
-                    <label className="text-sm text-white/80">Enter OTP</label>
+                    <label className="block mb-2.5 text-sm font-medium text-white/80">
+                      Enter OTP
+                    </label>
                     <input
                       type="text"
                       value={otp}
-                      onChange={(e) => setOtp(e.target.value.replace(/\D/g, "").slice(0, 6))}
+                      onChange={(e) =>
+                        setOtp(e.target.value.replace(/\D/g, "").slice(0, 6))
+                      }
                       required
                       maxLength={6}
-                      className="mt-1 h-[46px] w-full rounded-xl bg-transparent border border-white/20 px-4 text-white text-center text-2xl tracking-widest"
+                      placeholder="••••••"
+                      className="h-14 w-full rounded-xl bg-white/5 border border-white/15 px-4 text-white placeholder:text-white/20 outline-none focus:border-blue-400 transition text-center text-2xl tracking-[0.5em]"
                     />
                   </div>
 
                   <button
                     disabled={loading || otp.length !== 6}
-                    className="mt-5 w-full h-[46px] rounded-xl bg-blue-500 hover:bg-blue-600 disabled:bg-blue-500/50 text-white font-bold transition"
+                    className="mt-2 w-full h-[46px] rounded-xl bg-blue-500 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold transition"
                   >
                     {loading ? "Verifying..." : "Verify & Create account"}
                   </button>
-                </form>
-              </>
-            )}
 
+                  <div className="flex items-center justify-between pt-1 text-sm">
+                    <button
+                      type="button"
+                      onClick={() => setStep("signup")}
+                      className="text-white/60 hover:text-white transition-colors"
+                    >
+                      ← Back
+                    </button>
+                    <button
+                      type="button"
+                      onClick={resendOTP}
+                      disabled={resending}
+                      className="text-blue-300 hover:text-blue-200 disabled:opacity-50 transition-colors"
+                    >
+                      {resending ? "Sending..." : "Resend code"}
+                    </button>
+                  </div>
+                </form>
+              )}
+            </div>
+
+            {step === "signup" && (
+              <p className="mt-8 text-center text-sm text-white/70">
+                Already have an account?{" "}
+                <Link
+                  href="/signin"
+                  className="font-semibold text-white hover:underline"
+                >
+                  Sign in
+                </Link>
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,236 +1,247 @@
 "use client";
-import { usePathname } from "next/navigation";
+
 import { useTheme } from "@/state/theme";
-import Link from "next/link";
-import Image from "next/image";
-import { useEffect, useState } from "react";
-import { Plane } from "lucide-react";
-import { HiOutlineSun, HiOutlineMoon } from "react-icons/hi";
 import { AnimatePresence, motion } from "framer-motion";
+import { Menu, Plane, X } from "lucide-react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { HiOutlineMoon, HiOutlineSun } from "react-icons/hi";
 import Toggle from "./toggle";
+
+// --- Constants ---
+const MARKETING_LINKS = [
+  { href: "/#features", key: "features", label: "Features" },
+  { href: "/#how-it-works", key: "how-it-works", label: "How it works" },
+  { href: "/#testimonials", key: "testimonials", label: "Stories" },
+  { href: "/#faq", key: "faq", label: "FAQ" },
+];
+
+const APP_LINKS = [
+  { href: "/upload", label: "Upload" },
+  { href: "/routes", label: "Routes" },
+];
+
+const SECTIONS = ["features", "how-it-works", "testimonials", "faq"];
+
+// --- Helper Styles ---
+const getLinkClasses = (isActive: boolean) =>
+  `text-sm pb-0.5 border-b-2 transition-colors duration-200 ${
+    isActive
+      ? "text-slate-900 dark:text-white font-semibold border-slate-900 dark:border-white"
+      : "text-slate-600 dark:text-slate-300 font-medium border-transparent hover:text-slate-900 dark:hover:text-white"
+  }`;
 
 export default function SiteHeader() {
   const { data: session } = useSession();
-  const [open, setOpen] = useState(false);
   const { theme, changeTheme } = useTheme();
   const pathname = usePathname();
-  const [activeSection, setActiveSection] = useState<string | null>(null);
-  const isRouteActive = (path: string) => pathname === path;
 
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeSection, setActiveSection] = useState<string | null>(null);
+
+  const isRouteActive = useCallback((path: string) => pathname === path, [pathname]);
+
+  // Handle active section highlighting on scroll
   useEffect(() => {
     if (pathname !== "/") {
       setActiveSection(null);
       return;
     }
 
-    const sections = ["features", "how-it-works", "testimonials", "faq"];
-
     const handleScroll = () => {
       let currentSection: string | null = null;
 
-        <nav className="hidden items-center text-sm font-medium text-white/95 gap-8 md:flex">
-          <Link href="#features" className="hover:text-white transition-colors">Features</Link>
-          <Link href="#how-it-works" className="hover:text-white transition-colors">How it works</Link>
-          <Link href="#testimonials" className="hover:text-white transition-colors">Stories</Link>
-          <Link href="#faq" className="hover:text-white transition-colors">FAQ</Link>
-          <Link href="/upload" className="hover:text-white transition-colors">Upload</Link>
-        </nav>
-      for (const section of sections) {
+      for (const section of SECTIONS) {
         const element = document.getElementById(section);
         if (element) {
           const rect = element.getBoundingClientRect();
           if (rect.top <= 150 && rect.bottom >= 150) {
             currentSection = section;
+            break;
           }
         }
       }
-
       setActiveSection(currentSection);
     };
 
-    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleScroll, { passive: true });
     handleScroll();
 
     return () => window.removeEventListener("scroll", handleScroll);
   }, [pathname]);
 
+  // Lock body scroll when mobile menu is open
   useEffect(() => {
-    document.body.style.overflow = open ? "hidden" : "auto";
-  }, [open]);
+    document.body.style.overflow = isOpen ? "hidden" : "auto";
+  }, [isOpen]);
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-slate-200 bg-white/80 backdrop-blur-md dark:bg-slate-900/80 dark:border-slate-800 transition-colors duration-300">
-      <div className="mx-auto max-w-7xl flex items-center justify-between px-6 py-3">
-
-        {/* LEFT SIDE */}
+      <div className="mx-auto max-w-7xl flex items-center justify-between px-6 py-3 gap-6">
+        
+        {/* BRAND */}
         <Link
           href={session?.user ? "/dashboard/profile" : "/"}
-          className="flex items-center gap-3 group"
+          className="flex items-center gap-2.5 shrink-0 group"
         >
-          <div className="relative inline-flex h-9 w-9 items-center justify-center rounded-lg bg-slate-900 dark:bg-white text-white dark:text-slate-900 transition-transform duration-300 group-hover:scale-110 shadow-sm overflow-hidden">
+          <div className="relative inline-flex h-9 w-9 items-center justify-center rounded-lg bg-slate-900 dark:bg-white text-white dark:text-slate-900 transition-transform duration-300 group-hover:scale-105 shadow-sm overflow-hidden">
             <Plane className="h-5 w-5 rotate-[-45deg] group-hover:rotate-0 transition-transform duration-500" />
           </div>
-
-          <span className="bg-white/90 text-black px-4 py-1.5 rounded-full text-lg font-semibold tracking-tight transition-all duration-300 hover:scale-105 shadow-sm dark:bg-slate-800 dark:text-white">
+          <span className="text-lg font-bold tracking-tight text-slate-900 dark:text-white">
             travellersmeet
           </span>
         </Link>
 
-        {/* NAV LINKS */}
-        <nav className="hidden items-center text-sm font-medium text-slate-600 dark:text-slate-300 gap-8 md:flex">
-          <Link
-            href="/#features"
-            className={`transition-colors ${
-              activeSection === "features"
-                ? "text-slate-900 dark:text-white font-semibold border-b-2 border-slate-900 dark:border-white"
-                : "hover:text-slate-900 dark:hover:text-white"
-            }`}
-          >
-            Features
-          </Link>
-          <Link
-            href="/#how-it-works"
-            className={`transition-colors ${
-              activeSection === "how-it-works"
-                ? "text-slate-900 dark:text-white font-semibold border-b-2 border-slate-900 dark:border-white"
-                : "hover:text-slate-900 dark:hover:text-white"
-            }`}
-          >
-            How it works
-          </Link>
-          <Link
-            href="/#testimonials"
-            className={`transition-colors ${
-              activeSection === "testimonials"
-                ? "text-slate-900 dark:text-white font-semibold border-b-2 border-slate-900 dark:border-white"
-                : "hover:text-slate-900 dark:hover:text-white"
-            }`}
-          >
-            Stories
-          </Link>
-          <Link
-            href="/#faq"
-            className={`transition-colors ${
-              activeSection === "faq"
-                ? "text-slate-900 dark:text-white font-semibold border-b-2 border-slate-900 dark:border-white"
-                : "hover:text-slate-900 dark:hover:text-white"
-            }`}
-          >
-            FAQ
-          </Link>
-          <Link
-            href="/upload"
-            className={`transition-colors ${
-              isRouteActive("/upload")
-                ? "text-slate-900 dark:text-white font-semibold border-b-2 border-slate-900 dark:border-white"
-                : "hover:text-slate-900 dark:hover:text-white"
-            }`}
-          >
-            Upload
-          </Link>
-          <Link
-            href="/routes"
-            className={`transition-colors ${
-              isRouteActive("/routes")
-                ? "text-slate-900 dark:text-white font-semibold border-b-2 border-slate-900 dark:border-white"
-                : "hover:text-slate-900 dark:hover:text-white"
-            }`}
-          >
-            Routes
-          </Link>
-        </nav>
+        {/* CENTER: Navigation Links */}
+        <div className="hidden md:flex items-center gap-6 flex-1 justify-center">
+          <nav className="flex items-center gap-6">
+            {MARKETING_LINKS.map((link) => (
+              <Link
+                key={link.key}
+                href={link.href}
+                className={getLinkClasses(activeSection === link.key)}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
 
-        {/* RIGHT SIDE */}
-        <div className="hidden md:flex items-center gap-4">
+          <div className="h-4 w-px bg-slate-200 dark:bg-slate-700" />
 
+          <nav className="flex items-center gap-6">
+            {APP_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={getLinkClasses(isRouteActive(link.href))}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+
+        {/* RIGHT: Desktop Actions */}
+        <div className="hidden md:flex items-center gap-3 shrink-0">
           {session?.user?.id ? (
             <Link
               href="/dashboard"
-              className="rounded-lg bg-slate-900 dark:bg-white px-4 py-2.5 text-sm font-semibold text-white dark:text-slate-900 hover:opacity-90 transition-all shadow-sm"
+              className="flex items-center rounded-lg bg-slate-900 dark:bg-white h-10 px-4 text-sm font-semibold text-white dark:text-slate-900 hover:opacity-90 transition-all shadow-sm"
             >
               Dashboard
             </Link>
           ) : (
             <>
-              <Link href="/signin" className="text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white">
+              <Link
+                href="/signin"
+                className="text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"
+              >
                 Sign in
               </Link>
               <Link
                 href="/signup"
-                className="rounded-lg bg-slate-900 dark:bg-white px-4 py-2.5 text-sm font-semibold text-white dark:text-slate-900 hover:opacity-90 shadow-sm"
+                className="flex items-center rounded-lg bg-slate-900 dark:bg-white h-10 px-4 text-sm font-semibold text-white dark:text-slate-900 hover:opacity-90 shadow-sm transition-opacity"
               >
                 Get started
               </Link>
             </>
           )}
 
-          <button onClick={changeTheme} className="p-2">
-            {theme === "dark" ? (
-              <HiOutlineMoon size={22} />
-            ) : (
-              <HiOutlineSun size={22} />
-            )}
+          <button
+            onClick={changeTheme}
+            aria-label="Toggle theme"
+            className="p-2 rounded-full text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-white transition-colors"
+          >
+            {theme === "dark" ? <HiOutlineMoon size={20} /> : <HiOutlineSun size={20} />}
           </button>
         </div>
 
         {/* MOBILE MENU BUTTON */}
         <button
-          className="md:hidden p-2"
-          onClick={() => setOpen((v) => !v)}
+          className="md:hidden p-2 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-lg transition-colors shrink-0"
+          onClick={() => setIsOpen((prev) => !prev)}
+          aria-label={isOpen ? "Close menu" : "Open menu"}
         >
-          ☰
+          {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
         </button>
       </div>
 
       {/* MOBILE MENU */}
       <AnimatePresence>
-        {open && (
-          <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} exit={{ opacity: 0, height: 0 }} className="overflow-hidden z-20 absolute left-0 right-0 border-b border-slate-200/60 dark:border-slate-800/60 bg-white dark:bg-slate-900 md:hidden transition duration-150">
-            <div className="mx-auto max-w-6xl px-6 py-3">
-              <div className="grid gap-2 dark:*:text-slate-200">
-                <Link href="#features" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Features</Link>
-                <Link href="#how-it-works" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>How it works</Link>
-                <Link href="#testimonials" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Stories</Link>
-                <Link href="#faq" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>FAQ</Link>
-                <Link href="/upload" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Upload</Link>
-                <Link href="/#features" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Features</Link>
-                <Link href="/#how-it-works" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>How it works</Link>
-                <Link href="/#testimonials" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>Stories</Link>
-                <Link href="/#faq" className="rounded px-2 py-2 text-slate-800 hover:opacity-80" onClick={() => setOpen(false)}>FAQ</Link>
-                <Link
-                  href="/upload"
-                  className={`rounded px-2 py-2 ${
-                    isRouteActive("/upload")
-                      ? "bg-slate-100 dark:bg-slate-800 font-semibold"
-                      : "text-slate-800 hover:opacity-80"
-                  }`}
-                  onClick={() => setOpen(false)}
-                >
-                  Upload
-                </Link>
+        {isOpen && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden absolute left-0 right-0 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 md:hidden z-50"
+          >
+            <div className="mx-auto max-w-6xl px-6 py-4">
+              <div className="grid gap-1">
+                <p className="px-2 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                  Explore
+                </p>
+                {MARKETING_LINKS.map((link) => (
                   <Link
-                    href="/routes"
-                    className={`rounded px-2 py-2 ${
-                      isRouteActive("/routes")
-                        ? "bg-slate-100 dark:bg-slate-800 font-semibold"
-                        : "text-slate-800 hover:opacity-80"
-                    }`}
-                    onClick={() => setOpen(false)}
+                    key={link.key}
+                    href={link.href}
+                    className="rounded px-2 py-2 text-slate-800 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                    onClick={() => setIsOpen(false)}
                   >
-                    Routes
+                    {link.label}
                   </Link>
-                <div className="flex pl-2 pr-8 py-2 justify-between">
-                  <p>Dark Theme</p>
+                ))}
+
+                <p className="px-2 pt-4 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                  Your account
+                </p>
+                {APP_LINKS.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className={`rounded px-2 py-2 transition-colors ${
+                      isRouteActive(link.href)
+                        ? "bg-slate-100 dark:bg-slate-800 font-semibold text-slate-900 dark:text-white"
+                        : "text-slate-800 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800"
+                    }`}
+                    onClick={() => setIsOpen(false)}
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+
+                <div className="flex px-2 py-3 mt-2 justify-between items-center border-t border-slate-100 dark:border-slate-800">
+                  <p className="text-sm text-slate-600 dark:text-slate-300">Dark theme</p>
                   <Toggle theme={theme} changeTheme={changeTheme} />
                 </div>
-                <div className="flex flex-col gap-2 pt-2 border-t border-slate-100 dark:border-slate-800">
+                
+                <div className="flex flex-col gap-2 pt-2">
                   {session?.user?.id ? (
-                    <Link className="rounded-lg bg-slate-900 dark:bg-white px-4 py-2.5 text-center text-sm font-semibold text-white dark:text-slate-900 shadow-sm" href="/dashboard" onClick={() => setOpen(false)}>Dashboard</Link>
+                    <Link
+                      className="rounded-lg bg-slate-900 dark:bg-white px-4 py-2.5 text-center text-sm font-semibold text-white dark:text-slate-900 shadow-sm"
+                      href="/dashboard"
+                      onClick={() => setIsOpen(false)}
+                    >
+                      Dashboard
+                    </Link>
                   ) : (
                     <>
-                      <Link href="/signin" className="text-center py-2 text-sm font-medium text-slate-600 dark:text-slate-300" onClick={() => setOpen(false)}>Sign in</Link>
-                      <Link href="/signup" className="rounded-lg bg-slate-900 dark:bg-white px-4 py-2.5 text-center text-sm font-semibold text-white dark:text-slate-900 shadow-sm" onClick={() => setOpen(false)}>Get started</Link>
+                      <Link
+                        href="/signin"
+                        className="text-center py-2 text-sm font-medium text-slate-600 dark:text-slate-300"
+                        onClick={() => setIsOpen(false)}
+                      >
+                        Sign in
+                      </Link>
+                      <Link
+                        href="/signup"
+                        className="rounded-lg bg-slate-900 dark:bg-white px-4 py-2.5 text-center text-sm font-semibold text-white dark:text-slate-900 shadow-sm"
+                        onClick={() => setIsOpen(false)}
+                      >
+                        Get started
+                      </Link>
                     </>
                   )}
                 </div>


### PR DESCRIPTION
### Summary

This PR updates the authentication-required pages (`/routes`, `/routes/new`, and `/upload`) to match the look and feel of the existing `/signin` page.

### Closes Issue

#166 

### Changes

- Added a page heading, subtitle, and context badge (e.g. **ROUTES** / **UPLOAD**) above the sign-in form.
- Updated spacing, alignment, and container sizing for a more consistent layout.
- Fixed text that was invisible in light mode by replacing hardcoded `text-white` styles with proper theme-aware classes.

### Why

These pages felt visually inconsistent compared to `/signin '. This PR reuses the existing design pattern instead of introducing a new one, resulting in a more consistent authentication experience.

### Scope

- UI/layout improvements only.
- No authentication, session, backend, or API changes.

### Screenshots
<img width="1920" height="1080" alt="Screenshot (1525)" src="https://github.com/user-attachments/assets/7c838edf-8518-4494-b281-34ce0ed15402" />
<img width="1920" height="1080" alt="Screenshot (1526)" src="https://github.com/user-attachments/assets/78d49123-efcf-4123-b7ee-66c821ca9c17" />
<img width="1920" height="1080" alt="Screenshot (1527)" src="https://github.com/user-attachments/assets/13ab8124-7ae4-4611-a06f-a62b59cbed00" />
<img width="1920" height="1080" alt="Screenshot (1528)" src="https://github.com/user-attachments/assets/caf8a8ab-690b-46c4-b49c-188171061b44" />
<img width="1920" height="1080" alt="Screenshot (1529)" src="https://github.com/user-attachments/assets/d841fa3f-301e-4770-b8bf-f0829590a680" />
<img width="1920" height="1080" alt="Screenshot (1530)" src="https://github.com/user-attachments/assets/cb9f682e-9af2-42d9-8db0-d6d555c4392c" />
<img width="1920" height="1080" alt="Screenshot (1531)" src="https://github.com/user-attachments/assets/c8c4594e-9141-43e6-9796-a2bded70f335" />

### Testing

- [x] Verified `/routes`
- [x] Verified `/routes/new`
- [x] Verified `/upload`
- [x] Verified `/signup`
- [x] Verified `/signin`
- [x] Verified light and dark mode