### PR TITLE
fix: add per-page SEO metadata, robots.txt, and sitemap.xml

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,6 +1,12 @@
 import ForgotPasswordForm from "@/components/forgot-password-form";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Forgot Password",
+  description: "Reset the password for your travellersmeet account.",
+};
 
 export default async function ForgotPasswordPage() {
   const session = await auth();

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,6 +1,12 @@
 import ResetPasswordForm from "@/components/reset-password-form";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Reset Password",
+  description: "Choose a new password for your travellersmeet account.",
+};
 
 export default async function ResetPasswordPage() {
   const session = await auth();

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,6 +1,12 @@
 import SignInForm from "@/components/sign-in-form";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+  description: "Sign in to your travellersmeet account.",
+};
 
 export default async function SignInPage() {
   const session = await auth();

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,6 +1,12 @@
 import SignUpForm from "@/components/sign-up-form";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign Up",
+  description: "Create your travellersmeet account to connect with verified solo travellers.",
+};
 
 export default async function SignUpPage() {
   const session = await auth();

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,12 @@
 import Link from "next/link";
 import { Users, ShieldCheck, Globe2 } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "travellersmeet helps solo travellers safely connect with others going to the same destination and dates — verified through real tickets.",
+};
 
 export default function AboutPage() {
   return (

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,4 +1,10 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Authentication Error",
+  description: "There was a problem signing you in to travellersmeet.",
+};
 
 interface AuthErrorPageProps {
   searchParams?: {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import { Mail, Send } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact",
+  description:
+    "Questions, safety concerns, or partnership ideas — get in touch with the travellersmeet team.",
+};
 
 export default function ContactPage() {
   return (

--- a/src/app/dashboard/messages/page.tsx
+++ b/src/app/dashboard/messages/page.tsx
@@ -1,6 +1,12 @@
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import ChatInterface from "@/components/ChatInterface";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Messages",
+  description: "Chat with your travellersmeet matches.",
+};
 
 export default async function MessagesPage() {
   const session = await auth();

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,12 @@ import { auth } from "@/lib/auth";
 import Link from "next/link";
 import prisma from "@/lib/prisma";
 import DashboardMatches from "@/components/DashboardMatches";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description: "Manage your travellersmeet profile, matches, and ticket verification.",
+};
 
 export default async function DashboardPage() {
   const session = await auth();

--- a/src/app/dashboard/profile/edit/layout.tsx
+++ b/src/app/dashboard/profile/edit/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Edit Profile",
+  description: "Edit your travellersmeet profile details.",
+};
+
+export default function EditProfileLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/dashboard/profile/layout.tsx
+++ b/src/app/dashboard/profile/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Your Profile",
+  description: "View your travellersmeet profile details.",
+};
+
+export default function ProfileLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/feedback/layout.tsx
+++ b/src/app/feedback/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Feedback",
+  description: "Share feedback or report an issue with travellersmeet.",
+};
+
+export default function FeedbackLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,15 +32,34 @@ export const viewport = {
   userScalable: true,
 };
 
+const siteTitle = "travellersmeet — Meet verified travellers";
+const siteDescription =
+  "Connect with fellow solo travellers going to the same destination. Verified by ticket uploads.";
+
 export const metadata = {
-  title: "travellersmeet — Meet verified travellers",
-  description:
-    "Connect with fellow solo travellers going to the same destination. Verified by ticket uploads.",
+  title: {
+    default: siteTitle,
+    template: "%s — travellersmeet",
+  },
+  description: siteDescription,
   manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",
     title: "travellersmeet",
+  },
+  openGraph: {
+    title: siteTitle,
+    description: siteDescription,
+    siteName: "travellersmeet",
+    images: ["/cover.png"],
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteTitle,
+    description: siteDescription,
+    images: ["/cover.png"],
   },
 };
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "Learn how travellersmeet collects, uses, and protects your account details and ticket-verification data.",
+};
+
 export default function PrivacyPage() {
   return (
     <main className="mx-auto max-w-6xl px-6 py-16">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.NEXTAUTH_URL ||
+  "https://travellers-meet.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/dashboard/", "/auth/", "/demo-routes"],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/routes/page.tsx
+++ b/src/app/routes/page.tsx
@@ -1,6 +1,12 @@
 import SignInForm from "@/components/sign-in-form";
 import { auth } from "@/lib/auth";
 import RoutesClient from "./routes-client";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Your Routes",
+  description: "View and manage your saved travel routes on travellersmeet.",
+};
 
 export default async function RoutesPage() {
   const session = await auth();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.NEXTAUTH_URL ||
+  "https://travellers-meet.vercel.app";
+
+const publicRoutes = [
+  "",
+  "/about",
+  "/contact",
+  "/privacy",
+  "/terms",
+  "/signin",
+  "/signup",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return publicRoutes.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+    changeFrequency: route === "" ? "weekly" : "monthly",
+    priority: route === "" ? 1 : 0.6,
+  }));
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms & Conditions",
+  description:
+    "Read the terms and conditions for using travellersmeet to connect with fellow verified travellers.",
+};
+
 export default function TermsPage() {
   return (
     <main className="mx-auto max-w-6xl px-6 py-16">

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,6 +1,12 @@
 import SignInForm from "@/components/sign-in-form";
 import TicketUploadForm from "@/components/ticket-upload-form";
 import { auth } from "@/lib/auth";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Upload Ticket",
+  description: "Upload your travel ticket to get verified on travellersmeet.",
+};
 
 export default async function UploadPage() {
   const session = await auth();


### PR DESCRIPTION
Fixes #265
Fixes #266

## Problem
Only the root layout (`src/app/layout.tsx`) defined page metadata, so every route — `/about`, `/contact`, `/privacy`, `/terms`, `/dashboard`, the auth pages, etc. — shared the exact same `<title>` and description. Search engines treat that as duplicate content across the whole site. There was also no Open Graph/Twitter Card metadata (shared links show no useful preview) and no `robots.txt` or `sitemap.xml` in any form.

## Fix

**#265 — per-page metadata**
- Root layout now defines a title template (`"%s — travellersmeet"`) plus `openGraph`/`twitter` fields, using `/cover.png` as the share image.
- Added page-specific `title`/`description` to every route.
- Three pages are client components and can't export `metadata` directly (`dashboard/profile`, `dashboard/profile/edit`, `feedback`) — added a sibling server-component `layout.tsx` for each to provide it instead.

**#266 — robots.txt & sitemap.xml**
- `src/app/robots.ts`: allows `/`, disallows `/api/`, `/dashboard/`, `/auth/`, and `/demo-routes` (the last one being the internal testing page tracked separately in #268).
- `src/app/sitemap.ts`: lists the public routes (home, about, contact, privacy, terms, signin, signup) with `lastModified`/`changeFrequency`/`priority`.
- Base URL resolves from `NEXT_PUBLIC_SITE_URL` → `NEXTAUTH_URL` → falls back to the deployed URL (`https://travellers-meet.vercel.app`, per the README's demo link) so it works correctly in prod without extra config.

## Verification
- Ran the dev server locally and confirmed tab titles render correctly per page (e.g. "About — travellersmeet", "Contact — travellersmeet", "Sign In — travellersmeet", "Feedback — travellersmeet" for the client-component case), and that `/robots.txt` and `/sitemap.xml` render with the expected content.
- `npx tsc --noEmit` — clean
- `npm run lint` — no new warnings (pre-existing `<img>`/a11y warnings in unrelated files untouched)
- `npm test` — 50/50 passing

Only metadata/route-handler files touched — no changes to app logic.