### PR TITLE
fix: make resend from address configurable via env variable (#198)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
 GEMINI_API_KEY="replace with api"
 RESEND_API_KEY="replace-me" # Resend API Key for sending emails (https://resend.com)
+RESEND_FROM_EMAIL="onboarding@resend.dev" # Verified email domain registered in Resend (default: onboarding@resend.dev)
 
 GOOGLE_CLIENT_ID = 
 GOOGLE_CLIENT_SECRET= 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -45,7 +45,7 @@ export async function sendOTPEmail(email: string, otp: string) {
     }
 
     await client.emails.send({
-      from: 'Travellers <onboarding@resend.dev>',
+      from: `Travellers <${process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev'}>`,
       to: email,
       subject: 'Verify your email - Travellers',
       html: `
@@ -97,7 +97,7 @@ export async function sendPasswordResetEmail(email: string, token: string) {
   // Development/Fall-back: log to console if no API key is provided
   if (!process.env.RESEND_API_KEY) {
     console.log('='.repeat(50));
-    console.log('📧 PASSWORD RESET EMAIL (Terminal Mode)');
+    console.log(' PASSWORD RESET EMAIL (Terminal Mode)');
     console.log('='.repeat(50));
     console.log(`To: ${email}`);
     console.log(`Reset URL: ${resetUrl}`);
@@ -116,7 +116,7 @@ export async function sendPasswordResetEmail(email: string, token: string) {
     }
 
     await client.emails.send({
-      from: 'Travellers <onboarding@resend.dev>',
+      from: `Travellers <${process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev'}>`,
       to: email,
       subject: 'Reset your password - Travellers',
       html: `
@@ -141,7 +141,7 @@ export async function sendPasswordResetEmail(email: string, token: string) {
               </div>
               
               <p style="font-size: 14px; color: #6b7280; margin-top: 30px;">
-                ⏱️ This link will expire in <strong>1 hour</strong>.
+               This link will expire in <strong>1 hour</strong>.
               </p>
               
               <p style="font-size: 14px; color: #6b7280; margin-top: 20px;">


### PR DESCRIPTION
###  Overview
This PR resolves issue #198 by replacing the hardcoded `onboarding@resend.dev` email sender address with a configurable environment variable `RESEND_FROM_EMAIL` (defaulting to `onboarding@resend.dev` for local sandbox development).

Closes #198

---

### Key Changes
1. **Configurable Sender Email (`src/lib/email.ts`):**
   * Replaced the hardcoded `'Travellers <onboarding@resend.dev>'` string in both `sendOTPEmail` and `sendPasswordResetEmail` with `process.env.RESEND_FROM_EMAIL`.
   * Retained `onboarding@resend.dev` as a fallback value so local sandbox environments do not break.
2. **Environment Variable Configurations:**
   * Added `RESEND_FROM_EMAIL` documentation in `.env.example` and local `.env`.

---

### Note for Maintainer (@singh-odyssey )
Since the `onboarding@resend.dev` sandbox domain only allows sending to the registered Resend account owner, you will need to:
1. Go to your production deployment environment (e.g. Vercel dashboard).
2. Set the environment variable `RESEND_FROM_EMAIL` to your verified domain sender address (e.g., `Verify <no-reply@yourdomain.com>`).
3. Make sure the domain configuration is verified in your Resend Dashboard.

---

### How to Verify
Run the existing test suits to confirm email utilities remain fully compliant:
```bash
npx vitest run src/app/api/auth/__tests__/forgot-password.test.ts
npx vitest run src/app/api/auth/__tests__/reset-password.test.ts
