### PR TITLE
fix: remove stray console.log of the full session on dashboard load

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,7 +5,6 @@ import DashboardMatches from "@/components/DashboardMatches";
 
 export default async function DashboardPage() {
   const session = await auth();
-  console.log("SESSION:", session);
   if (!session?.user?.id) {
     return (
       <main className="mx-auto max-w-3xl px-6 py-16">


### PR DESCRIPTION
Fixes #274

## Problem
`src/app/dashboard/page.tsx` logged the entire auth session object (user id, name, email) to the server console on every dashboard request:

```ts
const session = await auth();
console.log("SESSION:", session);
```

## Fix
Removed the line. Searched the rest of the repo for the same pattern (`console.log` printing a session/user object) — this was the only occurrence.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — no new warnings
- `npm test` — 50/50 passing

Single-line change, `src/app/dashboard/page.tsx` only.