### PR TITLE
fix: replace /routes/new test stub with an auth-gated coming-soon page

### DIFF
--- a/src/app/routes/new/new-route-client.tsx
+++ b/src/app/routes/new/new-route-client.tsx
@@ -10,9 +10,6 @@ import { ArrowLeft, Save, MapPin } from "lucide-react";
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-console.log("PlaceAutocomplete:", PlaceAutocomplete);
-console.log("MapLibreRoute:", MapLibreRoute);
-
 export default function NewRouteClient({ userId }: { userId: string }) {
   const router = useRouter();
   

--- a/src/app/routes/new/page.tsx
+++ b/src/app/routes/new/page.tsx
@@ -1,3 +1,47 @@
-export default function Page() {
-  return <h1 style={{ color: "red", fontSize: 60 }}>TEST PAGE</h1>;
+import SignInForm from "@/components/sign-in-form";
+import { auth } from "@/lib/auth";
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "New Route",
+  description: "Create a new travel route on travellersmeet.",
+};
+
+export default async function NewRoutePage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return (
+      <main className="flex flex-col items-center py-6">
+        <div className="mx-auto max-w-md text-center px-6 mb-6">
+          <span className="inline-block rounded-full bg-black/5 dark:bg-white/5 border border-black/10 dark:border-white/10 px-4 py-1 text-xs font-medium tracking-wide text-slate-500 dark:text-slate-400 uppercase">
+            Routes
+          </span>
+          <h1 className="mt-5 text-3xl font-bold text-slate-900 dark:text-white">
+            Sign in to create a route
+          </h1>
+        </div>
+
+        <SignInForm />
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+      <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">
+        Route creation is coming soon
+      </h1>
+      <p className="text-slate-600 dark:text-slate-400 mb-8">
+        We&apos;re still building the route-creation flow. Check back soon to plan your next trip.
+      </p>
+      <Link
+        href="/routes"
+        className="inline-block px-6 py-3 rounded-lg bg-slate-900 dark:bg-white text-white dark:text-slate-900 font-semibold hover:opacity-90 transition"
+      >
+        Back to Routes
+      </Link>
+    </main>
+  );
 }


### PR DESCRIPTION
Fixes #273

## Problem
`src/app/routes/new/page.tsx` was a hardcoded test placeholder:

```tsx
export default function Page() {
  return <h1 style={{ color: "red", fontSize: 60 }}>TEST PAGE</h1>;
}
```

This isn't just a leftover dev route — it's linked twice from the real "My Routes" page (`routes-client.tsx`) as the "Add new route" button, so anyone following the actual in-app flow hits it.

## What I found digging in
The component this was presumably meant to render, `NewRouteClient`, turned out to be unfinished as well — all its state and handlers (origin/destination selection via `PlaceAutocomplete`, save via `routeCacheManager`, a demo-route helper) are defined but never wired into JSX. Its `return` is just `<div>Hello</div>`. Fully building that flow (place autocomplete + map preview + save) is a real feature, not a bug fix, so I kept this PR scoped to the immediate bug: no test/debug content in production.

## Fix
- `page.tsx` is now auth-gated (same pattern as `src/app/upload/page.tsx`): shows a sign-in prompt if there's no session, and otherwise a "Route creation is coming soon" message with a link back to `/routes`.
- Removed two leftover top-level `console.log("PlaceAutocomplete:", ...)` / `console.log("MapLibreRoute:", ...)` debug statements from `new-route-client.tsx` (still unused/unreferenced — left the component itself in place as scaffolding for whoever picks up the real feature).

## Verification
- Ran the dev server locally: unauthenticated visit to `/routes/new` now shows the sign-in prompt (mirrors `/upload`'s behavior) instead of the red test heading.
- `npx tsc --noEmit` — clean
- `npm run lint` — no new warnings
- `npm test` — 50/50 passing