### PR TITLE
fix: point footer social icons to a coming-soon page instead of platform homepages

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Coming Soon",
+  description: "Our social media channels are on the way.",
+};
+
+export default function ComingSoonPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-6 bg-white dark:bg-slate-900 transition-colors duration-300">
+      <div className="text-center max-w-xl">
+        <h1 className="text-4xl font-bold text-slate-900 dark:text-white mb-4">
+          Coming Soon
+        </h1>
+
+        <p className="text-lg text-slate-600 dark:text-slate-300 mb-8">
+          We&apos;re still setting up our social media presence — check back soon to follow travellersmeet.
+        </p>
+
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 rounded-lg bg-slate-900 dark:bg-white text-white dark:text-slate-900 font-semibold hover:opacity-90 transition"
+        >
+          Return to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -168,35 +168,29 @@ export default function SiteFooter() {
               <Github className="w-5 h-5 text-slate-600 dark:text-white hover:text-slate-900 dark:hover:text-slate-300 transition-colors duration-300 cursor-pointer" />
             </a>
 
-            <a
-              href="https://twitter.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Twitter"
+            <Link
+              href="/coming-soon"
+              aria-label="Twitter — coming soon"
               className="hover:scale-110 transition-transform duration-200"
             >
               <Twitter className="w-5 h-5 text-slate-600 dark:text-white hover:text-slate-900 dark:hover:text-slate-300 transition-colors duration-300 cursor-pointer" />
-            </a>
+            </Link>
 
-            <a
-              href="https://instagram.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Instagram"
+            <Link
+              href="/coming-soon"
+              aria-label="Instagram — coming soon"
               className="hover:scale-110 transition-transform duration-200"
             >
               <Instagram className="w-5 h-5 text-slate-600 dark:text-white hover:text-slate-900 dark:hover:text-slate-300 transition-colors duration-300 cursor-pointer" />
-            </a>
+            </Link>
 
-            <a
-              href="https://linkedin.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn"
+            <Link
+              href="/coming-soon"
+              aria-label="LinkedIn — coming soon"
               className="hover:scale-110 transition-transform duration-200"
             >
               <FaLinkedin className="w-5 h-5 text-slate-600 dark:text-white hover:text-slate-900 dark:hover:text-slate-300 transition-colors duration-300 cursor-pointer" />
-            </a>
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes #267

## Problem
The Twitter/Instagram/LinkedIn icons in the site footer linked to the generic platform homepages (`https://twitter.com/`, `https://instagram.com/`, `https://linkedin.com/`) instead of a real travellersmeet profile, leading visitors to a dead end.

## Fix
Per [@singh-odyssey's comment on the issue](https://github.com/singh-odyssey/travellers/issues/267#issuecomment-5025973253): there are no real social accounts yet, so — rather than inventing URLs — added a simple `/coming-soon` page and pointed all three footer icons there instead. Switched from `<a target="_blank">` to `next/link` for these three, since they're now internal navigation rather than external links.

## Verification
- Ran the dev server locally: `/coming-soon` renders correctly, and confirmed via the footer icons' actual DOM attributes that all three now point to `/coming-soon` with no `target` attribute.
- `npx tsc --noEmit` — clean
- `npm run lint` — no new warnings
- `npm test` — 50/50 passing

Only `src/components/site-footer.tsx` and the new `src/app/coming-soon/page.tsx` are touched.