### PR TITLE
fix: point footer "Find Travellers" link to the real matches feature

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -52,7 +52,7 @@ export default function SiteFooter() {
             <h3 className="font-semibold mb-3 transition-colors duration-300">Explore</h3>
             <ul className="space-y-2 text-slate-600 dark:text-gray-300 transition-colors duration-300">
               <li>
-                <Link href="/demo-routes" className="hover:text-slate-900 dark:hover:text-white transition-colors">
+                <Link href="/dashboard" className="hover:text-slate-900 dark:hover:text-white transition-colors">
                   Find Travellers
                 </Link>
               </li>


### PR DESCRIPTION
Fixes #268

## Problem
The footer's "Explore" column linked **"Find Travellers"** to `/demo-routes` — an internal developer testing page for the offline route-visualization feature (heading: "🗺️ Demo Routes (No API Key Required)", with a "🧪 Testing Instructions" section), not an actual travellers-matching feature.

## Fix
`/dashboard` is where the real feature already lives — it renders `DashboardMatches` (matches, connection requests, accepted connections) for signed-in users. Pointed the footer link there instead. Anonymous visitors get redirected to sign in first (existing `dashboard/layout.tsx` behavior), which fits the app's verified-travellers model well.

## Verification
- Ran the dev server locally: confirmed via DOM that the "Find Travellers" link's `href` is now `/dashboard`, and that visiting it without a session redirects cleanly to sign-in with no console errors.
- `npx tsc --noEmit` — clean
- `npm run lint` — no new warnings
- `npm test` — 50/50 passing

Only `src/components/site-footer.tsx` touched (one-line change).