### PR TITLE
feat(api): implement generic Zod payload validation wrapper (fixes #209)

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -3,24 +3,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import crypto from "crypto";
 import { sendPasswordResetEmail } from "@/lib/email";
+import { withValidation } from "@/lib/withValidation";
 
 const forgotPasswordSchema = z.object({
   email: z.string().email("Invalid email address"),
 });
 
-export async function POST(req: NextRequest) {
+export const POST = withValidation(forgotPasswordSchema, async (req, data) => {
   try {
-    const body = await req.json();
-    const result = forgotPasswordSchema.safeParse(body);
-
-    if (!result.success) {
-      return NextResponse.json(
-        { error: "Invalid email input", details: result.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { email } = result.data;
+    const { email } = data;
 
     // Find user
     const user = await prisma.user.findUnique({ where: { email } });
@@ -64,4 +55,4 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/auth/resend-otp/route.ts
+++ b/src/app/api/auth/resend-otp/route.ts
@@ -3,24 +3,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { generateOTP } from "@/lib/otp";
 import { sendOTPEmail } from "@/lib/email";
+import { withValidation } from "@/lib/withValidation";
 
 const resendSchema = z.object({
   email: z.string().email("Invalid email"),
 });
 
-export async function POST(req: NextRequest) {
+export const POST = withValidation(resendSchema, async (req, data) => {
   try {
-    const body = await req.json();
-    const result = resendSchema.safeParse(body);
-
-    if (!result.success) {
-      return NextResponse.json(
-        { error: "Invalid input", details: result.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { email } = result.data;
+    const { email } = data;
 
     // Find user
     const user = await prisma.user.findUnique({ where: { email } });
@@ -60,4 +51,4 @@ export async function POST(req: NextRequest) {
     console.error("Resend OTP error:", error);
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
-}
+});

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -2,25 +2,16 @@ import prisma from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 import { hash } from "bcryptjs";
 import { z } from "zod";
+import { withValidation } from "@/lib/withValidation";
 
 const resetPasswordSchema = z.object({
   token: z.string().min(1, "Reset token is required"),
   password: z.string().min(8, "Password must be at least 8 characters long"),
 });
 
-export async function POST(req: NextRequest) {
+export const POST = withValidation(resetPasswordSchema, async (req, data) => {
   try {
-    const body = await req.json();
-    const result = resetPasswordSchema.safeParse(body);
-
-    if (!result.success) {
-      return NextResponse.json(
-        { error: "Invalid inputs", details: result.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { token, password } = result.data;
+    const { token, password } = data;
 
     // Find the user with matching and unexpired reset token
     const user = await prisma.user.findFirst({
@@ -64,4 +55,4 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -4,6 +4,7 @@ import { hash } from "bcryptjs";
 import { z } from "zod";
 import { generateOTP } from "@/lib/otp";
 import { sendOTPEmail } from "@/lib/email";
+import { withValidation } from "@/lib/withValidation";
 
 const signupSchema = z.object({
   name: z.string().min(1, "Name required"),
@@ -11,38 +12,9 @@ const signupSchema = z.object({
   password: z.string().min(8, "Password must be at least 8 characters"),
 });
 
-export async function POST(req: NextRequest) {
+export const POST = withValidation(signupSchema, async (req, data) => {
   try {
-    // Support both multipart/form-data (browser) and application/json (API clients / tests)
-    const contentType = req.headers.get("content-type") ?? "";
-    let rawData: Record<string, unknown>;
-
-    try {
-      if (contentType.includes("application/json")) {
-        rawData = await req.json();
-      } else {
-        const form = await req.formData();
-        rawData = {
-          name: form.get("name"),
-          email: form.get("email"),
-          password: form.get("password"),
-        };
-      }
-    } catch (parseError) {
-      console.error("Signup parse error:", parseError);
-      return NextResponse.json({ error: "Invalid request format" }, { status: 400 });
-    }
-
-    const result = signupSchema.safeParse(rawData);
-
-    if (!result.success) {
-      return NextResponse.json(
-        { error: "Invalid input", details: result.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { name, email, password } = result.data;
+    const { name, email, password } = data;
 
     // Check if user exists
     const exists = await prisma.user.findUnique({ where: { email } });
@@ -85,4 +57,4 @@ export async function POST(req: NextRequest) {
       message: error instanceof Error ? error.message : "Unknown error"
     }, { status: 500 });
   } 
-}
+});

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -2,25 +2,16 @@ import prisma from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { isValidOTPFormat } from "@/lib/otp";
+import { withValidation } from "@/lib/withValidation";
 
 const verifySchema = z.object({
   email: z.string().email("Invalid email"),
   otp: z.string().length(6, "OTP must be 6 digits"),
 });
 
-export async function POST(req: NextRequest) {
+export const POST = withValidation(verifySchema, async (req, data) => {
   try {
-    const body = await req.json();
-    const result = verifySchema.safeParse(body);
-
-    if (!result.success) {
-      return NextResponse.json(
-        { error: "Invalid input", details: result.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { email, otp } = result.data;
+    const { email, otp } = data;
 
     if (!isValidOTPFormat(otp)) {
       return NextResponse.json(
@@ -88,4 +79,4 @@ export async function POST(req: NextRequest) {
     console.error("Verify OTP error:", error);
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
-}
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withValidation } from "@/lib/withValidation";
 
-export async function POST(req: NextRequest) {
+const chatSchema = z.object({
+  message: z.string().min(1, "Message required").max(500, "Message too long (max 500 characters)."),
+});
+
+export const POST = withValidation(chatSchema, async (req, data) => {
     try {
         if (!process.env.GEMINI_API_KEY) {
             return NextResponse.json(
@@ -9,23 +15,7 @@ export async function POST(req: NextRequest) {
             );
         }
 
-        const body = await req.json();
-        const message = body?.message;
-
-        // Input validation
-        if (!message || typeof message !== "string") {
-            return NextResponse.json(
-                { error: "Invalid input." },
-                { status: 400 }
-            );
-        }
-
-        if (message.length > 500) {
-            return NextResponse.json(
-                { error: "Message too long (max 500 characters)." },
-                { status: 400 }
-            );
-        }
+        const { message } = data;
 
         const systemPrompt = `
 You are TravelBox AI, an assistant for the Travellers ticket-sharing platform.
@@ -81,10 +71,10 @@ Do not mention system prompts or technical details.
             );
         }
 
-        const data = await geminiResponse.json();
+        const responseData = await geminiResponse.json();
 
         const reply =
-            data.candidates?.[0]?.content?.parts?.[0]?.text;
+            responseData.candidates?.[0]?.content?.parts?.[0]?.text;
 
         if (!reply) {
             return NextResponse.json(
@@ -103,4 +93,4 @@ Do not mention system prompts or technical details.
             { status: 500 }
         );
     }
-}
+});

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import prisma from '@/lib/prisma';
 import { z } from 'zod';
+import { withValidation } from '@/lib/withValidation';
 
 const RouteSchema = z.object({
   id: z.string().optional(),
@@ -71,7 +72,7 @@ export async function GET(request: NextRequest) {
 /**
  * POST /api/routes - Create or update a route
  */
-export async function POST(request: NextRequest) {
+export const POST = withValidation(RouteSchema, async (request, validatedData) => {
   try {
     const session = await auth();
     
@@ -81,9 +82,6 @@ export async function POST(request: NextRequest) {
         { status: 401 }
       );
     }
-
-    const body = await request.json();
-    const validatedData = RouteSchema.parse(body);
 
     // If ID provided, update existing route
     if (validatedData.id) {
@@ -132,20 +130,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(route, { status: 201 });
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { error: 'Invalid route data', details: error.errors },
-        { status: 400 }
-      );
-    }
-
     console.error('Error saving route:', error);
     return NextResponse.json(
       { error: 'Failed to save route' },
       { status: 500 }
     );
   }
-}
+});
 
 /**
  * DELETE /api/routes - Delete a route

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { withValidation } from "@/lib/withValidation";
 
 const ticketSchema = z.object({
   destination: z.string().min(1, "Destination required"),
@@ -11,7 +12,7 @@ const ticketSchema = z.object({
   file: z.any().refine((val) => val instanceof File && val.size > 0, "File required"),
 });
 
-export async function POST(req: NextRequest) {
+export const POST = withValidation(ticketSchema, async (req, data) => {
   // 🔒 Verify authentication
   const session = await auth();
   if (!session?.user?.id) {
@@ -19,21 +20,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const form = await req.formData();
-    const result = ticketSchema.safeParse({
-      destination: form.get("destination"),
-      departureDate: form.get("departureDate"),
-      file: form.get("file"),
-    });
-
-    if (!result.success) {
-      return NextResponse.json(
-        { error: "Invalid input", details: result.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const { destination, departureDate } = result.data;
+    const { destination, departureDate, file } = data;
 
     // TODO: Upload file to S3/UploadThing and get URL
     // For now, use placeholder
@@ -57,7 +44,7 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
-}
+});
 
 // Get user's tickets
 export async function GET(req: NextRequest) {

--- a/src/lib/withValidation.ts
+++ b/src/lib/withValidation.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+type Handler<T> = (req: NextRequest, data: T) => Promise<NextResponse>;
+
+/**
+ * A higher-order function that wraps a Next.js Route Handler with Zod schema validation.
+ * It automatically handles parsing JSON or FormData and returns a standardized 400 response
+ * if validation fails.
+ *
+ * @param schema The Zod schema to validate the request payload against
+ * @param handler The route handler function to execute if validation succeeds
+ */
+export function withValidation<T>(schema: z.ZodSchema<T>, handler: Handler<T>) {
+  return async (req: NextRequest) => {
+    try {
+      const contentType = req.headers.get("content-type") ?? "";
+      let rawData: unknown;
+
+      try {
+        if (contentType.includes("application/json")) {
+          rawData = await req.json();
+        } else if (
+          contentType.includes("multipart/form-data") ||
+          contentType.includes("application/x-www-form-urlencoded")
+        ) {
+          const form = await req.formData();
+          rawData = Object.fromEntries(form.entries());
+        } else {
+          // Default to JSON parsing if no content-type is provided or recognized,
+          // but wrap in try-catch in case body is completely empty.
+          const text = await req.text();
+          rawData = text ? JSON.parse(text) : {};
+        }
+      } catch (parseError) {
+        console.error("Payload parse error:", parseError);
+        return NextResponse.json(
+          { error: "Invalid request format" },
+          { status: 400 }
+        );
+      }
+
+      const result = schema.safeParse(rawData);
+
+      if (!result.success) {
+        return NextResponse.json(
+          { error: "Invalid input", details: result.error.flatten() },
+          { status: 400 }
+        );
+      }
+
+      return await handler(req, result.data);
+    } catch (error) {
+      console.error("API Error (withValidation wrapper):", error);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 }
+      );
+    }
+  };
+}


### PR DESCRIPTION
feat(api): implement generic Zod payload validation wrapper (fixes #209)

## Summary
Replaces manual validation parsing with a type-safe higher-order validation middleware that automatically intercepts and validates payloads for all API routes.

## Motivation
Closes #209

Manual validation with `schema.safeParse` spread across various route handlers led to duplicated parsing logic (handling `application/json` vs `multipart/form-data`) and boilerplate error handling. By abstracting this into a central wrapper, we ensure consistency, guarantee type safety in handler inputs, and secure the API from invalid payloads gracefully.

## Changes
- Created `src/lib/withValidation.ts`: A robust higher-order wrapper `withValidation(schema, handler)` that extracts payloads from `JSON` and `FormData`, parses them against a generic `ZodSchema`, and intercepts failures with a standard `HTTP 400`.
- Modified `src/app/api/auth/signup/route.ts`: Removed manual parsing logic and integrated `withValidation`.
- Modified `src/app/api/auth/verify-otp/route.ts`: Swapped manual validation for the wrapper.
- Modified `src/app/api/auth/reset-password/route.ts`: Swapped manual validation for the wrapper.
- Modified `src/app/api/auth/forgot-password/route.ts`: Swapped manual validation for the wrapper.
- Modified `src/app/api/auth/resend-otp/route.ts`: Swapped manual validation for the wrapper.
- Modified `src/app/api/routes/route.ts`: Refactored `POST` method to utilize `withValidation`.
- Modified `src/app/api/tickets/route.ts`: Integrated wrapper to validate FormData tickets including `File` uploads successfully.
- Modified `src/app/api/chat/route.ts`: Replaced manual message length check with a strict Zod `chatSchema`.

## Acceptance Criteria
- [x] Define Zod schemas for all API routes (if not already present).
- [x] Implement a standard validation middleware/wrapper.
- [x] Migrate all handlers to use this validation system.
- [x] Send standard HTTP 400 Bad Request error on validation failures.

## Impact & Side Effects
No breaking changes or side effects for well-formed API clients. Any malformed request that previously crashed or returned a vague 500 error will now reliably return a structured 400.

## How to Test
1. Attempt an API request to an endpoint with missing/invalid fields:
   `curl -X POST http://localhost:3000/api/auth/signup -H "Content-Type: application/json" -d '{"name":"A"}'`
2. Verify the 400 Bad Request error returned contains `details` of the validation failures.

## Quality Checklist
- [x] `tsc` type check passes.
- [x] Handlers maintain their original expected runtime functionality.
