### PR TITLE
fix: prevent dashboard redirection on failed sign-in

### DIFF
--- a/src/app/dashboard/layout.test.tsx
+++ b/src/app/dashboard/layout.test.tsx
@@ -1,0 +1,50 @@
+import { vi } from "vitest";
+import DashboardLayout from "./layout";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: mocks.auth,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+vi.mock("@/components/Sidebar", () => ({
+  default: () => <aside>Sidebar</aside>,
+}));
+
+describe("DashboardLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects unauthenticated users to sign in", async () => {
+    mocks.auth.mockResolvedValue(null);
+
+    await DashboardLayout({
+      children: <div>Protected content</div>,
+    });
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/signin");
+  });
+
+  it("allows authenticated users to access the dashboard", async () => {
+    mocks.auth.mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "traveller@example.com",
+      },
+    });
+
+    await DashboardLayout({
+      children: <div>Protected content</div>,
+    });
+
+    expect(mocks.redirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,17 +1,26 @@
 import Sidebar from "@/components/Sidebar";
+import { auth } from "@/lib/auth";
 import { ReactNode } from "react";
+import { redirect } from "next/navigation";
 
-export default function DashboardLayout({
-    children,
+export default async function DashboardLayout({
+  children,
 }: {
-    children: ReactNode;
+  children: ReactNode;
 }) {
-    return (
-        <div className="flex bg-[#FDFCF8] dark:bg-[#0A0B1E] min-h-[calc(100vh-64px)]">
-            <Sidebar />
-            <main className="flex-1 p-8 overflow-y-auto">
-                {children}
-            </main>
-        </div>
-    );
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/signin");
+  }
+
+  return (
+    <div className="flex bg-[#FDFCF8] dark:bg-[#0A0B1E] min-h-[calc(100vh-64px)]">
+      <Sidebar />
+
+      <main className="flex-1 p-8 overflow-y-auto">
+        {children}
+      </main>
+    </div>
+  );
 }

--- a/src/components/__tests__/sign-in-form.test.tsx
+++ b/src/components/__tests__/sign-in-form.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SignInForm from "../sign-in-form";
+import { vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  signIn: vi.fn(),
+  replace: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next-auth/react", () => ({
+  signIn: mocks.signIn,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mocks.replace,
+    refresh: mocks.refresh,
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => (
+    <span role="img" aria-label={alt} />
+  ),
+}));
+
+describe("SignInForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function fillAndSubmit() {
+    const user = userEvent.setup();
+
+    render(<SignInForm />);
+
+    const emailInput = screen.getByPlaceholderText("you@example.com");
+    const passwordInput = document.querySelector(
+      'input[name="password"]',
+    ) as HTMLInputElement;
+
+    await user.type(emailInput, "test@example.com");
+    await user.type(passwordInput, "wrongpassword");
+
+    await user.click(
+      screen.getByRole("button", { name: /^sign in$/i }),
+    );
+  }
+
+  it("does not redirect when credentials are invalid", async () => {
+    mocks.signIn.mockResolvedValue({
+      ok: false,
+      error: "CredentialsSignin",
+      code: "credentials",
+      status: 401,
+      url: null,
+    });
+
+    await fillAndSubmit();
+
+    expect(
+      await screen.findByText("Invalid email or password"),
+    ).toBeInTheDocument();
+
+    expect(mocks.replace).not.toHaveBeenCalled();
+    expect(mocks.refresh).not.toHaveBeenCalled();
+  });
+
+  it("redirects to dashboard after successful sign in", async () => {
+    mocks.signIn.mockResolvedValue({
+      ok: true,
+      error: undefined,
+      code: undefined,
+      status: 200,
+      url: "/dashboard",
+    });
+
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith("/dashboard");
+    });
+
+    expect(mocks.refresh).toHaveBeenCalled();
+  });
+});

--- a/src/components/sign-in-form.tsx
+++ b/src/components/sign-in-form.tsx
@@ -3,10 +3,13 @@
 import { signIn } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
 import { FaApple, FaEye, FaEyeSlash } from "react-icons/fa";
 
 export default function SignInForm() {
+  const router = useRouter();
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
@@ -21,28 +24,33 @@ export default function SignInForm() {
     const password = formData.get("password") as string;
 
     try {
-      const res = await signIn("credentials", {
-        email,
-        password,
-        redirect: false,
-      });
+  const res = await signIn("credentials", {
+    email,
+    password,
+    redirect: false,
+  });
 
-      if (!res?.ok) {
-        setError(
-          res?.error === "CredentialsSignin"
-            ? "Invalid email or password"
-            : res?.error || "Failed to sign in",
-        );
-        setLoading(false);
-        return;
-      }
+  if (!res?.ok || res.error) {
+    const isCredentialsError =
+      res?.error === "CredentialsSignin" ||
+      res?.code === "credentials";
 
-      window.location.href = "/dashboard";
-    } catch {
-      setError("Something went wrong. Please try again.");
-    } finally {
-      setLoading(false);
-    }
+    setError(
+      isCredentialsError
+        ? "Invalid email or password"
+        : "Failed to sign in. Please try again.",
+    );
+
+    return;
+  }
+
+  router.replace("/dashboard");
+  router.refresh();
+} catch {
+  setError("Something went wrong. Please try again.");
+} finally {
+  setLoading(false);
+}
   }
 
   return (


### PR DESCRIPTION
## fix #180 

## Description

This PR fixes the authentication flow to prevent users with invalid credentials from being redirected to the Dashboard.

### Changes Made

* Improved the sign-in flow to ensure navigation to the Dashboard only occurs after successful authentication.
* Displayed a clear error message when invalid credentials are entered.
* Added server-side protection for the Dashboard layout to prevent unauthenticated users from accessing protected routes directly.
* Added regression tests covering:

  * Failed sign-in attempts (no redirect and appropriate error message).
  * Successful sign-in flow (redirect to Dashboard).
  * Protected Dashboard access.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (e.g., new page, component, or functionality)
* [ ] UI/UX improvement (design, layout, or styling updates)
* [ ] Performance optimization (e.g., code splitting, caching)
* [ ] Documentation update (README, contribution guidelines, etc.)
* [ ] Other (please specify):

## Screenshots

**Before**

* Users could incorrectly reach the Dashboard after failed authentication.
* Protected Dashboard routes were not fully guarded.

<img width="1053" height="402" alt="Screenshot 2026-07-04 175142" src="https://github.com/user-attachments/assets/148c4801-7d49-40d6-95a2-69a9687495b8" />


**After**

* Invalid credentials keep users on the Sign-In page with an appropriate error message.
* Only authenticated users can access Dashboard routes.

<img width="1900" height="984" alt="Screenshot 2026-07-04 174846" src="https://github.com/user-attachments/assets/d711ec7b-f7f1-47af-96ef-40a43e0c09be" />


## Dependencies

* No new dependencies were added.
* No configuration changes were required.

## Checklist

* [x] Lints pass (`npm run lint`)
* [ ] Builds locally (`npm run build`)
* [x] Tests added/updated (if changing logic)
* [ ] Docs updated (README/CONTRIBUTING as needed)
* [x] I have tested my changes across major browsers/devices
* [x] My changes do not generate new console warnings or errors.
* [ ] I ran `npm run build` and attached a screenshot in this PR.
* [x] This issue is assigned to me.
