### PR TITLE
fix(ui): capitalize navbar brand name

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -98,7 +98,7 @@ export default function SiteHeader() {
             <Plane className="h-5 w-5 rotate-[-45deg] group-hover:rotate-0 transition-transform duration-500" />
           </div>
           <span className="text-lg font-bold tracking-tight text-slate-900 dark:text-white">
-            travellersmeet
+            Travellersmeet
           </span>
         </Link>
 


### PR DESCRIPTION
## fix #213 

## 📝 Description

This PR corrects the Travellersmeet brand text displayed in the navbar.

The navbar previously displayed the brand as `travellersmeet`. It now displays `Travellersmeet` with a capital **T**, as requested in the issue.

### Changes Made

- Updated the navbar brand text from `travellersmeet` to `Travellersmeet`.
- Kept the existing logo, styling, navigation behavior, and responsive layout unchanged.
- Made no changes to authentication, database, or routing functionality.

## 🛠️ Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🎨 UI/UX Enhancement
- [ ] 📚 Documentation update
- [ ] ⚡ Performance optimization / Refactoring
- [ ] 🧪 Tests

## 📷 Screenshots / Recordings

<img width="1863" height="211" alt="Screenshot 2026-07-15 173502" src="https://github.com/user-attachments/assets/16b1320e-1373-404c-9e35-bf988f40277f" />

## 🧪 Testing Performed

- [x] Ran `npx tsc --noEmit`
- [x] Ran `npm run lint`
- [x] Ran `npm test`
- [x] Verified the corrected brand name on desktop
- [x] Verified the corrected brand name on mobile
- [x] Confirmed the homepage brand link still works
- [x] Checked the browser console for new errors


## Checklist
- [x] Lints pass (`npm run lint`)
- [x] Builds locally (`npm run build`)
- [ ] Tests added/updated (if changing logic)
- [ ] Docs updated (README/CONTRIBUTING as needed)
- [x] I have tested my changes across major browsers/devices
- [x] My changes do not generate new console warnings or errors , I ran `npm run build` and attached      scrrenshot in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.


