### PR TITLE
refactor: extract reusable credential validation schema

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,7 @@ import AppleProvider from "next-auth/providers/apple";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import prisma from "@/lib/prisma";
 import { compare } from "bcryptjs";
-import { z } from "zod";
+import { credentialsSchema } from "@/lib/validation/auth";
 
 const adapter = PrismaAdapter(prisma) as any;
 
@@ -43,11 +43,7 @@ export const { auth, signIn, signOut, handlers } = NextAuth({
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
-        const schema = z.object({
-          email: z.string().email(),
-          password: z.string().min(8)
-        });
-        const parsed = schema.safeParse(credentials ?? {});
+        const parsed = credentialsSchema.safeParse(credentials ?? {});
         if (!parsed.success) return null;
 
         const { email, password } = parsed.data;

--- a/src/lib/validation/auth.ts
+++ b/src/lib/validation/auth.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const credentialsSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+export type CredentialsInput = z.infer<typeof credentialsSchema>;


### PR DESCRIPTION
## Summary

This PR refactors the authentication credential validation by moving the inline Zod schema into a reusable validation module.

### Changes Made

- Created a dedicated authentication validation module.
- Moved the credential validation schema into the shared module.
- Exported reusable authentication validation schemas.
- Updated the `authorize()` function to use the shared schema.
- Preserved the existing validation behavior.

### Benefits

- Improves code reusability.
- Simplifies maintenance.
- Promotes consistent validation across authentication flows.

Closes #255