### PR TITLE
feat: implement real-time user-to-user messaging system via Pusher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,11 @@ GOOGLE_CLIENT_SECRET=
 
 APPLE_CLIENT_ID=
 APPLE_CLEINT_SECRET=
+
+# Pusher Configuration
+PUSHER_APP_ID="your-pusher-app-id"
+PUSHER_KEY="your-pusher-key"
+PUSHER_SECRET="your-pusher-secret"
+PUSHER_CLUSTER="your-pusher-cluster"
+NEXT_PUBLIC_PUSHER_KEY="your-pusher-key"
+NEXT_PUBLIC_PUSHER_CLUSTER="your-pusher-cluster"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "maplibre-gl": "^5.24.0",
         "next": "^14.2.35",
         "next-auth": "^5.0.0-beta.30",
+        "pusher": "^5.3.4",
+        "pusher-js": "^8.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
@@ -2235,10 +2237,19 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -3102,6 +3113,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
@@ -3466,6 +3489,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmmirror.com/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -3751,7 +3780,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3966,6 +3994,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -4266,6 +4306,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -4332,7 +4381,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4471,7 +4519,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4525,7 +4572,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4538,7 +4584,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5120,6 +5165,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.3.0.tgz",
@@ -5344,6 +5398,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmmirror.com/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -5460,7 +5530,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5485,7 +5554,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5646,7 +5714,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5733,7 +5800,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5746,7 +5812,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6021,6 +6086,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-base64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-1.1.0.tgz",
+      "integrity": "sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g==",
+      "license": "MIT",
+      "bin": {
+        "is_base64": "bin/is-base64",
+        "is-base64": "bin/is-base64"
       }
     },
     "node_modules/is-bigint": {
@@ -7007,7 +7082,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7084,6 +7158,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -7390,6 +7485,48 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -10038,6 +10175,32 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/pusher": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/pusher/-/pusher-5.3.4.tgz",
+      "integrity": "sha512-gA7NpPRsQW9qpry/Ov+o9KKIPaRMziiDoEtiZ6EF0+QiSdsnT49+dH7+hf0Dvd4d+HEGQDHp6VXtrVM5DDrpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.7",
+        "abort-controller": "^3.0.0",
+        "is-base64": "^1.1.0",
+        "node-fetch": "^2.7.0",
+        "tweetnacl": "^1.0.0",
+        "tweetnacl-util": "^0.15.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/pusher-js": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
+      "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
+      "license": "MIT",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11862,6 +12025,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "license": "Unlicense"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
@@ -12018,7 +12193,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/union-value": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "maplibre-gl": "^5.24.0",
     "next": "^14.2.35",
     "next-auth": "^5.0.0-beta.30",
+    "pusher": "^5.3.4",
+    "pusher-js": "^8.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,10 +32,14 @@ model User {
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
 
-  tickets       Ticket[]
-  accounts      Account[]
-  sessions      Session[]
-  routes        Route[]
+  tickets          Ticket[]
+  accounts         Account[]
+  sessions         Session[]
+  routes           Route[]
+  conversations    Conversation[]      @relation("UserConversations")
+  sentMessages     Message[]           @relation("SentMessages")
+  sentRequests     ConnectionRequest[] @relation("SentRequests")
+  receivedRequests ConnectionRequest[] @relation("ReceivedRequests")
 
   @@index([email])
 }
@@ -138,4 +142,47 @@ model Route {
   updatedAt        DateTime   @updatedAt
 
   @@index([userId, updatedAt])
+}
+
+model ConnectionRequest {
+  id         String                  @id @default(cuid())
+  senderId   String
+  sender     User                    @relation("SentRequests", fields: [senderId], references: [id], onDelete: Cascade)
+  receiverId String
+  receiver   User                    @relation("ReceivedRequests", fields: [receiverId], references: [id], onDelete: Cascade)
+  status     ConnectionRequestStatus @default(PENDING)
+  createdAt  DateTime                @default(now())
+  updatedAt  DateTime                @updatedAt
+
+  @@unique([senderId, receiverId])
+  @@index([senderId])
+  @@index([receiverId])
+}
+
+enum ConnectionRequestStatus {
+  PENDING
+  ACCEPTED
+  DECLINED
+}
+
+model Conversation {
+  id        String    @id @default(cuid())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  users     User[]    @relation("UserConversations")
+  messages  Message[]
+}
+
+model Message {
+  id             String       @id @default(cuid())
+  conversationId String
+  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  senderId       String
+  sender         User         @relation("SentMessages", fields: [senderId], references: [id], onDelete: Cascade)
+  text           String       @db.Text
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  @@index([conversationId])
+  @@index([senderId])
 }

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -55,4 +55,4 @@ export const POST = withValidation(forgotPasswordSchema, async (req, data) => {
       { status: 500 }
     );
   }
-});
+}, "Invalid email input");

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -55,4 +55,4 @@ export const POST = withValidation(resetPasswordSchema, async (req, data) => {
       { status: 500 }
     );
   }
-});
+}, "Invalid inputs");

--- a/src/app/api/connections/__tests__/route.test.ts
+++ b/src/app/api/connections/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { GET, POST } from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    connectionRequest: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    conversation: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/pusher", () => ({
+  triggerPusher: vi.fn(() => Promise.resolve()),
+}));
+
+describe("Connections API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (auth as any).mockResolvedValue({ user: { id: "user-1", name: "User 1" } });
+  });
+
+  describe("GET /api/connections", () => {
+    it("returns 401 if unauthorized", async () => {
+      (auth as any).mockResolvedValue(null);
+      const res = await GET({} as any);
+      expect(res.status).toBe(401);
+    });
+
+    it("returns connection lists", async () => {
+      (prisma.connectionRequest.findMany as any).mockResolvedValue([]);
+      const res = await GET({} as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data).toHaveProperty("incoming");
+      expect(data).toHaveProperty("outgoing");
+      expect(data).toHaveProperty("connections");
+    });
+  });
+
+  describe("POST /api/connections", () => {
+    it("sends connection request", async () => {
+      (prisma.connectionRequest.findFirst as any).mockResolvedValue(null);
+      (prisma.connectionRequest.create as any).mockResolvedValue({ id: "req-1", senderId: "user-1", receiverId: "user-2" });
+
+      const req = {
+        json: async () => ({ action: "send", userId: "user-2" }),
+      };
+
+      const res = await POST(req as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(prisma.connectionRequest.create).toHaveBeenCalled();
+    });
+
+    it("accepts connection request and creates conversation", async () => {
+      (prisma.connectionRequest.findUnique as any).mockResolvedValue({ id: "req-1", senderId: "user-2", receiverId: "user-1", status: "PENDING" });
+      (prisma.conversation.findFirst as any).mockResolvedValue(null);
+      (prisma.conversation.create as any).mockResolvedValue({ id: "conv-1" });
+
+      const req = {
+        json: async () => ({ action: "accept", userId: "user-2" }),
+      };
+
+      const res = await POST(req as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.conversationId).toBe("conv-1");
+      expect(prisma.conversation.create).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -161,7 +161,7 @@ export async function POST(req: NextRequest) {
             },
           });
 
-          await triggerPusher(`user-${userId}`, "connection-request", {
+          await triggerPusher(`private-user-${userId}`, "connection-request", {
             request: updated,
           });
 
@@ -182,7 +182,7 @@ export async function POST(req: NextRequest) {
         },
       });
 
-      await triggerPusher(`user-${userId}`, "connection-request", {
+      await triggerPusher(`private-user-${userId}`, "connection-request", {
         request: newRequest,
       });
 
@@ -232,7 +232,7 @@ export async function POST(req: NextRequest) {
         });
       }
 
-      await triggerPusher(`user-${userId}`, "connection-accepted", {
+      await triggerPusher(`private-user-${userId}`, "connection-accepted", {
         conversationId: conversation.id,
         connectedUser: {
           id: currentUserId,

--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -1,0 +1,273 @@
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { triggerPusher } from "@/lib/pusher";
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+
+  try {
+    const incoming = await prisma.connectionRequest.findMany({
+      where: {
+        receiverId: userId,
+        status: "PENDING",
+      },
+      include: {
+        sender: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            bio: true,
+            location: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const outgoing = await prisma.connectionRequest.findMany({
+      where: {
+        senderId: userId,
+        status: "PENDING",
+      },
+      include: {
+        receiver: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            bio: true,
+            location: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const accepted = await prisma.connectionRequest.findMany({
+      where: {
+        status: "ACCEPTED",
+        OR: [
+          { senderId: userId },
+          { receiverId: userId },
+        ],
+      },
+      include: {
+        sender: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            bio: true,
+            location: true,
+          },
+        },
+        receiver: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            bio: true,
+            location: true,
+          },
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    // Map accepted requests to connection objects representing the other user
+    const connections = accepted.map((req) => {
+      const otherUser = req.senderId === userId ? req.receiver : req.sender;
+      return {
+        requestId: req.id,
+        user: otherUser,
+        connectedAt: req.updatedAt,
+      };
+    });
+
+    return NextResponse.json({
+      incoming,
+      outgoing,
+      connections,
+    });
+  } catch (error) {
+    console.error("Fetch connections error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const currentUserId = session.user.id;
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { action, userId } = body;
+
+  if (!action || !userId) {
+    return NextResponse.json({ error: "action and userId are required" }, { status: 400 });
+  }
+
+  if (userId === currentUserId) {
+    return NextResponse.json({ error: "Cannot connect with yourself" }, { status: 400 });
+  }
+
+  try {
+    if (action === "send") {
+      // Check for existing connection request
+      const existing = await prisma.connectionRequest.findFirst({
+        where: {
+          OR: [
+            { senderId: currentUserId, receiverId: userId },
+            { senderId: userId, receiverId: currentUserId },
+          ],
+        },
+      });
+
+      if (existing) {
+        if (existing.status === "ACCEPTED") {
+          return NextResponse.json({ error: "Already connected" }, { status: 400 });
+        }
+        if (existing.status === "PENDING") {
+          return NextResponse.json({ error: "Connection request already pending" }, { status: 400 });
+        }
+        // If it was declined, we let them send a new request by resetting/updating it
+        if (existing.status === "DECLINED") {
+          const updated = await prisma.connectionRequest.update({
+            where: { id: existing.id },
+            data: {
+              senderId: currentUserId,
+              receiverId: userId,
+              status: "PENDING",
+            },
+            include: {
+              sender: {
+                select: { id: true, name: true, image: true },
+              },
+            },
+          });
+
+          await triggerPusher(`user-${userId}`, "connection-request", {
+            request: updated,
+          });
+
+          return NextResponse.json({ success: true, request: updated });
+        }
+      }
+
+      const newRequest = await prisma.connectionRequest.create({
+        data: {
+          senderId: currentUserId,
+          receiverId: userId,
+          status: "PENDING",
+        },
+        include: {
+          sender: {
+            select: { id: true, name: true, image: true },
+          },
+        },
+      });
+
+      await triggerPusher(`user-${userId}`, "connection-request", {
+        request: newRequest,
+      });
+
+      return NextResponse.json({ success: true, request: newRequest });
+    }
+
+    if (action === "accept") {
+      const request = await prisma.connectionRequest.findUnique({
+        where: {
+          senderId_receiverId: {
+            senderId: userId,
+            receiverId: currentUserId,
+          },
+        },
+      });
+
+      if (!request || request.status !== "PENDING") {
+        return NextResponse.json({ error: "No pending connection request found" }, { status: 404 });
+      }
+
+      // Update connection request
+      await prisma.connectionRequest.update({
+        where: { id: request.id },
+        data: { status: "ACCEPTED" },
+      });
+
+      // Create conversation (or find if somehow exists already)
+      let conversation = await prisma.conversation.findFirst({
+        where: {
+          AND: [
+            { users: { some: { id: currentUserId } } },
+            { users: { some: { id: userId } } },
+          ],
+        },
+      });
+
+      if (!conversation) {
+        conversation = await prisma.conversation.create({
+          data: {
+            users: {
+              connect: [
+                { id: currentUserId },
+                { id: userId },
+              ],
+            },
+          },
+        });
+      }
+
+      await triggerPusher(`user-${userId}`, "connection-accepted", {
+        conversationId: conversation.id,
+        connectedUser: {
+          id: currentUserId,
+          name: session.user.name || "A traveler",
+        },
+      });
+
+      return NextResponse.json({ success: true, conversationId: conversation.id });
+    }
+
+    if (action === "decline") {
+      const request = await prisma.connectionRequest.findUnique({
+        where: {
+          senderId_receiverId: {
+            senderId: userId,
+            receiverId: currentUserId,
+          },
+        },
+      });
+
+      if (!request || request.status !== "PENDING") {
+        return NextResponse.json({ error: "No pending connection request found" }, { status: 404 });
+      }
+
+      const updated = await prisma.connectionRequest.update({
+        where: { id: request.id },
+        data: { status: "DECLINED" },
+      });
+
+      return NextResponse.json({ success: true, request: updated });
+    }
+
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  } catch (error) {
+    console.error("Connection action error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,0 +1,59 @@
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+
+  try {
+    const conversations = await prisma.conversation.findMany({
+      where: {
+        users: {
+          some: { id: userId },
+        },
+      },
+      include: {
+        users: {
+          where: {
+            id: { not: userId },
+          },
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            bio: true,
+            location: true,
+          },
+        },
+        messages: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    // Format the response for easier rendering in the sidebar
+    const formatted = conversations.map((conv) => {
+      const otherUser = conv.users[0] || null;
+      const lastMessage = conv.messages[0] || null;
+      return {
+        id: conv.id,
+        createdAt: conv.createdAt,
+        updatedAt: conv.updatedAt,
+        otherUser,
+        lastMessage,
+      };
+    });
+
+    return NextResponse.json({ conversations: formatted });
+  } catch (error) {
+    console.error("Fetch conversations error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -55,6 +55,8 @@ export async function GET(req: NextRequest) {
             id: true,
             name: true,
             image: true,
+            bio: true,
+            location: true,
           },
         },
       },

--- a/src/app/api/messages/__tests__/route.test.ts
+++ b/src/app/api/messages/__tests__/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { GET, POST } from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    message: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    conversation: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    $transaction: vi.fn((promises) => Promise.all(promises)),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/pusher", () => ({
+  triggerPusher: vi.fn(() => Promise.resolve()),
+}));
+
+describe("Messages API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (auth as any).mockResolvedValue({ user: { id: "user-1", name: "User 1" } });
+  });
+
+  describe("GET /api/messages", () => {
+    it("returns 400 if conversationId is missing", async () => {
+      const req = {
+        url: "http://localhost:3000/api/messages",
+      };
+      const res = await GET(req as any);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns messages for a valid conversation", async () => {
+      (prisma.conversation.findFirst as any).mockResolvedValue({ id: "conv-1" });
+      (prisma.message.findMany as any).mockResolvedValue([{ id: "msg-1", text: "Hello" }]);
+
+      const req = {
+        url: "http://localhost:3000/api/messages?conversationId=conv-1",
+      };
+      const res = await GET(req as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.messages).toHaveLength(1);
+    });
+  });
+
+  describe("POST /api/messages", () => {
+    it("sends a message and triggers pusher", async () => {
+      (prisma.conversation.findFirst as any).mockResolvedValue({ id: "conv-1" });
+      (prisma.conversation.findUnique as any).mockResolvedValue({ users: [{ id: "user-1" }, { id: "user-2" }] });
+      (prisma.message.create as any).mockResolvedValue({ id: "msg-2", text: "New message" });
+      (prisma.conversation.update as any).mockResolvedValue({ id: "conv-1" });
+
+      const req = {
+        json: async () => ({ conversationId: "conv-1", text: "New message" }),
+      };
+
+      const res = await POST(req as any);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.message.text).toBe("New message");
+    });
+  });
+});

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -1,0 +1,145 @@
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { triggerPusher } from "@/lib/pusher";
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+  const url = new URL(req.url);
+  const conversationId = url.searchParams.get("conversationId");
+
+  if (!conversationId) {
+    return NextResponse.json({ error: "conversationId is required" }, { status: 400 });
+  }
+
+  try {
+    // Check if user is participant of conversation
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id: conversationId,
+        users: {
+          some: { id: userId },
+        },
+      },
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    const messages = await prisma.message.findMany({
+      where: { conversationId },
+      orderBy: { createdAt: "asc" },
+      include: {
+        sender: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({ messages });
+  } catch (error) {
+    console.error("Fetch messages error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { conversationId, text } = body;
+
+  if (!conversationId || !text || text.trim() === "") {
+    return NextResponse.json({ error: "conversationId and non-empty text are required" }, { status: 400 });
+  }
+
+  try {
+    // Check if user is participant of conversation
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id: conversationId,
+        users: {
+          some: { id: userId },
+        },
+      },
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    // Save message and update conversation's updatedAt timestamp
+    const [message] = await prisma.$transaction([
+      prisma.message.create({
+        data: {
+          conversationId,
+          senderId: userId,
+          text: text.trim(),
+        },
+        include: {
+          sender: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          },
+        },
+      }),
+      prisma.conversation.update({
+        where: { id: conversationId },
+        data: { updatedAt: new Date() },
+      }),
+    ]);
+
+    // Trigger Pusher event
+    await triggerPusher(`chat-${conversationId}`, "new-message", {
+      message,
+    });
+
+    // Also trigger update on user sidebars for conversation lists
+    // Fetch users in conversation to trigger sidebar updates
+    const users = await prisma.conversation.findUnique({
+      where: { id: conversationId },
+      select: {
+        users: {
+          select: { id: true },
+        },
+      },
+    });
+
+    if (users) {
+      for (const u of users.users) {
+        await triggerPusher(`user-${u.id}`, "conversation-updated", {
+          conversationId,
+          lastMessage: message,
+        });
+      }
+    }
+
+    return NextResponse.json({ success: true, message });
+  } catch (error) {
+    console.error("Send message error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -113,7 +113,7 @@ export async function POST(req: NextRequest) {
     ]);
 
     // Trigger Pusher event
-    await triggerPusher(`chat-${conversationId}`, "new-message", {
+    await triggerPusher(`private-chat-${conversationId}`, "new-message", {
       message,
     });
 
@@ -129,12 +129,14 @@ export async function POST(req: NextRequest) {
     });
 
     if (users) {
-      for (const u of users.users) {
-        await triggerPusher(`user-${u.id}`, "conversation-updated", {
-          conversationId,
-          lastMessage: message,
-        });
-      }
+      await Promise.all(
+        users.users.map((u) =>
+          triggerPusher(`private-user-${u.id}`, "conversation-updated", {
+            conversationId,
+            lastMessage: message,
+          })
+        )
+      );
     }
 
     return NextResponse.json({ success: true, message });

--- a/src/app/api/pusher/auth/route.ts
+++ b/src/app/api/pusher/auth/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { pusherServer } from "@/lib/pusher";
+import { withValidation } from "@/lib/withValidation";
+import { z } from "zod";
+
+const pusherAuthSchema = z.object({
+  socket_id: z.string(),
+  channel_name: z.string(),
+});
+
+export const POST = withValidation(pusherAuthSchema, async (req, data) => {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+  const { socket_id, channel_name } = data;
+
+  // Enforce security checks on channel names
+  if (channel_name.startsWith("private-user-")) {
+    const targetUserId = channel_name.replace("private-user-", "");
+    if (targetUserId !== userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  } else if (channel_name.startsWith("private-chat-")) {
+    const conversationId = channel_name.replace("private-chat-", "");
+    
+    // Check database to ensure user is a participant of the conversation
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id: conversationId,
+        users: {
+          some: { id: userId },
+        },
+      },
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  } else {
+    return NextResponse.json({ error: "Invalid channel name" }, { status: 400 });
+  }
+
+  if (!pusherServer) {
+    // Return mock auth response for development/testing if Pusher credentials are not set
+    return NextResponse.json({
+      auth: `mock-auth-signature-for-${userId}`,
+    });
+  }
+
+  try {
+    const authResponse = pusherServer.authorizeChannel(socket_id, channel_name);
+    return NextResponse.json(authResponse);
+  } catch (error) {
+    console.error("Pusher auth error:", error);
+    return NextResponse.json({ error: "Pusher authorization failed" }, { status: 500 });
+  }
+});

--- a/src/app/api/tickets/__tests__/tickets.test.ts
+++ b/src/app/api/tickets/__tests__/tickets.test.ts
@@ -18,6 +18,10 @@ vi.mock("@/lib/auth", () => ({
     auth: vi.fn(),
 }))
 
+vi.mock("@/lib/cloudinary-upload", () => ({
+    uploadFileToCloudinary: vi.fn(() => Promise.resolve({ url: "about:blank" })),
+}))
+
 class MockFile extends Blob {
     name: string
     lastModified: number

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -21,10 +21,11 @@ const ticketSchema = z.object({
   }),
   file: z
   .any()
+  .refine((val) => val instanceof File, "File required")
   .refine((val) => val instanceof File && val.size > 0, "File required")
-  .refine((val) => val.size <= MAX_FILE_SIZE, "File size exceeds 10MB")
+  .refine((val) => val instanceof File && val.size <= MAX_FILE_SIZE, "File size exceeds 10MB")
   .refine(
-    (val) => ALLOWED_TYPES.includes(val.type),
+    (val) => val instanceof File && ALLOWED_TYPES.includes(val.type),
     "Unsupported file type"
   ),
 });

--- a/src/app/dashboard/messages/page.tsx
+++ b/src/app/dashboard/messages/page.tsx
@@ -1,0 +1,21 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import ChatInterface from "@/components/ChatInterface";
+
+export default async function MessagesPage() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/signin");
+  }
+
+  return (
+    <ChatInterface
+      currentUser={{
+        id: session.user.id,
+        name: session.user.name || "Traveller",
+        image: session.user.image || null,
+        email: session.user.email || undefined,
+      }}
+    />
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import Link from "next/link";
 import prisma from "@/lib/prisma";
+import DashboardMatches from "@/components/DashboardMatches";
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -35,8 +36,11 @@ export default async function DashboardPage() {
                   <p className="font-medium">{t.destination}</p>
                   <p className="text-sm text-slate-600 dark:text-slate-400">Departure: {new Date(t.departureDate).toDateString()}</p>
                 </div>
-                <span className="rounded-full border px-3 py-1 text-sm dark:border-slate-600">{t.status}</span>
+                <span className={`rounded-full border px-3 py-1 text-sm ${t.status === "VERIFIED" ? "border-green-500 text-green-600 dark:text-green-400" : "dark:border-slate-600"}`}>{t.status}</span>
               </div>
+              {t.status === "VERIFIED" && (
+                <DashboardMatches destination={t.destination} departureDate={t.departureDate.toISOString()} />
+              )}
             </div>
           ))
         )}

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { getPusherClient } from "@/lib/pusher-client";
+import { 
+  MessageSquare, Send, Compass, UserCheck, UserX, 
+  MapPin, Calendar, Loader2, Sparkles, Inbox, RefreshCw 
+} from "lucide-react";
+
+interface User {
+  id: string;
+  name: string;
+  image: string | null;
+  email?: string;
+}
+
+interface Conversation {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  otherUser: {
+    id: string;
+    name: string;
+    image: string | null;
+    bio: string | null;
+    location: string | null;
+  } | null;
+  lastMessage: {
+    id: string;
+    text: string;
+    createdAt: string;
+    senderId: string;
+  } | null;
+}
+
+interface Request {
+  id: string;
+  senderId: string;
+  receiverId: string;
+  status: string;
+  sender: {
+    id: string;
+    name: string;
+    image: string | null;
+    bio: string | null;
+    location: string | null;
+  };
+}
+
+export default function ChatInterface({
+  currentUser,
+}: {
+  currentUser: User;
+}) {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [incomingRequests, setIncomingRequests] = useState<Request[]>([]);
+  const [activeConvId, setActiveConvId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<any[]>([]);
+  const [inputText, setInputText] = useState("");
+  
+  const [loadingConvs, setLoadingConvs] = useState(true);
+  const [loadingMessages, setLoadingMessages] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const pusherSubscribedChats = useRef<Set<string>>(new Set());
+
+  // Fetch initial conversations and connection requests
+  const fetchData = async () => {
+    setLoadingConvs(true);
+    try {
+      const convRes = await fetch("/api/conversations");
+      const convData = await convRes.json();
+      if (convRes.ok) {
+        setConversations(convData.conversations || []);
+      }
+
+      const connRes = await fetch("/api/connections");
+      const connData = await connRes.json();
+      if (connRes.ok) {
+        setIncomingRequests(connData.incoming || []);
+      }
+    } catch (error) {
+      console.error("Error loading chat workspace data:", error);
+    } finally {
+      setLoadingConvs(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  // Fetch messages when active conversation changes
+  const fetchMessages = async (convId: string) => {
+    setLoadingMessages(true);
+    try {
+      const res = await fetch(`/api/messages?conversationId=${convId}`);
+      const data = await res.json();
+      if (res.ok) {
+        setMessages(data.messages || []);
+      }
+    } catch (error) {
+      console.error("Error fetching messages:", error);
+    } finally {
+      setLoadingMessages(false);
+    }
+  };
+
+  useEffect(() => {
+    if (activeConvId) {
+      fetchMessages(activeConvId);
+    } else {
+      setMessages([]);
+    }
+  }, [activeConvId]);
+
+  // Subscribe to personal pusher channel for incoming requests and accepted connections
+  useEffect(() => {
+    const pusher = getPusherClient();
+    if (!pusher || !currentUser.id) return;
+
+    const channelName = `user-${currentUser.id}`;
+    const channel = pusher.subscribe(channelName);
+
+    channel.bind("connection-request", (data: { request: Request }) => {
+      setIncomingRequests((prev) => [data.request, ...prev]);
+    });
+
+    channel.bind("connection-accepted", (data: { conversationId: string; connectedUser: any }) => {
+      // Reload conversations list when someone accepts our request
+      fetchData();
+    });
+
+    channel.bind("conversation-updated", (data: { conversationId: string; lastMessage: any }) => {
+      // Update conversations list with the new message and reorder
+      setConversations((prev) => {
+        const updated = prev.map((conv) => {
+          if (conv.id === data.conversationId) {
+            return {
+              ...conv,
+              lastMessage: data.lastMessage,
+              updatedAt: data.lastMessage.createdAt,
+            };
+          }
+          return conv;
+        });
+        // Sort by updatedAt descending
+        return [...updated].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      });
+    });
+
+    return () => {
+      pusher.unsubscribe(channelName);
+    };
+  }, [currentUser.id]);
+
+  // Subscribe to pusher channel for active chat messages
+  useEffect(() => {
+    const pusher = getPusherClient();
+    if (!pusher || !activeConvId) return;
+
+    const channelName = `chat-${activeConvId}`;
+    const currentSubscribedChats = pusherSubscribedChats.current;
+    
+    // Check if we are already subscribed to avoid duplicate bindings
+    if (currentSubscribedChats.has(activeConvId)) return;
+
+    const channel = pusher.subscribe(channelName);
+    currentSubscribedChats.add(activeConvId);
+
+    channel.bind("new-message", (data: { message: any }) => {
+      // Add message to chat list if we are not the sender (as we add it optimistically or after API returns)
+      setMessages((prev) => {
+        // Prevent duplicate appending
+        if (prev.some((m) => m.id === data.message.id)) return prev;
+        return [...prev, data.message];
+      });
+    });
+
+    return () => {
+      pusher.unsubscribe(channelName);
+      currentSubscribedChats.delete(activeConvId);
+    };
+  }, [activeConvId]);
+
+  // Scroll to bottom of message list on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loadingMessages]);
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inputText.trim() || !activeConvId || sending) return;
+
+    const messageText = inputText.trim();
+    setInputText("");
+    setSending(true);
+
+    // Optimistic message object
+    const tempId = `temp-${Date.now()}`;
+    const optimisticMessage = {
+      id: tempId,
+      text: messageText,
+      createdAt: new Date().toISOString(),
+      senderId: currentUser.id,
+      sender: {
+        id: currentUser.id,
+        name: currentUser.name || "You",
+        image: currentUser.image,
+      },
+    };
+
+    setMessages((prev) => [...prev, optimisticMessage]);
+
+    try {
+      const res = await fetch("/api/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          conversationId: activeConvId,
+          text: messageText,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to send message");
+
+      // Replace optimistic message with actual db message
+      setMessages((prev) =>
+        prev.map((m) => (m.id === tempId ? data.message : m))
+      );
+
+      // Update last message in the conversations sidebar list
+      setConversations((prev) => {
+        const updated = prev.map((conv) => {
+          if (conv.id === activeConvId) {
+            return {
+              ...conv,
+              lastMessage: data.message,
+              updatedAt: data.message.createdAt,
+            };
+          }
+          return conv;
+        });
+        return [...updated].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      });
+    } catch (error) {
+      console.error("Failed to send message:", error);
+      // Remove optimistic message and show error
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      alert("Failed to send message. Please try again.");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleRequestAction = async (targetUserId: string, action: "accept" | "decline") => {
+    setActionLoading(targetUserId);
+    try {
+      const res = await fetch("/api/connections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, userId: targetUserId }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to process request");
+
+      // Remove from incoming requests UI list
+      setIncomingRequests((prev) => prev.filter((r) => r.senderId !== targetUserId));
+
+      if (action === "accept" && data.conversationId) {
+        // Navigate or open the newly unlocked conversation
+        setActiveConvId(data.conversationId);
+      }
+
+      await fetchData();
+    } catch (err: any) {
+      alert(err.message || "Failed to process request.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const activeConv = conversations.find((c) => c.id === activeConvId);
+
+  return (
+    <div className="flex h-[calc(100vh-140px)] rounded-2xl bg-white dark:bg-[#0A0B1E] border border-slate-100 dark:border-slate-800 shadow-xl overflow-hidden">
+      {/* Sidebar List */}
+      <div className="w-80 border-r border-slate-100 dark:border-slate-800 flex flex-col bg-slate-50/50 dark:bg-[#0F1129]/30">
+        <div className="p-4 border-b border-slate-100 dark:border-slate-800 flex items-center justify-between">
+          <h2 className="font-bold text-lg text-slate-800 dark:text-white flex items-center gap-2">
+            <MessageSquare className="text-blue-500" size={18} /> Conversations
+          </h2>
+          <button 
+            onClick={fetchData} 
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-white transition"
+            title="Refresh Chats"
+          >
+            <RefreshCw size={15} />
+          </button>
+        </div>
+
+        {/* Incoming Requests Section */}
+        {incomingRequests.length > 0 && (
+          <div className="p-4 border-b border-slate-100 dark:border-slate-800 bg-amber-50/30 dark:bg-amber-950/10">
+            <h3 className="text-xs font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wider mb-2 flex items-center gap-1">
+              <Sparkles size={12} /> Pending Connections ({incomingRequests.length})
+            </h3>
+            <div className="space-y-3">
+              {incomingRequests.map((req) => (
+                <div 
+                  key={req.id} 
+                  className="rounded-xl border border-amber-100 dark:border-amber-900/40 bg-white dark:bg-[#11122D] p-3 shadow-sm"
+                >
+                  <div className="flex items-center gap-2">
+                    {req.sender.image ? (
+                      <img src={req.sender.image} alt={req.sender.name} className="w-8 h-8 rounded-full object-cover" />
+                    ) : (
+                      <div className="w-8 h-8 rounded-full bg-amber-500 flex items-center justify-center text-white text-xs font-semibold">
+                        {req.sender.name.charAt(0).toUpperCase()}
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-bold truncate text-slate-800 dark:text-white">{req.sender.name}</p>
+                      {req.sender.location && (
+                        <p className="text-[10px] text-slate-500 dark:text-slate-400 truncate flex items-center gap-0.5 mt-0.5">
+                          <MapPin size={8} /> {req.sender.location}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex gap-2 mt-3 justify-end">
+                    <button
+                      disabled={actionLoading === req.senderId}
+                      onClick={() => handleRequestAction(req.senderId, "decline")}
+                      className="inline-flex items-center gap-0.5 px-2 py-1 rounded-md text-[10px] font-medium border border-slate-200 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-800 text-slate-500 transition"
+                    >
+                      <UserX size={10} /> Decline
+                    </button>
+                    <button
+                      disabled={actionLoading === req.senderId}
+                      onClick={() => handleRequestAction(req.senderId, "accept")}
+                      className="inline-flex items-center gap-0.5 px-2.5 py-1 rounded-md text-[10px] font-semibold bg-green-600 hover:bg-green-700 text-white transition shadow-sm"
+                    >
+                      <UserCheck size={10} /> Accept
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Conversations List */}
+        <div className="flex-1 overflow-y-auto divide-y divide-slate-50 dark:divide-slate-850">
+          {loadingConvs ? (
+            <div className="flex flex-col items-center justify-center py-12 text-slate-400">
+              <Loader2 className="animate-spin text-blue-500 mb-2" size={20} />
+              <span className="text-xs">Loading conversations...</span>
+            </div>
+          ) : conversations.length === 0 ? (
+            <div className="text-center py-16 px-4">
+              <Inbox size={28} className="text-slate-300 dark:text-slate-700 mx-auto mb-2" />
+              <p className="text-xs font-medium text-slate-500 dark:text-slate-400">No active chats yet.</p>
+              <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-1 leading-normal">
+                Matches with verified travellers will show up here after accepting connection requests.
+              </p>
+            </div>
+          ) : (
+            conversations.map((conv) => {
+              const other = conv.otherUser;
+              if (!other) return null;
+              const isActive = conv.id === activeConvId;
+              const unread = false; // Add custom unread logic if needed later
+
+              return (
+                <button
+                  key={conv.id}
+                  onClick={() => setActiveConvId(conv.id)}
+                  className={`w-full text-left p-4 flex gap-3 transition ${
+                    isActive 
+                      ? "bg-[#1E293B] text-white shadow-inner" 
+                      : "hover:bg-slate-100/50 dark:hover:bg-white/5 text-slate-700 dark:text-slate-300"
+                  }`}
+                >
+                  <div className="relative flex-shrink-0">
+                    {other.image ? (
+                      <img src={other.image} alt={other.name} className="w-10 h-10 rounded-full object-cover" />
+                    ) : (
+                      <div className={`w-10 h-10 rounded-full flex items-center justify-center font-bold text-xs ${
+                        isActive ? "bg-slate-700 text-white" : "bg-blue-100 dark:bg-blue-900/30 text-blue-600"
+                      }`}>
+                        {other.name.charAt(0).toUpperCase()}
+                      </div>
+                    )}
+                    <div className="absolute right-0 bottom-0 w-2.5 h-2.5 rounded-full bg-green-500 border-2 border-white dark:border-[#0A0B1E]" />
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex justify-between items-baseline">
+                      <h4 className={`text-xs font-bold truncate ${isActive ? "text-white" : "text-slate-900 dark:text-slate-100"}`}>
+                        {other.name}
+                      </h4>
+                      {conv.lastMessage && (
+                        <span className={`text-[9px] ${isActive ? "text-slate-400" : "text-slate-400"}`}>
+                          {new Date(conv.lastMessage.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                        </span>
+                      )}
+                    </div>
+                    {other.location && (
+                      <p className={`text-[10px] truncate ${isActive ? "text-slate-400" : "text-slate-500"}`}>
+                        {other.location}
+                      </p>
+                    )}
+                    <p className={`text-[11px] truncate mt-1 ${
+                      isActive ? "text-slate-200" : "text-slate-600 dark:text-slate-400"
+                    } ${unread ? "font-bold" : ""}`}>
+                      {conv.lastMessage ? conv.lastMessage.text : "No messages yet"}
+                    </p>
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {/* Main Chat Workspace */}
+      <div className="flex-1 flex flex-col bg-slate-50/20 dark:bg-[#0A0B1E]/10">
+        {activeConvId && activeConv && activeConv.otherUser ? (
+          <>
+            {/* Header info */}
+            <div className="p-4 border-b border-slate-100 dark:border-slate-800 bg-white dark:bg-[#0A0B1E] flex justify-between items-center shadow-sm">
+              <div className="flex items-center gap-3">
+                {activeConv.otherUser.image ? (
+                  <img src={activeConv.otherUser.image} alt={activeConv.otherUser.name} className="w-10 h-10 rounded-full object-cover" />
+                ) : (
+                  <div className="w-10 h-10 rounded-full bg-gradient-to-tr from-blue-500 to-indigo-600 flex items-center justify-center text-white font-semibold text-xs">
+                    {activeConv.otherUser.name.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div>
+                  <h3 className="font-bold text-sm text-slate-800 dark:text-white">{activeConv.otherUser.name}</h3>
+                  {activeConv.otherUser.location && (
+                    <p className="text-[10px] text-slate-500 dark:text-slate-400 flex items-center gap-0.5 mt-0.5">
+                      <MapPin size={10} /> {activeConv.otherUser.location}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {activeConv.otherUser.bio && (
+                <div className="hidden md:block max-w-xs xl:max-w-sm rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-100 dark:border-slate-850 p-2 text-[10px] text-slate-600 dark:text-slate-400 italic">
+                  &quot;{activeConv.otherUser.bio}&quot;
+                </div>
+              )}
+            </div>
+
+            {/* Messages body */}
+            <div className="flex-1 overflow-y-auto p-4 space-y-4">
+              {loadingMessages ? (
+                <div className="flex flex-col items-center justify-center h-full text-slate-400">
+                  <Loader2 className="animate-spin text-blue-500 mb-2" size={24} />
+                  <span className="text-xs">Fetching past messages...</span>
+                </div>
+              ) : messages.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-full text-center p-6 text-slate-400">
+                  <Sparkles size={24} className="text-blue-500 mb-2" />
+                  <p className="text-xs font-semibold text-slate-600 dark:text-slate-300">This is the start of your conversation!</p>
+                  <p className="text-[10px] mt-1 leading-normal max-w-xs">
+                    Say hello to plan your itinerary, share transport, or coordinate dates. Keep things friendly and travel-safe!
+                  </p>
+                </div>
+              ) : (
+                messages.map((msg, index) => {
+                  const isMe = msg.senderId === currentUser.id;
+                  const showSenderHeader = index === 0 || messages[index - 1].senderId !== msg.senderId;
+
+                  return (
+                    <div 
+                      key={msg.id} 
+                      className={`flex flex-col ${isMe ? "items-end" : "items-start"}`}
+                    >
+                      {!isMe && showSenderHeader && (
+                        <span className="text-[9px] text-slate-400 ml-1 mb-1 font-medium">
+                          {msg.sender.name}
+                        </span>
+                      )}
+                      <div
+                        className={`max-w-[70%] rounded-2xl px-4 py-2.5 text-xs shadow-sm ${
+                          isMe
+                            ? "bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-tr-none"
+                            : "bg-white dark:bg-[#0F1129] border border-slate-100 dark:border-slate-800 text-slate-800 dark:text-slate-200 rounded-tl-none"
+                        }`}
+                      >
+                        <p className="leading-relaxed whitespace-pre-wrap">{msg.text}</p>
+                      </div>
+                      <span className="text-[8px] text-slate-400 mt-1 mx-1">
+                        {new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      </span>
+                    </div>
+                  );
+                })
+              )}
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* Input form */}
+            <form 
+              onSubmit={handleSendMessage}
+              className="p-4 border-t border-slate-100 dark:border-slate-800 bg-white dark:bg-[#0A0B1E] flex gap-2 items-center"
+            >
+              <input
+                type="text"
+                value={inputText}
+                onChange={(e) => setInputText(e.target.value)}
+                placeholder={`Message ${activeConv.otherUser.name}...`}
+                className="flex-1 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl px-4 py-2.5 text-xs text-slate-800 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+              />
+              <button
+                type="submit"
+                disabled={!inputText.trim() || sending}
+                className="bg-blue-600 hover:bg-blue-700 text-white rounded-xl p-2.5 disabled:opacity-40 transition flex-shrink-0 shadow-md hover:shadow-lg"
+              >
+                <Send size={15} />
+              </button>
+            </form>
+          </>
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center p-6 text-center text-slate-400 dark:text-slate-600">
+            <Compass size={40} className="text-slate-300 dark:text-slate-800 mb-4 animate-pulse" />
+            <h3 className="font-bold text-sm text-slate-700 dark:text-slate-300">Your Inbox</h3>
+            <p className="text-xs max-w-sm mt-1 leading-normal">
+              Select an active conversation on the left, or accept pending traveler requests to begin planning your trip together!
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -121,7 +121,7 @@ export default function ChatInterface({
     const pusher = getPusherClient();
     if (!pusher || !currentUser.id) return;
 
-    const channelName = `user-${currentUser.id}`;
+    const channelName = `private-user-${currentUser.id}`;
     const channel = pusher.subscribe(channelName);
 
     channel.bind("connection-request", (data: { request: Request }) => {
@@ -161,7 +161,7 @@ export default function ChatInterface({
     const pusher = getPusherClient();
     if (!pusher || !activeConvId) return;
 
-    const channelName = `chat-${activeConvId}`;
+    const channelName = `private-chat-${activeConvId}`;
     const currentSubscribedChats = pusherSubscribedChats.current;
     
     // Check if we are already subscribed to avoid duplicate bindings

--- a/src/components/DashboardMatches.tsx
+++ b/src/components/DashboardMatches.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Compass, UserPlus, Check, X, MessageSquare, MapPin, Calendar, RefreshCw, Loader2 } from "lucide-react";
+import Link from "next/link";
+
+interface Match {
+  id: string;
+  userId: string;
+  destination: string;
+  departureDate: string;
+  ticketUrl: string;
+  status: string;
+  user: {
+    id: string;
+    name: string;
+    image: string | null;
+    bio: string | null;
+    location: string | null;
+  };
+}
+
+interface Connection {
+  requestId: string;
+  user: {
+    id: string;
+    name: string;
+    image: string | null;
+  };
+  connectedAt: string;
+}
+
+interface Request {
+  id: string;
+  senderId: string;
+  receiverId: string;
+  status: string;
+  sender?: {
+    id: string;
+    name: string;
+    image: string | null;
+  };
+  receiver?: {
+    id: string;
+    name: string;
+    image: string | null;
+  };
+}
+
+export default function DashboardMatches({
+  destination,
+  departureDate,
+}: {
+  destination: string;
+  departureDate: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [incomingRequests, setIncomingRequests] = useState<Request[]>([]);
+  const [outgoingRequests, setOutgoingRequests] = useState<Request[]>([]);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMatchesAndConnections = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // Fetch matches
+      const dateStr = new Date(departureDate).toISOString().split("T")[0];
+      const matchRes = await fetch(`/api/matches?destination=${encodeURIComponent(destination)}&date=${dateStr}`);
+      const matchData = await matchRes.json();
+
+      if (!matchRes.ok) throw new Error(matchData.error || "Failed to load matches");
+
+      // Fetch connections
+      const connRes = await fetch("/api/connections");
+      const connData = await connRes.json();
+
+      if (!connRes.ok) throw new Error(connData.error || "Failed to load connections");
+
+      setMatches(matchData.matches || []);
+      setConnections(connData.connections || []);
+      setIncomingRequests(connData.incoming || []);
+      setOutgoingRequests(connData.outgoing || []);
+    } catch (err: any) {
+      console.error(err);
+      setError(err.message || "Something went wrong while fetching matches.");
+    } finally {
+      setLoading(false);
+    }
+  }, [departureDate, destination]);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchMatchesAndConnections();
+    }
+  }, [isOpen, fetchMatchesAndConnections]);
+
+  const handleConnect = async (targetUserId: string) => {
+    setActionLoading(targetUserId);
+    try {
+      const res = await fetch("/api/connections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "send", userId: targetUserId }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to send request");
+
+      // Refresh data
+      await fetchMatchesAndConnections();
+    } catch (err: any) {
+      alert(err.message || "Failed to send request.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleAccept = async (targetUserId: string) => {
+    setActionLoading(targetUserId);
+    try {
+      const res = await fetch("/api/connections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "accept", userId: targetUserId }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to accept connection");
+
+      // Refresh data
+      await fetchMatchesAndConnections();
+    } catch (err: any) {
+      alert(err.message || "Failed to accept request.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDecline = async (targetUserId: string) => {
+    setActionLoading(targetUserId);
+    try {
+      const res = await fetch("/api/connections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "decline", userId: targetUserId }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to decline connection");
+
+      // Refresh data
+      await fetchMatchesAndConnections();
+    } catch (err: any) {
+      alert(err.message || "Failed to decline request.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  // Helper to determine the connection state of a matched traveler
+  const getConnectionState = (targetUserId: string) => {
+    const isAccepted = connections.some((c) => c.user.id === targetUserId);
+    if (isAccepted) return "ACCEPTED";
+
+    const isIncoming = incomingRequests.some((r) => r.senderId === targetUserId);
+    if (isIncoming) return "INCOMING";
+
+    const isOutgoing = outgoingRequests.some((r) => r.receiverId === targetUserId);
+    if (isOutgoing) return "OUTGOING";
+
+    return "NONE";
+  };
+
+  return (
+    <div className="mt-4 border-t border-slate-100 dark:border-slate-800 pt-4">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-xl transition bg-slate-50 hover:bg-slate-100 dark:bg-slate-800 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-200"
+      >
+        <Compass size={16} className={loading ? "animate-spin text-blue-500" : "text-blue-500"} />
+        {isOpen ? "Hide Matches" : "Find Matches"}
+      </button>
+
+      {isOpen && (
+        <div className="mt-4 rounded-2xl bg-slate-50/50 dark:bg-slate-900/30 border border-slate-100 dark:border-slate-800/80 p-4 transition-all duration-300">
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="animate-spin text-blue-500 mr-2" size={20} />
+              <span className="text-sm text-slate-500">Searching matching verified itineraries...</span>
+            </div>
+          ) : error ? (
+            <div className="text-center py-6">
+              <p className="text-sm text-red-500">{error}</p>
+              <button
+                onClick={fetchMatchesAndConnections}
+                className="mt-3 inline-flex items-center gap-1.5 text-xs text-blue-500 hover:underline"
+              >
+                <RefreshCw size={12} /> Try Again
+              </button>
+            </div>
+          ) : matches.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                No matching verified travelers found within 3 days of your trip.
+              </p>
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+                We will update you when a traveler uploads a matching ticket.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2">
+              {matches.map((match) => {
+                const connState = getConnectionState(match.userId);
+                const isUserActionLoading = actionLoading === match.userId;
+
+                return (
+                  <div
+                    key={match.id}
+                    className="flex flex-col justify-between rounded-xl bg-white dark:bg-[#0F1129] border border-slate-150 dark:border-slate-800 p-4 shadow-sm transition hover:shadow-md hover:translate-y-[-2px] duration-200"
+                  >
+                    <div>
+                      <div className="flex items-start gap-3">
+                        {match.user.image ? (
+                          <img
+                            src={match.user.image}
+                            alt={match.user.name}
+                            className="w-11 h-11 rounded-full object-cover border-2 border-blue-500/20"
+                          />
+                        ) : (
+                          <div className="w-11 h-11 rounded-full bg-gradient-to-tr from-blue-500 to-indigo-600 flex items-center justify-center text-white font-semibold text-sm">
+                            {match.user.name.charAt(0).toUpperCase()}
+                          </div>
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-semibold text-sm truncate dark:text-white">{match.user.name}</h4>
+                          {match.user.location && (
+                            <p className="text-xs text-slate-500 dark:text-slate-400 flex items-center gap-1 mt-0.5">
+                              <MapPin size={12} /> {match.user.location}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+
+                      {match.user.bio && (
+                        <p className="mt-3 text-xs text-slate-600 dark:text-slate-300 line-clamp-2 italic bg-slate-50/80 dark:bg-slate-800/40 p-2 rounded-lg border border-slate-100/50 dark:border-slate-800/40">
+                          &quot;{match.user.bio}&quot;
+                        </p>
+                      )}
+
+                      <div className="mt-3 flex items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+                        <span className="flex items-center gap-1 font-medium text-indigo-600 dark:text-indigo-400">
+                          <Compass size={12} /> {match.destination}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Calendar size={12} /> {new Date(match.departureDate).toLocaleDateString()}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="mt-4 pt-3 border-t border-slate-50 dark:border-slate-800/60 flex justify-end">
+                      {isUserActionLoading ? (
+                        <button
+                          disabled
+                          className="w-full sm:w-auto inline-flex items-center justify-center gap-1.5 px-4 py-1.5 rounded-lg text-xs font-medium bg-slate-100 text-slate-400 dark:bg-slate-800"
+                        >
+                          <Loader2 size={13} className="animate-spin" /> Processing...
+                        </button>
+                      ) : connState === "NONE" ? (
+                        <button
+                          onClick={() => handleConnect(match.userId)}
+                          className="w-full sm:w-auto inline-flex items-center justify-center gap-1.5 px-4 py-1.5 rounded-lg text-xs font-semibold bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-sm hover:from-blue-700 hover:to-indigo-700 transition"
+                        >
+                          <UserPlus size={13} /> Connect
+                        </button>
+                      ) : connState === "OUTGOING" ? (
+                        <span className="w-full sm:w-auto inline-flex items-center justify-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-50 text-blue-600 border border-blue-100 dark:bg-blue-950/20 dark:text-blue-400 dark:border-blue-900/30">
+                          Request Sent
+                        </span>
+                      ) : connState === "INCOMING" ? (
+                        <div className="flex gap-2 w-full sm:w-auto">
+                          <button
+                            onClick={() => handleDecline(match.userId)}
+                            className="inline-flex items-center justify-center p-1.5 rounded-lg border border-slate-200 hover:bg-slate-50 text-slate-500 hover:text-red-500 transition dark:border-slate-800 dark:hover:bg-slate-850"
+                            title="Decline"
+                          >
+                            <X size={14} />
+                          </button>
+                          <button
+                            onClick={() => handleAccept(match.userId)}
+                            className="inline-flex items-center justify-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-green-600 text-white hover:bg-green-700 transition shadow-sm"
+                          >
+                            <Check size={13} /> Accept
+                          </button>
+                        </div>
+                      ) : (
+                        <Link
+                          href="/dashboard/messages"
+                          className="w-full sm:w-auto inline-flex items-center justify-center gap-1.5 px-4 py-1.5 rounded-lg text-xs font-semibold bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-white shadow-sm transition"
+                        >
+                          <MessageSquare size={13} /> Message
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Home, User, Map, Settings } from "lucide-react"
+import { Home, User, Map, Settings, MessageSquare } from "lucide-react"
 
 export default function Sidebar() {
     const pathname = usePathname()
 
     const navItems = [
         { label: "Dashboard", icon: Home, href: "/dashboard" },
+        { label: "Messages", icon: MessageSquare, href: "/dashboard/messages" },
         { label: "Profile", icon: User, href: "/dashboard/profile" },
         { label: "Trips", icon: Map, href: "#" },
         { label: "Settings", icon: Settings, href: "#" },

--- a/src/lib/pusher-client.ts
+++ b/src/lib/pusher-client.ts
@@ -1,0 +1,21 @@
+import PusherClient from "pusher-js";
+
+const key = process.env.NEXT_PUBLIC_PUSHER_KEY || "dummy-key";
+const cluster = process.env.NEXT_PUBLIC_PUSHER_CLUSTER || "mt1";
+
+export const getPusherClient = () => {
+  if (typeof window === "undefined") return null;
+
+  const globalWithPusher = window as typeof window & {
+    pusherClient?: PusherClient;
+  };
+
+  if (!globalWithPusher.pusherClient) {
+    globalWithPusher.pusherClient = new PusherClient(key, {
+      cluster,
+      forceTLS: true,
+    });
+  }
+
+  return globalWithPusher.pusherClient;
+};

--- a/src/lib/pusher-client.ts
+++ b/src/lib/pusher-client.ts
@@ -1,10 +1,11 @@
 import PusherClient from "pusher-js";
 
-const key = process.env.NEXT_PUBLIC_PUSHER_KEY || "dummy-key";
-const cluster = process.env.NEXT_PUBLIC_PUSHER_CLUSTER || "mt1";
+const key = process.env.NEXT_PUBLIC_PUSHER_KEY;
+const cluster = process.env.NEXT_PUBLIC_PUSHER_CLUSTER;
 
 export const getPusherClient = () => {
   if (typeof window === "undefined") return null;
+  if (!key || !cluster) return null;
 
   const globalWithPusher = window as typeof window & {
     pusherClient?: PusherClient;
@@ -14,6 +15,7 @@ export const getPusherClient = () => {
     globalWithPusher.pusherClient = new PusherClient(key, {
       cluster,
       forceTLS: true,
+      authEndpoint: "/api/pusher/auth",
     });
   }
 

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -1,0 +1,36 @@
+import Pusher from "pusher";
+
+const appId = process.env.PUSHER_APP_ID;
+const key = process.env.PUSHER_KEY;
+const secret = process.env.PUSHER_SECRET;
+const cluster = process.env.PUSHER_CLUSTER;
+
+const isConfigured = !!(appId && key && secret && cluster);
+
+export const pusherServer = isConfigured
+  ? new Pusher({
+      appId: appId!,
+      key: key!,
+      secret: secret!,
+      cluster: cluster!,
+      useTLS: true,
+    })
+  : null;
+
+if (!isConfigured) {
+  console.warn(
+    "⚠️ Pusher environment variables (PUSHER_APP_ID, PUSHER_KEY, PUSHER_SECRET, PUSHER_CLUSTER) are not fully configured. Real-time updates will be logged to the console but not delivered."
+  );
+}
+
+export async function triggerPusher(channel: string, event: string, data: any) {
+  if (pusherServer) {
+    try {
+      await pusherServer.trigger(channel, event, data);
+    } catch (error) {
+      console.error(`Error triggering Pusher event '${event}' on channel '${channel}':`, error);
+    }
+  } else {
+    console.log(`[Pusher Mock Trigger] Channel: ${channel}, Event: ${event}, Data:`, data);
+  }
+}

--- a/src/lib/withValidation.ts
+++ b/src/lib/withValidation.ts
@@ -11,10 +11,10 @@ type Handler<T> = (req: NextRequest, data: T) => Promise<NextResponse>;
  * @param schema The Zod schema to validate the request payload against
  * @param handler The route handler function to execute if validation succeeds
  */
-export function withValidation<T>(schema: z.ZodSchema<T>, handler: Handler<T>) {
+export function withValidation<T>(schema: z.ZodSchema<T>, handler: Handler<T>, customErrorMsg?: string) {
   return async (req: NextRequest) => {
     try {
-      const contentType = req.headers.get("content-type") ?? "";
+      const contentType = req.headers?.get("content-type") ?? "";
       let rawData: unknown;
 
       try {
@@ -27,10 +27,18 @@ export function withValidation<T>(schema: z.ZodSchema<T>, handler: Handler<T>) {
           const form = await req.formData();
           rawData = Object.fromEntries(form.entries());
         } else {
-          // Default to JSON parsing if no content-type is provided or recognized,
-          // but wrap in try-catch in case body is completely empty.
-          const text = await req.text();
-          rawData = text ? JSON.parse(text) : {};
+          // If no content-type is provided (e.g. in test mocks), check available methods
+          if (typeof req.formData === "function") {
+            const form = await req.formData();
+            rawData = Object.fromEntries(form.entries());
+          } else if (typeof req.json === "function") {
+            rawData = await req.json();
+          } else if (typeof req.text === "function") {
+            const text = await req.text();
+            rawData = text ? JSON.parse(text) : {};
+          } else {
+            rawData = {};
+          }
         }
       } catch (parseError) {
         console.error("Payload parse error:", parseError);
@@ -44,7 +52,7 @@ export function withValidation<T>(schema: z.ZodSchema<T>, handler: Handler<T>) {
 
       if (!result.success) {
         return NextResponse.json(
-          { error: "Invalid input", details: result.error.flatten() },
+          { error: customErrorMsg ?? "Invalid input", details: result.error.flatten() },
           { status: 400 }
         );
       }

--- a/src/lib/withValidation.ts
+++ b/src/lib/withValidation.ts
@@ -28,11 +28,11 @@ export function withValidation<T>(schema: z.ZodSchema<T>, handler: Handler<T>, c
           rawData = Object.fromEntries(form.entries());
         } else {
           // If no content-type is provided (e.g. in test mocks), check available methods
-          if (typeof req.formData === "function") {
+          if (typeof req.json === "function") {
+            rawData = await req.json();
+          } else if (typeof req.formData === "function") {
             const form = await req.formData();
             rawData = Object.fromEntries(form.entries());
-          } else if (typeof req.json === "function") {
-            rawData = await req.json();
           } else if (typeof req.text === "function") {
             const text = await req.text();
             rawData = text ? JSON.parse(text) : {};


### PR DESCRIPTION
## Description
This PR implements a secure, real-time user-to-user messaging and connection request system using Pusher. Chat functionality is locked until connection requests are accepted. Real-time updates occur via secure private channels.

## Key Changes

### 1. Security & Pusher Private Channels
- Migrated all real-time events to secure private channels (`private-user-${id}` and `private-chat-${id}`).
- Implemented `/api/pusher/auth` endpoint to authenticate Pusher subscriptions based on user session and database room membership.
- Safe-guarded `getPusherClient()` to return `null` if keys are missing to prevent unconfigured outbound network calls.

### 2. Database Models (`prisma/schema.prisma`)
- Added `ConnectionRequest` (sender, receiver, status: PENDING, ACCEPTED, DECLINED).
- Added `Conversation` (participants relationship).
- Added `Message` (text content and sender mapping).

### 3. API Endpoints
- **`/api/connections`**: Manages connection requests (`send`, `accept`, `decline`). Spawns a conversation when accepted.
- **`/api/conversations`**: Lists active chats with last message preview.
- **`/api/messages`**: Fetches/sends messages, utilizing `Promise.all` to trigger updates concurrently.
- **`/api/matches`**: Extended to fetch user `bio` and `location`.
- **`withValidation` Helper**: Fixed fallback parsing order to try JSON before FormData.
- **Tickets Validation**: Added safety refinements to prevent crashes when file uploads are omitted.

### 4. UI Components
- **`DashboardMatches.tsx`**: Dynamic drawer to review match companion profiles and request/manage connections.
- **`ChatInterface.tsx`**: Two-pane interface supporting list of conversations, real-time message feeds, scroll-to-bottom effects, and pending request approvals.
- **Sidebar**: Integrated the "Messages" link.

---

## Verification & Testing
- Added unit tests for new endpoints. Corrected ticket test mocks for the new Cloudinary pipeline.
- All **50/50 unit/integration tests pass successfully**:
  ```bash
  Test Files  14 passed (14)
  Tests  50 passed (50)