### PR TITLE
fix: reduce false positives in duplicate-issue detection

### DIFF
--- a/.github/workflows/detect-duplicate-issues.yml
+++ b/.github/workflows/detect-duplicate-issues.yml
@@ -21,9 +21,30 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Combine title + body
-            const newText = `${newIssue.title}\n${newIssue.body || ""}`
-              .toLowerCase();
+            // Words that show up in nearly every issue because they come from
+            // the bug/feature-request templates or the project name, not from
+            // the reporter's actual content. Left unfiltered, these alone clear
+            // the old 3-word threshold and flag every new issue as a duplicate
+            // of unrelated ones.
+            const STOPWORDS = new Set([
+              "description", "expected", "behavior", "behaviour", "actual",
+              "steps", "reproduce", "screenshot", "screenshots", "environment",
+              "additional", "context", "problem", "proposal", "alternatives",
+              "applicable", "explain", "clearly", "solution", "feature",
+              "consider", "relevant", "acceptance", "criteria", "observe",
+              "notice", "affects", "impact", "would", "should", "could",
+              "please", "issue", "issues", "website", "working", "travellersmeet",
+            ]);
+
+            const toWordSet = (text) =>
+              new Set(
+                text
+                  .toLowerCase()
+                  .split(/\W+/)
+                  .filter(w => w.length > 5 && !STOPWORDS.has(w))
+              );
+
+            const newWords = toWordSet(`${newIssue.title}\n${newIssue.body || ""}`);
 
             // Fetch recent issues (open + closed)
             const issues = await github.paginate(
@@ -38,25 +59,27 @@ jobs:
 
             const similarIssues = [];
 
-            for (const issue of issues) {
-              // Skip self & PRs
-              if (issue.number === newIssue.number) continue;
-              if (issue.pull_request) continue;
+            // Too little real content to judge similarity from (e.g. an
+            // unfilled template) — skip rather than flag against everything.
+            if (newWords.size >= 3) {
+              for (const issue of issues) {
+                // Skip self & PRs
+                if (issue.number === newIssue.number) continue;
+                if (issue.pull_request) continue;
 
-              const oldText = `${issue.title}\n${issue.body || ""}`
-                .toLowerCase();
+                const oldWords = toWordSet(`${issue.title}\n${issue.body || ""}`);
+                let matches = 0;
+                for (const word of newWords) {
+                  if (oldWords.has(word)) matches++;
+                }
 
-              // Basic keyword similarity check
-              const words = newText.split(/\W+/).filter(w => w.length > 4);
-              let matches = 0;
-
-              for (const word of words) {
-                if (oldText.includes(word)) matches++;
-              }
-
-              // Heuristic threshold
-              if (matches >= 3) {
-                similarIssues.push(issue);
+                // Jaccard similarity (shared words / total distinct words across
+                // both issues) so a small overlap on a large issue, or a couple
+                // of incidental shared words, doesn't trigger a false match.
+                const union = new Set([...newWords, ...oldWords]).size;
+                if (matches >= 3 && matches / union >= 0.3) {
+                  similarIssues.push(issue);
+                }
               }
             }
 


### PR DESCRIPTION
Fixes #227

## Problem
`detect-duplicate-issues.yml` flagged an issue as a duplicate whenever it shared just 3 words (>4 chars) with *any* prior issue, using naive substring matching. Since the bug/feature-request issue template boilerplate ("description", "expected behavior", "steps to reproduce", etc.) alone clears that bar, nearly every new issue was auto-tagged as a duplicate of unrelated ones. Live example: #229 got flagged as a duplicate of #224, #223, #213, #212, #211 — none of which have anything to do with its actual content (i18n/Hindi support).

## Fix
- Strip template/boilerplate and project-name stopwords before comparing
- Compare tokenized word sets instead of substring containment
- Require both a minimum absolute overlap and Jaccard similarity ≥ 0.3, so a couple of incidental shared words no longer trigger a match
- Skip issues with too little real content to judge (e.g. an unfilled template)

## Verification
Extracted the full issue history of this repo (113 issues, open + closed) and ran both the old and new heuristics against every pair offline:
- **Old heuristic**: flagged the vast majority of issues as duplicates of 50–100+ unrelated issues each.
- **New heuristic**: flags a small, plausible set per issue (e.g. correctly pairs #46/#47, two near-identical "can't create account/generate ticket" reports) and no longer misfires on #223–#229.

Also ran locally against this branch:
- `npm run lint` — no warnings
- `npx tsc --noEmit` — no errors
- `npm test` — 27 passed / 16 pre-existing failures in `signup.test.ts`, `forgot-password.test.ts`, `reset-password.test.ts`, `tickets.test.ts` (unrelated to this change — same root cause as #211, not touched here)

Only `.github/workflows/detect-duplicate-issues.yml` is changed.