### PR TITLE
test: fix SiteFooter image mock warnings

### DIFF
--- a/src/components/__tests__/site-footer.test.tsx
+++ b/src/components/__tests__/site-footer.test.tsx
@@ -1,43 +1,74 @@
-import { render, screen } from "@testing-library/react"
-import SiteFooter from "../site-footer"
-import { vi } from "vitest"
+import { render, screen } from "@testing-library/react";
+import type { ImgHTMLAttributes } from "react";
+import { describe, expect, it, vi } from "vitest";
 
-// Mock next/image
+import SiteFooter from "../site-footer";
+
+type MockImageProps = ImgHTMLAttributes<HTMLImageElement> & {
+  fill?: boolean;
+  priority?: boolean;
+};
+
 vi.mock("next/image", () => ({
-    default: ({ src, alt, ...props }: any) => {
-        // eslint-disable-next-line @next/next/no-img-element
-        return <img src={src} alt={alt} {...props} />
-    },
-}))
+  default: ({
+    fill: _fill,
+    priority: _priority,
+    ...props
+  }: MockImageProps) => {
+    // Next.js-only Image props are intentionally removed before
+    // forwarding the remaining attributes to the native img element.
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...props} />;
+  },
+}));
 
-// Mock lucide-react
 vi.mock("lucide-react", () => ({
-    Github: () => <div data-testid="github-icon" />,
-    Twitter: () => <div data-testid="twitter-icon" />,
-    Instagram: () => <div data-testid="instagram-icon" />,
-    Plane: () => <div data-testid="plane-icon" />,
-}))
+  Github: () => <svg data-testid="github-icon" />,
+  Twitter: () => <svg data-testid="twitter-icon" />,
+  Instagram: () => <svg data-testid="instagram-icon" />,
+  Plane: () => <svg data-testid="plane-icon" />,
+}));
+
+vi.mock("react-icons/fa", () => ({
+  FaLinkedin: () => <svg data-testid="linkedin-icon" />,
+}));
 
 describe("SiteFooter", () => {
-    it("renders travellersmeet brand text", () => {
-        render(<SiteFooter />)
-        expect(
-            screen.getByText("travellersmeet", { selector: "span" })
-        ).toBeInTheDocument()
-    })
+  it("renders travellersmeet brand text", () => {
+    render(<SiteFooter />);
 
-    it("renders section headers", () => {
-        render(<SiteFooter />)
-        expect(screen.getByRole("heading", { name: /Explore/i })).toBeInTheDocument()
-        expect(screen.getByRole("heading", { name: /Community/i })).toBeInTheDocument()
-        expect(screen.getByRole("heading", { name: /Legal/i })).toBeInTheDocument()
-        expect(screen.getByRole("heading", { name: /Newsletter/i })).toBeInTheDocument()
-    })
+    expect(
+      screen.getByText("travellersmeet", {
+        selector: "span",
+      }),
+    ).toBeInTheDocument();
+  });
 
-    it("renders copyright notice", () => {
-        render(<SiteFooter />)
-        expect(
-            screen.getByText(/© 2026 TravellersMeet/i)
-        ).toBeInTheDocument()
-    })
-})
+  it("renders section headers", () => {
+    render(<SiteFooter />);
+
+    expect(
+      screen.getByRole("heading", { name: /Explore/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", { name: /Community/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", { name: /Legal/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", { name: /Newsletter/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders copyright notice", () => {
+    render(<SiteFooter />);
+
+    expect(
+      screen.getByText(/© 2026 TravellersMeet/i),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## fix #212

## 📝 Description

This PR fixes React DOM warnings produced by the mocked Next.js `Image` component in the SiteFooter tests.

The previous mock forwarded Next.js-only props such as `fill` and `priority` directly to a native `<img>` element, causing React to report invalid non-boolean attribute warnings.

### Changes Made

- Updated the `next/image` mock to remove `fill` before forwarding props.
- Updated the `next/image` mock to remove `priority` before forwarding props.
- Added an explicit type for the mocked Image component.
- Added a mock for the LinkedIn icon imported from `react-icons/fa`.
- Kept all existing SiteFooter assertions unchanged.
- Made no changes to the production SiteFooter component.

## 🛠️ Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🎨 UI/UX Enhancement
- [ ] 📚 Documentation update
- [ ] ⚡ Performance optimization / Refactoring
- [x] 🧪 Tests

## 📷 Screenshots / Recordings
<img width="1083" height="489" alt="Screenshot 2026-07-15 172259" src="https://github.com/user-attachments/assets/0fa9d72d-42c1-40e8-9064-1608d8223050" />


## 🧪 Testing Performed

- [x] Ran the focused SiteFooter test:

  ```bash
  npx vitest run src/components/__tests__/site-footer.test.tsx


## Checklist
- [ ] Lints pass (`npm run lint`)
- [ ] Builds locally (`npm run build`)
- [ ] Tests added/updated (if changing logic)
- [ ] Docs updated (README/CONTRIBUTING as needed)
- [ ] I have tested my changes across major browsers/devices
- [ ] My changes do not generate new console warnings or errors , I ran `npm run build` and attached      scrrenshot in this PR.
- [ ] This is already assigned Issue to me, not an unassigned issue.


