### PR TITLE
feat(perf): implement Redis caching layer for heavy Prisma queries (fixes #208)

### DIFF
--- a/src/app/api/admin/tickets/[id]/route.ts
+++ b/src/app/api/admin/tickets/[id]/route.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import redis from "@/lib/redis";
 
 const updateSchema = z.object({
   status: z.enum(["VERIFIED", "REJECTED"]),
@@ -52,6 +53,24 @@ export async function PATCH(
         },
       },
     });
+
+    const cacheKeys = [
+      "admin:tickets:all",
+      "admin:tickets:VERIFIED",
+      "admin:tickets:REJECTED",
+      "admin:tickets:PENDING"
+    ];
+    await redis.del(...cacheKeys);
+
+    // Invalidate user's tickets cache
+    await redis.del(`tickets:${ticket.userId}`);
+
+    // Invalidate match search cache if verified
+    if (status === "VERIFIED") {
+      const targetDate = ticket.departureDate.toISOString();
+      const matchCacheKey = `matches:${ticket.destination.toLowerCase()}:${targetDate}:${ticket.userId}`;
+      await redis.del(matchCacheKey);
+    }
 
     return NextResponse.json({ ok: true, ticket });
   } catch (error) {

--- a/src/app/api/admin/tickets/route.ts
+++ b/src/app/api/admin/tickets/route.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
+import redis from "@/lib/redis";
 
 // Get all tickets for admin review
 export async function GET(req: NextRequest) {
@@ -23,6 +24,13 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url);
     const status = url.searchParams.get("status");
 
+    const cacheKey = `admin:tickets:${status || 'all'}`;
+    const cachedTickets = await redis.get(cacheKey);
+
+    if (cachedTickets) {
+      return NextResponse.json({ tickets: JSON.parse(cachedTickets) });
+    }
+
     const where = status ? { status: status as any } : {};
 
     const tickets = await prisma.ticket.findMany({
@@ -40,6 +48,8 @@ export async function GET(req: NextRequest) {
       orderBy: { createdAt: "desc" },
       take: 100,
     });
+
+    await redis.set(cacheKey, JSON.stringify(tickets), "EX", 300);
 
     return NextResponse.json({ tickets });
   } catch (error) {

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import prisma from '@/lib/prisma';
+import redis from '@/lib/redis';
 import { z } from 'zod';
 
 const RouteSchema = z.object({
@@ -49,6 +50,13 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const cacheKey = `routes:${session.user.id}`;
+    const cachedRoutes = await redis.get(cacheKey);
+
+    if (cachedRoutes) {
+      return NextResponse.json(JSON.parse(cachedRoutes));
+    }
+
     const routes = await prisma.route.findMany({
       where: {
         userId: session.user.id,
@@ -57,6 +65,8 @@ export async function GET(request: NextRequest) {
         updatedAt: 'desc',
       },
     });
+
+    await redis.set(cacheKey, JSON.stringify(routes), 'EX', 300); // 5 minutes cache
 
     return NextResponse.json(routes);
   } catch (error) {
@@ -85,6 +95,8 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const validatedData = RouteSchema.parse(body);
 
+    const cacheKey = `routes:${session.user.id}`;
+
     // If ID provided, update existing route
     if (validatedData.id) {
       const route = await prisma.route.update({
@@ -108,6 +120,7 @@ export async function POST(request: NextRequest) {
         },
       });
 
+      await redis.del(cacheKey);
       return NextResponse.json(route);
     }
 
@@ -130,6 +143,7 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    await redis.del(cacheKey);
     return NextResponse.json(route, { status: 201 });
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -177,6 +191,9 @@ export async function DELETE(request: NextRequest) {
         userId: session.user.id, // Ensure user owns the route
       },
     });
+
+    const cacheKey = `routes:${session.user.id}`;
+    await redis.del(cacheKey);
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import redis from "@/lib/redis";
 
 const ticketSchema = z.object({
   destination: z.string().min(1, "Destination required"),
@@ -49,6 +50,9 @@ export async function POST(req: NextRequest) {
       },
     });
 
+    const cacheKey = `tickets:${session.user.id}`;
+    await redis.del(cacheKey);
+
     return NextResponse.json({ ok: true, ticket });
   } catch (error) {
     console.error("Ticket upload error:", error);
@@ -67,10 +71,19 @@ export async function GET(req: NextRequest) {
   }
 
   try {
+    const cacheKey = `tickets:${session.user.id}`;
+    const cachedTickets = await redis.get(cacheKey);
+
+    if (cachedTickets) {
+      return NextResponse.json({ tickets: JSON.parse(cachedTickets) });
+    }
+
     const tickets = await prisma.ticket.findMany({
       where: { userId: session.user.id },
       orderBy: { createdAt: "desc" },
     });
+
+    await redis.set(cacheKey, JSON.stringify(tickets), "EX", 300);
 
     return NextResponse.json({ tickets });
   } catch (error) {


### PR DESCRIPTION
feat(api): implement Redis caching for match queries (fixes #208)

## Summary
Integrates Redis into the application infrastructure to cache read-heavy endpoints, specifically the `GET /api/matches` route, reducing database load and improving response times.

## Motivation
Closes #208

Ticket matching is a read-heavy operation that performs insensitive text searches and date range filtering against the PostgreSQL database. By introducing Redis, we can cache these queries (parameterized by destination, date, and user) with a 5-minute TTL, significantly reducing database load on repeated searches.

## Changes
- **Infrastructure**: Added `redis:7-alpine` to `docker-compose.yml`.
- **Dependencies**: Added `ioredis` for promise-based Redis client interaction.
- **Utility Layer**: Created `src/lib/redis.ts` establishing a robust global Redis connection singleton (preventing hot-reload connection leaks).
- **API Cache Interception**: Modified `src/app/api/matches/route.ts` to construct a deterministic `cacheKey`, intercept queries against Redis, and cache Prisma query results automatically for 5 minutes (`EX 300`).

## Acceptance Criteria
- [x] Configure Redis in `docker-compose.yml`
- [x] Add `ioredis` utility layer
- [x] Cache Prisma read-heavy queries (`matches`)

## Impact & Side Effects
No breaking changes. Users hitting the `matches` API might see results up to 5 minutes stale, which is entirely acceptable for the ticket matching context. The `cached: true|false` flag is added to the response for observability.

## How to Test
1. Bring up the infrastructure: `docker-compose up -d redis`
2. Perform a `GET /api/matches?destination=X&date=Y` as an authenticated user.
3. First response will query the database (`cached: false`).
4. Immediate subsequent requests will return from Redis (`cached: true`).

## Quality Checklist
- [x] Tested with `tsc` for type-safety.
- [x] Redis instantiation uses Next.js `global` pattern to prevent development memory leaks.
