### PR TITLE
fix: add missing GET /api/user/profile endpoint and homeLocation field

### DIFF
--- a/prisma/migrations/20260715070000_add_home_location_field/migration.sql
+++ b/prisma/migrations/20260715070000_add_home_location_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "homeLocation" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,11 +12,12 @@ model User {
   name          String
   email         String   @unique
   passwordHash  String?
-  image         String?     // Profile avatar URL
+  image         String?  @db.Text  // Profile avatar (base64 data URI)
 
   // ✅ NEW PROFILE FIELDS (Safe Additions)
   bio           String?     @db.Text
   location      String?
+  homeLocation  String?
   phone         String?
   isDeleted     Boolean     @default(false)  // Soft delete support
 

--- a/src/app/api/user/avatar/route.ts
+++ b/src/app/api/user/avatar/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse, NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+
+    if (!file || file.size === 0) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: "Invalid file type. Please upload a JPEG, PNG, or WebP image." },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: "File too large. Maximum size is 2MB." },
+        { status: 400 }
+      );
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const base64 = buffer.toString("base64");
+    const dataUri = `data:${file.type};base64,${base64}`;
+
+    const updatedUser = await prisma.user.update({
+      where: { email: session.user.email },
+      data: { image: dataUri },
+    });
+
+    return NextResponse.json({ ok: true, image: updatedUser.image });
+  } catch (error) {
+    console.error("Avatar upload error:", error);
+    return NextResponse.json({ error: "Failed to upload avatar" }, { status: 500 });
+  }
+}

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -2,6 +2,38 @@ import { NextResponse, NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 
+
+export async function GET() {
+  const session = await auth();
+
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: {
+        name: true,
+        email: true,
+        bio: true,
+        location: true,
+        image: true,
+        homeLocation: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(user);
+  } catch (error) {
+    console.error("Profile fetch error:", error);
+    return NextResponse.json({ error: "Failed to fetch profile" }, { status: 500 });
+  }
+}
+
 export async function PATCH(req: NextRequest) {
     const session = await auth();
 
@@ -21,7 +53,7 @@ export async function PATCH(req: NextRequest) {
                 name: body.name ?? undefined,
                 bio: body.bio ?? undefined,
                 location: body.location ?? undefined,
-                // homeLocation: body.homeLocation ?? undefined, // include if exists in schema
+                homeLocation: body.homeLocation ?? undefined, // include if exists in schema
             },
         });
 

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -17,7 +17,8 @@ export default function ProfilePage() {
     useEffect(() => {
         async function fetchProfile() {
             try {
-                const res = await fetch("/api/user/me");
+                // const res = await fetch("/api/user/me");
+                const res = await fetch("/api/user/profile");
                 if (res.ok) {
                     const data = await res.json();
                     setName(data.name ?? "");
@@ -143,7 +144,7 @@ export default function ProfilePage() {
                             </div>
 
                             <div className="space-y-2">
-                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Location</label>
+                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Home Location</label>
                                 <input
                                     value={homeLocation}
                                     onChange={(e) => setHomeLocation(e.target.value)}


### PR DESCRIPTION
Fixes #223

## Changes
- Added a `GET` handler to `src/app/api/user/profile/route.ts` — this was
  entirely missing and was the root cause of the bug (frontend called a
  dead `/api/user/me` route with no backend implementation).
- Added `homeLocation` to the `User` model in `prisma/schema.prisma`,
  uncommented it in the `PATCH` handler, and included it in the `GET`
  handler's select.
- Fixed the duplicate "Location" label on the second input to correctly
  read "Home Location".
- Added `src/app/api/user/avatar/route.ts` (POST) for avatar uploads,
  stored as base64 data URIs since there's no object storage configured.
- Included the Prisma migration for the new `homeLocation` column.

## Testing
Manually verified the full repro from #223: filled in name, bio,
location, home location, uploaded an avatar, saved, refreshed — all
fields including the avatar now persist correctly.

## Notes for reviewer
Avatar storage uses base64 in the `image` column as a stopgap given no
blob storage is set up yet — flagging in case a different approach is
preferred long-term.
