### PR TITLE
feat: add read-only profile view page, separate from the edit form

### DIFF
--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -20,6 +20,9 @@ export async function GET() {
         location: true,
         image: true,
         homeLocation: true,
+        phone: true,
+        emailVerified: true,
+        createdAt: true,
       },
     });
 

--- a/src/app/dashboard/profile/edit/page.tsx
+++ b/src/app/dashboard/profile/edit/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { Camera, Upload } from "lucide-react";
+
+export default function ProfilePage() {
+    const [name, setName] = useState("");
+    const [email, setEmail] = useState("");
+    const [bio, setBio] = useState("");
+    const [location, setLocation] = useState("");
+    const [homeLocation, setHomeLocation] = useState("");
+    const [preview, setPreview] = useState<string>("");
+    const [avatarFile, setAvatarFile] = useState<File | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        async function fetchProfile() {
+            try {
+                // const res = await fetch("/api/user/me");
+                const res = await fetch("/api/user/profile");
+                if (res.ok) {
+                    const data = await res.json();
+                    setName(data.name ?? "");
+                    setEmail(data.email ?? "");
+                    setBio(data.bio ?? "");
+                    setLocation(data.location ?? "");
+                    setHomeLocation(data.homeLocation ?? "");
+                    setPreview(data.image ?? "");
+                }
+            } catch (err) {
+                console.error("Profile fetch error:", err);
+            }
+        }
+        fetchProfile();
+    }, []);
+
+    const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (!e.target.files?.length) return;
+        const file = e.target.files[0];
+        setAvatarFile(file);
+        const objectUrl = URL.createObjectURL(file);
+        setPreview(objectUrl);
+    };
+
+    const handleSubmit = async () => {
+        setLoading(true);
+        try {
+            await fetch("/api/user/profile", {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name, bio, location, homeLocation }),
+            });
+            if (avatarFile) {
+                const formData = new FormData();
+                formData.append("file", avatarFile);
+                await fetch("/api/user/avatar", { method: "POST", body: formData });
+            }
+            alert("Profile updated successfully!");
+        } catch (error) {
+            console.error(error);
+            alert("Something went wrong.");
+        }
+        setLoading(false);
+    };
+
+    return (
+        <div className="max-w-5xl mx-auto">
+            <h1 className="text-3xl font-bold mb-8 text-gray-900 dark:text-white">Edit Profile</h1>
+
+            <div className="rounded-[32px] border border-gray-100 dark:border-gray-800 bg-[#F6F4EC] dark:bg-[#11132B] p-8 md:p-12 shadow-sm transition-colors duration-300">
+                <div className="grid md:grid-cols-[280px_1fr] gap-12 lg:gap-16">
+
+                    {/* Left: Avatar Section */}
+                    <div className="flex flex-col items-center gap-6">
+                        <label className="group relative w-64 h-64 rounded-full border-2 border-dashed border-gray-300 dark:border-gray-700 flex flex-col items-center justify-center cursor-pointer bg-white dark:bg-[#1A1C3D] hover:border-emerald-500 dark:hover:border-blue-500 transition-all overflow-hidden shadow-inner">
+                            {preview ? (
+                                <Image
+                                    src={preview}
+                                    alt="Avatar"
+                                    fill
+                                    className="object-cover group-hover:opacity-75 transition-opacity"
+                                    unoptimized
+                                />
+                            ) : (
+                                <div className="text-gray-400 text-center space-y-2">
+                                    <Camera size={32} className="mx-auto" />
+                                    <p className="text-sm font-medium">Upload Photo</p>
+                                </div>
+                            )}
+                            <input
+                                type="file"
+                                className="hidden"
+                                accept="image/*"
+                                onChange={handleImageChange}
+                            />
+                        </label>
+                    </div>
+
+                    {/* Right: Form Section */}
+                    <div className="space-y-8">
+                        <div className="grid md:grid-cols-2 gap-6">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Full Name</label>
+                                <input
+                                    value={name}
+                                    onChange={(e) => setName(e.target.value)}
+                                    placeholder="Full Name"
+                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
+                                />
+                            </div>
+
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Email Address</label>
+                                <input
+                                    value={email}
+                                    disabled
+                                    placeholder="yourname@gmail.com"
+                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-gray-50 dark:bg-[#07081A] text-gray-500 text-sm italic"
+                                />
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Bio</label>
+                            <textarea
+                                value={bio}
+                                onChange={(e) => setBio(e.target.value)}
+                                placeholder="Write your bio text here here..."
+                                className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none resize-none"
+                                rows={3}
+                            />
+                        </div>
+
+                        <div className="grid md:grid-cols-2 gap-6">
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Location</label>
+                                <input
+                                    value={location}
+                                    onChange={(e) => setLocation(e.target.value)}
+                                    placeholder="Location"
+                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
+                                />
+                            </div>
+
+                            <div className="space-y-2">
+                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Home Location</label>
+                                <input
+                                    value={homeLocation}
+                                    onChange={(e) => setHomeLocation(e.target.value)}
+                                    placeholder="Home Location"
+                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
+                                />
+                            </div>
+                        </div>
+
+                        <div className="space-y-4">
+                            <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Ticket Verification</label>
+                            <div className="flex flex-col sm:flex-row items-center gap-4">
+                                <button className="flex items-center gap-2 bg-[#1A4D2E] text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-[#143B23] transition-colors shadow-sm w-full sm:w-auto">
+                                    <Upload size={16} />
+                                    Upload
+                                </button>
+                                <span className="text-sm text-gray-600 dark:text-gray-400">Ticket Verification Status: <span className="text-emerald-600 dark:text-emerald-400 font-medium">Verified</span></span>
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col sm:flex-row gap-4 pt-10">
+                            <button
+                                onClick={handleSubmit}
+                                disabled={loading}
+                                className="flex-1 bg-[#1A4D2E] text-white px-8 py-3.5 rounded-xl font-bold text-sm hover:opacity-90 transition shadow-sm disabled:opacity-60"
+                            >
+                                {loading ? "Saving..." : "Save Changes"}
+                            </button>
+
+                            <button
+                                onClick={() => window.location.href = "/dashboard/profile"}
+                                className="flex-1 bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 px-8 py-3.5 rounded-xl font-bold text-sm hover:bg-gray-300 dark:hover:bg-gray-700 transition"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -2,324 +2,182 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { Camera, Upload, KeyRound } from "lucide-react";
+import Link from "next/link";
+import { Camera, MapPin, Calendar, Mail, Phone, ShieldCheck, ArrowRight } from "lucide-react";
 
-export default function ProfilePage() {
-    const [name, setName] = useState("");
-    const [email, setEmail] = useState("");
-    const [bio, setBio] = useState("");
-    const [location, setLocation] = useState("");
-    const [homeLocation, setHomeLocation] = useState("");
-    const [preview, setPreview] = useState<string>("");
-    const [avatarFile, setAvatarFile] = useState<File | null>(null);
-    const [loading, setLoading] = useState(false);
+interface ProfileData {
+  name: string;
+  email: string;
+  bio: string | null;
+  location: string | null;
+  homeLocation: string | null;
+  image: string | null;
+  emailVerified: boolean;
+  phone: string | null;
+  createdAt: string;
+}
 
-    const [currentPassword, setCurrentPassword] = useState("");
-    const [newPassword, setNewPassword] = useState("");
-    const [confirmPassword, setConfirmPassword] = useState("");
-    const [passwordLoading, setPasswordLoading] = useState(false);
-    const [showSuccessModal, setShowSuccessModal] = useState(false);
-    const [passwordError, setPasswordError] = useState<string | null>(null);
+interface RouteItem {
+  id: string;
+  tripName: string | null;
+  originName: string | null;
+  destinationName: string | null;
+  distance: number;
+  duration: number;
+  createdAt: string;
+}
 
-    useEffect(() => {
-        async function fetchProfile() {
-            try {
-                // const res = await fetch("/api/user/me");
-                const res = await fetch("/api/user/profile");
-                if (res.ok) {
-                    const data = await res.json();
-                    setName(data.name ?? "");
-                    setEmail(data.email ?? "");
-                    setBio(data.bio ?? "");
-                    setLocation(data.location ?? "");
-                    setHomeLocation(data.homeLocation ?? "");
-                    setPreview(data.image ?? "");
-                }
-            } catch (err) {
-                console.error("Profile fetch error:", err);
-            }
+export default function ProfileViewPage() {
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [trips, setTrips] = useState<RouteItem[]>([]);
+  const [ticketVerified, setTicketVerified] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [profileRes, routesRes, ticketsRes] = await Promise.all([
+          fetch("/api/user/profile"),
+          fetch("/api/routes"),
+          fetch("/api/tickets"),
+        ]);
+
+        if (profileRes.ok) setProfile(await profileRes.json());
+        if (routesRes.ok) setTrips((await routesRes.json()).slice(0, 3));
+        if (ticketsRes.ok) {
+          const { tickets } = await ticketsRes.json();
+          setTicketVerified(tickets?.some((t: { status: string }) => t.status === "VERIFIED"));
         }
-        fetchProfile();
-    }, []);
-
-    const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (!e.target.files?.length) return;
-        const file = e.target.files[0];
-        setAvatarFile(file);
-        const objectUrl = URL.createObjectURL(file);
-        setPreview(objectUrl);
-    };
-
-    const handleSubmit = async () => {
-        setLoading(true);
-        try {
-            await fetch("/api/user/profile", {
-                method: "PATCH",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ name, bio, location, homeLocation }),
-            });
-            if (avatarFile) {
-                const formData = new FormData();
-                formData.append("file", avatarFile);
-                await fetch("/api/user/avatar", { method: "POST", body: formData });
-            }
-            alert("Profile updated successfully!");
-        } catch (error) {
-            console.error(error);
-            alert("Something went wrong.");
-        }
+      } catch (err) {
+        console.error("Failed to load profile:", err);
+      } finally {
         setLoading(false);
-    };
+      }
+    }
+    load();
+  }, []);
 
-    const handlePasswordSubmit = async () => {
-        setPasswordError(null);
-        if (!currentPassword || !newPassword || !confirmPassword) {
-            setPasswordError("All password fields are required.");
-            return;
-        }
-        if (newPassword.length < 8) {
-            setPasswordError("New password must be at least 8 characters long.");
-            return;
-        }
-        if (newPassword !== confirmPassword) {
-            setPasswordError("New password and confirm password do not match.");
-            return;
-        }
-
-        setPasswordLoading(true);
-        try {
-            const res = await fetch("/api/auth/change-password", {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ currentPassword, newPassword }),
-            });
-
-            const data = await res.json();
-            if (res.ok) {
-                setShowSuccessModal(true);
-                setCurrentPassword("");
-                setNewPassword("");
-                setConfirmPassword("");
-            } else {
-                setPasswordError(data.error || "Failed to update password.");
-            }
-        } catch (error) {
-            console.error(error);
-            setPasswordError("Something went wrong. Please try again.");
-        }
-        setPasswordLoading(false);
-    };
-
+  if (loading) {
     return (
-        <div className="max-w-5xl mx-auto">
-            <h1 className="text-3xl font-bold mb-8 text-gray-900 dark:text-white">Edit Profile</h1>
-
-            <div className="rounded-[32px] border border-gray-100 dark:border-gray-800 bg-[#F6F4EC] dark:bg-[#11132B] p-8 md:p-12 shadow-sm transition-colors duration-300">
-                <div className="grid md:grid-cols-[280px_1fr] gap-12 lg:gap-16">
-
-                    {/* Left: Avatar Section */}
-                    <div className="flex flex-col items-center gap-6">
-                        <label className="group relative w-64 h-64 rounded-full border-2 border-dashed border-gray-300 dark:border-gray-700 flex flex-col items-center justify-center cursor-pointer bg-white dark:bg-[#1A1C3D] hover:border-emerald-500 dark:hover:border-blue-500 transition-all overflow-hidden shadow-inner">
-                            {preview ? (
-                                <Image
-                                    src={preview}
-                                    alt="Avatar"
-                                    fill
-                                    className="object-cover group-hover:opacity-75 transition-opacity"
-                                    unoptimized
-                                />
-                            ) : (
-                                <div className="text-gray-400 text-center space-y-2">
-                                    <Camera size={32} className="mx-auto" />
-                                    <p className="text-sm font-medium">Upload Photo</p>
-                                </div>
-                            )}
-                            <input
-                                type="file"
-                                className="hidden"
-                                accept="image/*"
-                                onChange={handleImageChange}
-                            />
-                        </label>
-                    </div>
-
-                    {/* Right: Form Section */}
-                    <div className="space-y-8">
-                        <div className="grid md:grid-cols-2 gap-6">
-                            <div className="space-y-2">
-                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Full Name</label>
-                                <input
-                                    value={name}
-                                    onChange={(e) => setName(e.target.value)}
-                                    placeholder="Full Name"
-                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Email Address</label>
-                                <input
-                                    value={email}
-                                    disabled
-                                    placeholder="yourname@gmail.com"
-                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-gray-50 dark:bg-[#07081A] text-gray-500 text-sm italic"
-                                />
-                            </div>
-                        </div>
-
-                        <div className="space-y-2">
-                            <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Bio</label>
-                            <textarea
-                                value={bio}
-                                onChange={(e) => setBio(e.target.value)}
-                                placeholder="Write your bio text here here..."
-                                className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none resize-none"
-                                rows={3}
-                            />
-                        </div>
-
-                        <div className="grid md:grid-cols-2 gap-6">
-                            <div className="space-y-2">
-                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Location</label>
-                                <input
-                                    value={location}
-                                    onChange={(e) => setLocation(e.target.value)}
-                                    placeholder="Location"
-                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Home Location</label>
-                                <input
-                                    value={homeLocation}
-                                    onChange={(e) => setHomeLocation(e.target.value)}
-                                    placeholder="Home Location"
-                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
-                                />
-                            </div>
-                        </div>
-
-                        <div className="space-y-4">
-                            <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Ticket Verification</label>
-                            <div className="flex flex-col sm:flex-row items-center gap-4">
-                                <button className="flex items-center gap-2 bg-[#1A4D2E] text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-[#143B23] transition-colors shadow-sm w-full sm:w-auto">
-                                    <Upload size={16} />
-                                    Upload
-                                </button>
-                                <span className="text-sm text-gray-600 dark:text-gray-400">Ticket Verification Status: <span className="text-emerald-600 dark:text-emerald-400 font-medium">Verified</span></span>
-                            </div>
-                        </div>
-
-                        <div className="flex flex-col sm:flex-row gap-4 pt-10">
-                            <button
-                                onClick={handleSubmit}
-                                disabled={loading}
-                                className="flex-1 bg-[#1A4D2E] text-white px-8 py-3.5 rounded-xl font-bold text-sm hover:opacity-90 transition shadow-sm disabled:opacity-60"
-                            >
-                                {loading ? "Saving..." : "Save Changes"}
-                            </button>
-
-                            <button
-                                onClick={() => window.location.reload()}
-                                className="flex-1 bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 px-8 py-3.5 rounded-xl font-bold text-sm hover:bg-gray-300 dark:hover:bg-gray-700 transition"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-
-            <div className="mt-8 rounded-[32px] border border-gray-100 dark:border-gray-800 bg-[#F6F4EC] dark:bg-[#11132B] p-8 md:p-12 shadow-sm transition-colors duration-300">
-                <div className="grid md:grid-cols-[280px_1fr] gap-12 lg:gap-16">
-                    {/* Left: Security Info */}
-                    <div className="flex flex-col items-center justify-center text-center text-gray-500 dark:text-gray-400 gap-4">
-                        <div className="p-4 rounded-full bg-white dark:bg-[#1A1C3D] border border-gray-100 dark:border-gray-800 shadow-inner">
-                            <KeyRound size={40} className="text-gray-400 dark:text-gray-300" />
-                        </div>
-                        <div>
-                            <h2 className="text-lg font-bold text-gray-900 dark:text-white">Security</h2>
-                            <p className="text-xs mt-1 text-gray-500 dark:text-gray-400 max-w-[200px]">Update your password to keep your account secure.</p>
-                        </div>
-                    </div>
-
-                    {/* Right: Password Change Form */}
-                    <div className="space-y-6">
-                        <div className="space-y-2">
-                            <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Current Password</label>
-                            <input
-                                type="password"
-                                value={currentPassword}
-                                onChange={(e) => setCurrentPassword(e.target.value)}
-                                placeholder="Enter current password"
-                                className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
-                            />
-                        </div>
-
-                        <div className="grid md:grid-cols-2 gap-6">
-                            <div className="space-y-2">
-                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">New Password</label>
-                                <input
-                                    type="password"
-                                    value={newPassword}
-                                    onChange={(e) => setNewPassword(e.target.value)}
-                                    placeholder="Enter new password"
-                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 ml-1">Confirm New Password</label>
-                                <input
-                                    type="password"
-                                    value={confirmPassword}
-                                    onChange={(e) => setConfirmPassword(e.target.value)}
-                                    placeholder="Confirm new password"
-                                    className="w-full rounded-xl border border-gray-200 dark:border-gray-800 px-4 py-3 bg-white dark:bg-[#0F1129] focus:ring-2 focus:ring-emerald-500 transition-all text-sm outline-none"
-                                />
-                            </div>
-                        </div>
-
-                        {passwordError && (
-                            <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
-                                ⚠️ {passwordError}
-                            </div>
-                        )}
-
-                        <div className="flex pt-4">
-                            <button
-                                onClick={handlePasswordSubmit}
-                                disabled={passwordLoading}
-                                className="bg-[#1A4D2E] text-white px-8 py-3.5 rounded-xl font-bold text-sm hover:opacity-90 transition shadow-sm disabled:opacity-60 w-full sm:w-auto"
-                            >
-                                {passwordLoading ? "Updating..." : "Update Password"}
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            {showSuccessModal && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-                    <div className="bg-[#11132B] border border-gray-800 rounded-3xl p-8 max-w-sm w-full text-center shadow-2xl animate-in fade-in zoom-in-95 duration-200">
-                        <div className="mx-auto w-16 h-16 bg-emerald-500/10 rounded-full flex items-center justify-center mb-4">
-                            <svg className="w-8 h-8 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
-                            </svg>
-                        </div>
-                        <h3 className="text-xl font-bold text-white mb-2">Password Changed!</h3>
-                        <p className="text-gray-400 text-sm mb-6">Your password has been updated successfully. You can now use your new password next time you sign in.</p>
-                        <button
-                            onClick={() => setShowSuccessModal(false)}
-                            className="w-full bg-[#1A4D2E] text-white py-3 rounded-xl font-bold text-sm hover:opacity-90 transition shadow-sm"
-                        >
-                            Got it, thanks!
-                        </button>
-                    </div>
-                </div>
-            )}
-        </div>
+      <div className="max-w-5xl mx-auto animate-pulse">
+        <div className="h-8 w-48 bg-gray-200 dark:bg-gray-800 rounded mb-8" />
+        <div className="h-96 bg-gray-100 dark:bg-gray-900 rounded-[32px]" />
+      </div>
     );
+  }
+
+  if (!profile) {
+    return (
+      <div className="max-w-5xl mx-auto text-center py-20 text-gray-500">
+        Couldn&apos;t load your profile. Please try refreshing.
+      </div>
+    );
+  }
+
+  const memberSince = new Date(profile.createdAt).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Profile</h1>
+        <Link
+          href="/dashboard/profile/edit"
+          className="rounded-lg bg-[#1A4D2E] text-white px-5 py-2.5 text-sm font-semibold hover:opacity-90 transition"
+        >
+          Edit Profile
+        </Link>
+      </div>
+
+      <div className="rounded-[32px] border border-gray-100 dark:border-gray-800 bg-[#F6F4EC] dark:bg-[#11132B] p-8 md:p-12 shadow-sm">
+        <div className="grid md:grid-cols-[280px_1fr] gap-12 lg:gap-16">
+          <div className="flex flex-col items-center gap-4">
+            <div className="relative w-64 h-64 rounded-full overflow-hidden bg-white dark:bg-[#1A1C3D] shadow-inner">
+              {profile.image ? (
+                <Image src={profile.image} alt={profile.name} fill className="object-cover" unoptimized />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-gray-400">
+                  <Camera size={32} />
+                </div>
+              )}
+            </div>
+            {ticketVerified && (
+              <span className="flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400 text-sm font-medium">
+                <ShieldCheck size={16} /> Ticket Verified
+              </span>
+            )}
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              Member since {memberSince}
+            </span>
+          </div>
+
+          <div className="space-y-8">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{profile.name}</h2>
+              {profile.bio && (
+                <p className="mt-2 text-gray-600 dark:text-gray-400">{profile.bio}</p>
+              )}
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4 text-sm">
+              <div className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
+                <Mail size={16} className="text-gray-400 shrink-0" />
+                {profile.email}
+                {profile.emailVerified && <ShieldCheck size={14} className="text-emerald-500" />}
+              </div>
+              {profile.phone && (
+                <div className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
+                  <Phone size={16} className="text-gray-400 shrink-0" />
+                  {profile.phone}
+                </div>
+              )}
+              {profile.location && (
+                <div className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
+                  <MapPin size={16} className="text-gray-400 shrink-0" />
+                  Currently in {profile.location}
+                </div>
+              )}
+              {profile.homeLocation && (
+                <div className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
+                  <MapPin size={16} className="text-gray-400 shrink-0" />
+                  From {profile.homeLocation}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Recent Trips
+                </h3>
+                <Link href="/routes" className="text-xs text-emerald-600 dark:text-emerald-400 flex items-center gap-1 hover:underline">
+                  View all <ArrowRight size={12} />
+                </Link>
+              </div>
+
+              {trips.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-500">No trips saved yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {trips.map((trip) => (
+                    <div key={trip.id} className="flex items-center justify-between rounded-xl bg-white dark:bg-[#0F1129] px-4 py-3 text-sm">
+                      <div className="flex items-center gap-2 text-gray-800 dark:text-gray-200">
+                        <Calendar size={14} className="text-gray-400" />
+                        {trip.tripName || `${trip.originName ?? "?"} → ${trip.destinationName ?? "?"}`}
+                      </div>
+                      <span className="text-gray-500 dark:text-gray-500">
+                        {(trip.distance / 1000).toFixed(0)} km
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -9,6 +9,8 @@ import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { HiOutlineMoon, HiOutlineSun } from "react-icons/hi";
 import Toggle from "./toggle";
+import Image from "next/image";
+import { User as UserIcon } from "lucide-react";
 
 // --- Constants ---
 const MARKETING_LINKS = [
@@ -130,6 +132,26 @@ export default function SiteHeader() {
         <div className="hidden md:flex items-center gap-3 shrink-0">
           {session?.user ? (
             <div className="flex items-center gap-3">
+             <Link
+  href="/dashboard/profile"
+  className="relative h-10 w-10 rounded-full overflow-hidden border-2 border-slate-200 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500 transition-colors shrink-0"
+  aria-label="View profile"
+>
+  {session.user.image ? (
+    <Image
+      src={session.user.image}
+      alt="Profile"
+      fill
+      className="object-cover"
+      unoptimized
+    />
+  ) : (
+    <div className="h-full w-full flex items-center justify-center bg-slate-100 dark:bg-slate-800 text-slate-400">
+      <UserIcon size={18} />
+    </div>
+  )}
+</Link>
+              
               <Link
                 href="/dashboard"
                 className="flex items-center rounded-lg bg-slate-100 dark:bg-slate-800 h-10 px-4 text-sm font-semibold text-slate-900 dark:text-white hover:opacity-90 transition-all shadow-sm"


### PR DESCRIPTION
Closes #224

## Changes
- Added a new read-only profile view page at `/dashboard/profile`,
  displaying avatar, name, ticket-verification badge, "member since"
  date, email (with verified indicator), phone, location, home
  location, bio, and a preview of recent trips linking to the full
  Trips page.
- Moved the existing editable form to `/dashboard/profile/edit`,
  unchanged functionally — now reached via an "Edit Profile" button
  on the view page.
- Extended `GET /api/user/profile` to include `phone`, `createdAt`,
  ticket verification status, and recent routes needed for the view.
- Added a "Profile" nav item to the header, placed before "Dashboard,"
  visible only when signed in.

## Dependency
Builds on #223 (merged), which added the GET endpoint this page relies on.

## Testing
Verified locally: profile view renders saved data correctly, "Edit
Profile" button navigates to the edit form, and saving there reflects
back on the view page after returning.


