### PR TITLE
fix: signup flow reliability and error messaging

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -66,10 +66,15 @@ export async function POST(req: NextRequest) {
     });
 
     // Send OTP email
-    try {
-      await sendOTPEmail(email, otp);
-    } catch (emailError) {
-      console.error("Signup email error (non-fatal):", emailError);
+    const emailResult = await sendOTPEmail(email, otp);
+
+    if (!emailResult.success) {
+      console.error("Signup email error:", emailResult.error);
+      return NextResponse.json({
+        ok: true,
+        userId: user.id,
+        error: "Account created, but we couldn't send the verification email. Please use 'Resend OTP' or contact support.",
+      }, { status: 207 }); // 207 = Multi-Status: partial success
     }
 
     return NextResponse.json({ ok: true, userId: user.id, message: "OTP sent to your email" });

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -84,5 +84,5 @@ export async function POST(req: NextRequest) {
       error: "Server error",
       message: error instanceof Error ? error.message : "Unknown error"
     }, { status: 500 });
-  }
+  } 
 }

--- a/src/components/sign-up-form.tsx
+++ b/src/components/sign-up-form.tsx
@@ -39,13 +39,7 @@ export default function SignUpForm() {
 
       const data = await res.json();
 
-      // if (!res.ok) {
-      //   setError(data.error || "Signup failed");
-      //   return;
-      // }
 
-      // setSuccess(data.message || "OTP sent! Check your email.");
-      // setStep("verify");
 
       if (!res.ok) {
   setError(data.message || data.error || "Signup failed");

--- a/src/components/sign-up-form.tsx
+++ b/src/components/sign-up-form.tsx
@@ -39,13 +39,28 @@ export default function SignUpForm() {
 
       const data = await res.json();
 
-      if (!res.ok) {
-        setError(data.error || "Signup failed");
-        return;
-      }
+      // if (!res.ok) {
+      //   setError(data.error || "Signup failed");
+      //   return;
+      // }
 
-      setSuccess(data.message || "OTP sent! Check your email.");
-      setStep("verify");
+      // setSuccess(data.message || "OTP sent! Check your email.");
+      // setStep("verify");
+
+      if (!res.ok) {
+  setError(data.message || data.error || "Signup failed");
+  return;
+}
+
+if (data.error) {
+  // Account created but email failed (status 207 partial success)
+  setError(data.error);
+  setStep("verify");
+  return;
+}
+
+setSuccess(data.message || "OTP sent! Check your email.");
+setStep("verify");
     } catch {
       setError("Network error. Please try again.");
     } finally {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -10,20 +10,7 @@ function getResendClient() {
   return resend;
 }
 
-// export async function sendOTPEmail(email: string, otp: string) {
-//   // Development/Fall-back: log to console if no API key is provided
-//   if (!process.env.RESEND_API_KEY) {
-//     console.log('='.repeat(50));
-//     console.log('📧 EMAIL VERIFICATION OTP (Terminal Mode)');
-//     console.log('='.repeat(50));
-//     console.log(`To: ${email}`);
-//     console.log(`OTP: ${otp}`);
-//     console.log(`Expires: 10 minutes`);
-//     console.log('='.repeat(50));
-//     console.log('NOTE: Add RESEND_API_KEY to .env to receive actual emails.');
-//     console.log('='.repeat(50));
-//     return { success: true };
-//   }
+
 export async function sendOTPEmail(email: string, otp: string) {
   // Development-only fallback: log to console if no API key is provided.
   // In production, a missing key is a real misconfiguration and should

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -10,19 +10,40 @@ function getResendClient() {
   return resend;
 }
 
+// export async function sendOTPEmail(email: string, otp: string) {
+//   // Development/Fall-back: log to console if no API key is provided
+//   if (!process.env.RESEND_API_KEY) {
+//     console.log('='.repeat(50));
+//     console.log('📧 EMAIL VERIFICATION OTP (Terminal Mode)');
+//     console.log('='.repeat(50));
+//     console.log(`To: ${email}`);
+//     console.log(`OTP: ${otp}`);
+//     console.log(`Expires: 10 minutes`);
+//     console.log('='.repeat(50));
+//     console.log('NOTE: Add RESEND_API_KEY to .env to receive actual emails.');
+//     console.log('='.repeat(50));
+//     return { success: true };
+//   }
 export async function sendOTPEmail(email: string, otp: string) {
-  // Development/Fall-back: log to console if no API key is provided
+  // Development-only fallback: log to console if no API key is provided.
+  // In production, a missing key is a real misconfiguration and should
+  // surface as a failure, not a silent false success.
   if (!process.env.RESEND_API_KEY) {
-    console.log('='.repeat(50));
-    console.log('📧 EMAIL VERIFICATION OTP (Terminal Mode)');
-    console.log('='.repeat(50));
-    console.log(`To: ${email}`);
-    console.log(`OTP: ${otp}`);
-    console.log(`Expires: 10 minutes`);
-    console.log('='.repeat(50));
-    console.log('NOTE: Add RESEND_API_KEY to .env to receive actual emails.');
-    console.log('='.repeat(50));
-    return { success: true };
+    if (process.env.NODE_ENV !== "production") {
+      console.log('='.repeat(50));
+      console.log('📧 EMAIL VERIFICATION OTP (Terminal Mode)');
+      console.log('='.repeat(50));
+      console.log(`To: ${email}`);
+      console.log(`OTP: ${otp}`);
+      console.log(`Expires: 10 minutes`);
+      console.log('='.repeat(50));
+      console.log('NOTE: Add RESEND_API_KEY to .env to receive actual emails.');
+      console.log('='.repeat(50));
+      return { success: true };
+    }
+
+    console.error('RESEND_API_KEY is not configured in production.');
+    return { success: false, error: new Error('Email service not configured') };
   }
 
   // Production: send real email via Resend


### PR DESCRIPTION
## Description

Fixes the misleading "Server error" / false success messaging in the sign-up 
flow (Closes #182 ).

Previously:
- When account creation failed, the frontend only showed a generic "Server 
  error" — even though the backend already computed a more specific detail 
  and never sent it through.
- If the OTP email failed to send, the app silently treated it as non-fatal 
  and told the user "OTP sent to your email" regardless — leaving users 
  stuck with no idea anything went wrong.

## Changes

- **`route.ts`** — now checks if the email actually sent; returns an honest 
  partial-success (207) with a clear message if it didn't
- **`sign-up-form.tsx`** — now shows the specific backend message instead of 
  the generic fallback, and correctly handles the 207 case (since it still 
  falls in the "ok" status range)
- **`email.ts`** — the local dev console-log fallback (used when 
  `RESEND_API_KEY` is missing) is now gated to non-production only. In 
  production, a missing key now correctly returns a failure instead of 
  silently claiming success

## Testing

- Verified full signup → OTP → verify → sign-in flow works locally
- Simulated an email failure with an invalid `RESEND_API_KEY`, confirmed the 
  new honest error message shows correctly
- `npm run build` passes with no errors

## For maintainer to check

While testing the **live site**, I signed up with real Gmail addresses 
multiple times and never received an OTP email. Could you confirm 
`RESEND_API_KEY` is actually set in Vercel's environment variables? If it's 
missing, that's likely why real users aren't getting OTPs at all — this PR 
makes that failure honest, but doesn't fix delivery itself since I don't 
have access to your Resend/Vercel config to verify further.


