### PR TITLE
feat: implement change password functionality in profile settings (#196)

### DIFF
--- a/src/app/api/auth/__tests__/change-password.test.ts
+++ b/src/app/api/auth/__tests__/change-password.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock prisma
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+// Mock next-auth auth method
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+// Mock bcryptjs compare and hash
+vi.mock("bcryptjs", () => ({
+  compare: vi.fn(),
+  hash: vi.fn(() => Promise.resolve("new_hashed_password")),
+}));
+
+import { PUT } from "../change-password/route";
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { compare } from "bcryptjs";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PUT /api/auth/change-password", () => {
+  const createRequest = (bodyData: any) => {
+    return {
+      json: async () => bodyData,
+    };
+  };
+
+  it("returns 401 Unauthorized if session is missing", async () => {
+    ;(auth as any).mockResolvedValue(null);
+
+    const req = createRequest({ currentPassword: "password123", newPassword: "newpassword123" });
+    const res = await PUT(req as any);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for invalid inputs", async () => {
+    ;(auth as any).mockResolvedValue({ user: { email: "test@example.com" } });
+
+    // case 1: empty fields
+    let req = createRequest({ currentPassword: "", newPassword: "" });
+    let res = await PUT(req as any);
+    let data = await res.json();
+    expect(res.status).toBe(400);
+
+    // case 2: newPassword too short
+    req = createRequest({ currentPassword: "password123", newPassword: "short" });
+    res = await PUT(req as any);
+    data = await res.json();
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 if user is an OAuth user (no passwordHash)", async () => {
+    ;(auth as any).mockResolvedValue({ user: { email: "test@example.com" } });
+    ;(prisma.user.findUnique as any).mockResolvedValue({
+      id: "user123",
+      email: "test@example.com",
+      passwordHash: null, // OAuth user
+    });
+
+    const req = createRequest({ currentPassword: "password123", newPassword: "newpassword123" });
+    const res = await PUT(req as any);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain("Google/Apple cannot change passwords directly");
+  });
+
+  it("returns 400 if current password is incorrect", async () => {
+    ;(auth as any).mockResolvedValue({ user: { email: "test@example.com" } });
+    ;(prisma.user.findUnique as any).mockResolvedValue({
+      id: "user123",
+      email: "test@example.com",
+      passwordHash: "old_hashed_password",
+    });
+    ;(compare as any).mockResolvedValue(false); // wrong password
+
+    const req = createRequest({ currentPassword: "wrongpassword", newPassword: "newpassword123" });
+    const res = await PUT(req as any);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBe("Incorrect current password");
+  });
+
+  it("returns 200 and updates password hash if input is correct", async () => {
+    ;(auth as any).mockResolvedValue({ user: { email: "test@example.com" } });
+    ;(prisma.user.findUnique as any).mockResolvedValue({
+      id: "user123",
+      email: "test@example.com",
+      passwordHash: "old_hashed_password",
+    });
+    ;(compare as any).mockResolvedValue(true); // correct password
+
+    const req = createRequest({ currentPassword: "correctpassword", newPassword: "newpassword123" });
+    const res = await PUT(req as any);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user123" },
+      data: { passwordHash: "new_hashed_password" },
+    });
+  });
+});

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse, NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { hash, compare } from "bcryptjs";
+import { z } from "zod";
+
+const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, "Current password is required"),
+  newPassword: z.string().min(8, "New password must be at least 8 characters"),
+});
+
+export async function PUT(req: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const result = changePasswordSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: "Invalid input", details: result.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const { currentPassword, newPassword } = result.data;
+
+    // Fetch the user from the database
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Check if the user is an OAuth user (no passwordHash)
+    if (!user.passwordHash) {
+      return NextResponse.json(
+        { error: "Accounts authenticated via Google/Apple cannot change passwords directly" },
+        { status: 400 }
+      );
+    }
+
+    // Verify current password
+    const isCurrentPasswordCorrect = await compare(currentPassword, user.passwordHash);
+    if (!isCurrentPasswordCorrect) {
+      return NextResponse.json({ error: "Incorrect current password" }, { status: 400 });
+    }
+
+    // Hash the new password (10 rounds)
+    const newPasswordHash = await hash(newPassword, 10);
+
+    // Update user in DB
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash: newPasswordHash },
+    });
+
+    return NextResponse.json({ ok: true, message: "Password updated successfully" });
+  } catch (error) {
+    console.error("Change password error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { Camera, Upload } from "lucide-react";
+import { Camera, Upload, KeyRound } from "lucide-react";
 
 export default function ProfilePage() {
     const [name, setName] = useState("");
@@ -13,6 +13,13 @@ export default function ProfilePage() {
     const [preview, setPreview] = useState<string>("");
     const [avatarFile, setAvatarFile] = useState<File | null>(null);
     const [loading, setLoading] = useState(false);
+
+    const [currentPassword, setCurrentPassword] = useState("");
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [passwordLoading, setPasswordLoading] = useState(false);
+    const [showSuccessModal, setShowSuccessModal] = useState(false);
+    const [passwordError, setPasswordError] = useState<string | null>(null);
 
     useEffect(() => {
         async function fetchProfile() {
@@ -61,6 +68,45 @@ export default function ProfilePage() {
             alert("Something went wrong.");
         }
         setLoading(false);
+    };
+
+    const handlePasswordSubmit = async () => {
+        setPasswordError(null);
+        if (!currentPassword || !newPassword || !confirmPassword) {
+            setPasswordError("All password fields are required.");
+            return;
+        }
+        if (newPassword.length < 8) {
+            setPasswordError("New password must be at least 8 characters long.");
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            setPasswordError("New password and confirm password do not match.");
+            return;
+        }
+
+        setPasswordLoading(true);
+        try {
+            const res = await fetch("/api/auth/change-password", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ currentPassword, newPassword }),
+            });
+
+            const data = await res.json();
+            if (res.ok) {
+                setShowSuccessModal(true);
+                setCurrentPassword("");
+                setNewPassword("");
+                setConfirmPassword("");
+            } else {
+                setPasswordError(data.error || "Failed to update password.");
+            }
+        } catch (error) {
+            console.error(error);
+            setPasswordError("Something went wrong. Please try again.");
+        }
+        setPasswordLoading(false);
     };
 
     return (
@@ -184,6 +230,95 @@ export default function ProfilePage() {
                     </div>
                 </div>
             </div>
+
+            <div className="mt-8 rounded-[32px] border border-gray-100 dark:border-gray-800 bg-[#F6F4EC] dark:bg-[#11132B] p-8 md:p-12 shadow-sm transition-colors duration-300">
+                <div className="grid md:grid-cols-[280px_1fr] gap-12 lg:gap-16">
+                    {/* Left: Security Info */}
+                    <div className="flex flex-col items-center justify-center text-center text-gray-500 dark:text-gray-400 gap-4">
+                        <div className="p-4 rounded-full bg-white dark:bg-[#1A1C3D] border border-gray-100 dark:border-gray-800 shadow-inner">
+                            <KeyRound size={40} className="text-gray-400 dark:text-gray-300" />
+                        </div>
+                        <div>
+                            <h2 className="text-lg font-bold text-gray-900 dark:text-white">Security</h2>
+                            <p className="text-xs mt-1 text-gray-500 dark:text-gray-400 max-w-[200px]">Update your password to keep your account secure.</p>
+                        </div>
+                    </div>
+
+                    {/* Right: Password Change Form */}
+                    <div className="space-y-6">
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Current Password</label>
+                            <input
+                                type="password"
+                                value={currentPassword}
+                                onChange={(e) => setCurrentPassword(e.target.value)}
+                                placeholder="Enter current password"
+                                className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
+                            />
+                        </div>
+
+                        <div className="grid md:grid-cols-2 gap-6">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">New Password</label>
+                                <input
+                                    type="password"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                    placeholder="Enter new password"
+                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
+                                />
+                            </div>
+
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Confirm New Password</label>
+                                <input
+                                    type="password"
+                                    value={confirmPassword}
+                                    onChange={(e) => setConfirmPassword(e.target.value)}
+                                    placeholder="Confirm new password"
+                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
+                                />
+                            </div>
+                        </div>
+
+                        {passwordError && (
+                            <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+                                ⚠️ {passwordError}
+                            </div>
+                        )}
+
+                        <div className="flex pt-4">
+                            <button
+                                onClick={handlePasswordSubmit}
+                                disabled={passwordLoading}
+                                className="bg-[#1A4D2E] text-white px-8 py-3.5 rounded-xl font-bold text-sm hover:opacity-90 transition shadow-sm disabled:opacity-60 w-full sm:w-auto"
+                            >
+                                {passwordLoading ? "Updating..." : "Update Password"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {showSuccessModal && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+                    <div className="bg-[#11132B] border border-gray-800 rounded-3xl p-8 max-w-sm w-full text-center shadow-2xl animate-in fade-in zoom-in-95 duration-200">
+                        <div className="mx-auto w-16 h-16 bg-emerald-500/10 rounded-full flex items-center justify-center mb-4">
+                            <svg className="w-8 h-8 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+                            </svg>
+                        </div>
+                        <h3 className="text-xl font-bold text-white mb-2">Password Changed!</h3>
+                        <p className="text-gray-400 text-sm mb-6">Your password has been updated successfully. You can now use your new password next time you sign in.</p>
+                        <button
+                            onClick={() => setShowSuccessModal(false)}
+                            className="w-full bg-[#1A4D2E] text-white py-3 rounded-xl font-bold text-sm hover:opacity-90 transition shadow-sm"
+                        >
+                            Got it, thanks!
+                        </button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
### Overview
This Pull Request resolves issue #196 by implementing a secure **Change Password** functionality directly in the User Profile settings.

Closes #196

---

### Key Changes

#### 1. Backend Route (`PUT /api/auth/change-password`)
* Created a secure Next.js API route that validates request payloads.
* Excludes OAuth users (Google/Apple login users) from changing passwords directly, as they do not have a stored password hash.
* Compares the current password against the stored database hash using `bcryptjs`.
* Hashes the new password (10 rounds) and updates the database via Prisma.

#### 2. Frontend UI (`src/app/dashboard/profile/page.tsx`)
* Added a dedicated "Security" card below the main profile edits matching the existing container theme and styling tokens.
* Replaced native browser `alert()` popups with:
  * **Inline Error Banner:** Displays input errors, length constraints, or mismatch warnings directly inside the form.
  * **Custom Success Modal:** An animated overlay popup with a checkmark graphic confirming password updates without blocking the browser thread.

#### 3. Automated Tests
* Implemented extensive unit tests covering 5 test branches under `src/app/api/auth/__tests__/change-password.test.ts`.

---

### Visual Proof (Screenshots)

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/546ef9d2-d405-425a-b090-7fca9c5ab973" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/3bdf40ef-ec62-4c78-be25-ebbfdcb35bee" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/51386b19-268a-4641-9ea6-9885f2caf889" />

---

### Test Verification Result

All unit tests pass successfully:

```bash
✓ src/app/api/auth/__tests__/change-password.test.ts (5 tests) 43ms
  ✓ PUT /api/auth/change-password > returns 401 Unauthorized if session is missing 18ms
  ✓ PUT /api/auth/change-password > returns 400 for invalid inputs 6ms
  ✓ PUT /api/auth/change-password > returns 400 if user is an OAuth user (no passwordHash) 3ms
  ✓ PUT /api/auth/change-password > returns 400 if current password is incorrect 4ms
  ✓ PUT /api/auth/change-password > returns 200 and updates password hash if input is correct 7ms
