### PR TITLE
feat: export saved routes to calendar

### DIFF
--- a/src/app/routes/routes-client.tsx
+++ b/src/app/routes/routes-client.tsx
@@ -5,6 +5,7 @@ import { RouteViewer } from '@/components/route-viewer';
 import { routeCacheManager } from '@/lib/utils/route-cache-manager';
 import type { CachedRoute } from '@/lib/types/route';
 import { Map, Plus, Search, Loader2 } from "lucide-react";
+import RouteCalendarExportButton from '@/components/route-calendar-export-button';
 import Link from 'next/link';
 
 export default function RoutesClient() {
@@ -12,6 +13,7 @@ export default function RoutesClient() {
   const [selectedRoute, setSelectedRoute] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
+  const [statusMessage, setStatusMessage] = useState('');
 
   useEffect(() => {
     loadRoutes();
@@ -93,6 +95,14 @@ export default function RoutesClient() {
       </header>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p
+          className="sr-only"
+          role="status"
+          aria-live="polite"
+        >
+          {statusMessage}
+        </p>
+
         {isLoading ? (
           <div className="flex items-center justify-center h-64">
             <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
@@ -127,32 +137,43 @@ export default function RoutesClient() {
               </h2>
               <div className="space-y-2 max-h-[calc(100vh-300px)] overflow-y-auto">
                 {filteredRoutes.map((route) => (
-                  <button
+                  <div
                     key={route.id}
-                    onClick={() => setSelectedRoute(route.id)}
-                    className={`w-full text-left p-4 rounded-lg border transition-all ${
+                    className={`w-full rounded-lg border p-4 transition-all ${
                       selectedRoute === route.id
                         ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700'
                         : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
                     }`}
                   >
-                    <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
-                      {route.tripName || 'Unnamed Route'}
-                    </h3>
-                    <div className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
-                      <p className="truncate">
-                        From: {route.originName || `${route.origin.lat.toFixed(4)}, ${route.origin.lng.toFixed(4)}`}
-                      </p>
-                      <p className="truncate">
-                        To: {route.destinationName || `${route.destination.lat.toFixed(4)}, ${route.destination.lng.toFixed(4)}`}
-                      </p>
-                    </div>
-                    <div className="mt-2 flex gap-3 text-xs text-gray-500 dark:text-gray-400">
-                      <span>{routeCacheManager.formatDistance(route.distance)}</span>
-                      <span>•</span>
-                      <span>{routeCacheManager.formatDuration(route.duration)}</span>
-                    </div>
-                  </button>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedRoute(route.id)}
+                      className="w-full text-left rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                      aria-label={`View ${route.tripName || 'saved route'} on the map`}
+                    >
+                      <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                        {route.tripName || 'Unnamed Route'}
+                      </h3>
+                      <div className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
+                        <p className="truncate">
+                          From: {route.originName || `${route.origin.lat.toFixed(4)}, ${route.origin.lng.toFixed(4)}`}
+                        </p>
+                        <p className="truncate">
+                          To: {route.destinationName || `${route.destination.lat.toFixed(4)}, ${route.destination.lng.toFixed(4)}`}
+                        </p>
+                      </div>
+                      <div className="mt-2 flex gap-3 text-xs text-gray-500 dark:text-gray-400">
+                        <span>{routeCacheManager.formatDistance(route.distance)}</span>
+                        <span>•</span>
+                        <span>{routeCacheManager.formatDuration(route.duration)}</span>
+                      </div>
+                    </button>
+
+                    <RouteCalendarExportButton
+                      route={route}
+                      onStatusChange={setStatusMessage}
+                    />
+                  </div>
                 ))}
               </div>
             </div>

--- a/src/components/route-calendar-export-button.tsx
+++ b/src/components/route-calendar-export-button.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { CalendarPlus, X } from "lucide-react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+
+import {
+  downloadCalendarEvent,
+  type CalendarRoute,
+} from "@/lib/calendar-export";
+import type { RouteMetadata } from "@/lib/types/route";
+
+interface RouteCalendarExportButtonProps {
+  route: RouteMetadata;
+  onStatusChange?: (message: string) => void;
+}
+
+function getDefaultDate(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 1);
+
+  const offset = date.getTimezoneOffset();
+  const localDate = new Date(date.getTime() - offset * 60_000);
+
+  return localDate.toISOString().slice(0, 10);
+}
+
+function getLocationName(
+  name: string | undefined,
+  coordinates: { lat: number; lng: number },
+): string {
+  return (
+    name?.trim() ||
+    `${coordinates.lat.toFixed(4)}, ${coordinates.lng.toFixed(4)}`
+  );
+}
+
+export default function RouteCalendarExportButton({
+  route,
+  onStatusChange,
+}: RouteCalendarExportButtonProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [departureDate, setDepartureDate] = useState(
+    getDefaultDate,
+  );
+  const [departureTime, setDepartureTime] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    firstInputRef.current?.focus();
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () =>
+      document.removeEventListener("keydown", handleEscape);
+  }, [isOpen]);
+
+  const closeDialog = () => {
+    setError("");
+    setIsOpen(false);
+  };
+
+  const handleExport = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError("");
+
+    try {
+      const origin = getLocationName(
+        route.originName,
+        route.origin,
+      );
+      const destination = getLocationName(
+        route.destinationName,
+        route.destination,
+      );
+
+      const calendarRoute: CalendarRoute = {
+        id: route.id,
+        title:
+          route.tripName?.trim() ||
+          `${origin} to ${destination}`,
+        origin,
+        destination,
+        departureDate,
+        departureTime: departureTime || undefined,
+        durationMinutes:
+          route.duration > 0
+            ? Math.max(1, Math.round(route.duration / 60))
+            : undefined,
+        notes: route.notes,
+        routeUrl:
+          typeof window !== "undefined"
+            ? `${window.location.origin}/routes`
+            : undefined,
+      };
+
+      downloadCalendarEvent(calendarRoute);
+      closeDialog();
+      onStatusChange?.(
+        `Calendar event downloaded for ${calendarRoute.title}.`,
+      );
+    } catch (exportError) {
+      const message =
+        exportError instanceof Error
+          ? exportError.message
+          : "Unable to export this route.";
+
+      setError(message);
+      onStatusChange?.(message);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          setIsOpen(true);
+        }}
+        className="mt-3 inline-flex items-center gap-2 rounded-md border border-blue-200 px-3 py-2 text-xs font-medium text-blue-700 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-950/40 dark:focus:ring-offset-gray-800"
+        aria-label={`Export ${
+          route.tripName || "saved route"
+        } to calendar`}
+      >
+        <CalendarPlus className="h-4 w-4" />
+        Export to Calendar
+      </button>
+
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              closeDialog();
+            }
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={descriptionId}
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl dark:bg-gray-800"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2
+                  id={titleId}
+                  className="text-xl font-semibold text-gray-900 dark:text-gray-100"
+                >
+                  Export route to calendar
+                </h2>
+                <p
+                  id={descriptionId}
+                  className="mt-1 text-sm text-gray-600 dark:text-gray-400"
+                >
+                  Choose the intended travel date. Adding a time is
+                  optional.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={closeDialog}
+                className="rounded-md p-2 text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:hover:bg-gray-700"
+                aria-label="Close calendar export dialog"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <form
+              className="mt-6 space-y-5"
+              onSubmit={handleExport}
+            >
+              <div>
+                <label
+                  htmlFor={`${titleId}-date`}
+                  className="block text-sm font-medium text-gray-800 dark:text-gray-200"
+                >
+                  Travel date
+                </label>
+                <input
+                  ref={firstInputRef}
+                  id={`${titleId}-date`}
+                  type="date"
+                  required
+                  value={departureDate}
+                  onChange={(event) =>
+                    setDepartureDate(event.target.value)
+                  }
+                  className="mt-2 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor={`${titleId}-time`}
+                  className="block text-sm font-medium text-gray-800 dark:text-gray-200"
+                >
+                  Departure time{" "}
+                  <span className="font-normal text-gray-500">
+                    (optional)
+                  </span>
+                </label>
+                <input
+                  id={`${titleId}-time`}
+                  type="time"
+                  value={departureTime}
+                  onChange={(event) =>
+                    setDepartureTime(event.target.value)
+                  }
+                  className="mt-2 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                />
+                <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                  Without a time, the route is exported as an
+                  all-day event.
+                </p>
+              </div>
+
+              {error && (
+                <p
+                  role="alert"
+                  className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-300"
+                >
+                  {error}
+                </p>
+              )}
+
+              <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={closeDialog}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                >
+                  <CalendarPlus className="h-4 w-4" />
+                  Download .ics file
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/__tests__/calendar-export.test.ts
+++ b/src/lib/__tests__/calendar-export.test.ts
@@ -1,0 +1,147 @@
+import {
+  createCalendarEvent,
+  createSafeCalendarFileName,
+  createStableEventUid,
+  downloadCalendarEvent,
+  escapeCalendarText,
+  formatCalendarDate,
+  formatUtcTimestamp,
+} from "@/lib/calendar-export";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const baseRoute = {
+  id: "route-123",
+  title: "Pune to Goa",
+  origin: "Pune",
+  destination: "Goa",
+  departureDate: "2026-08-15",
+  notes: "Pack snacks",
+  routeUrl: "https://travellersmeet.example/routes",
+};
+
+describe("calendar export utility", () => {
+  beforeEach(() => {
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => "blob:calendar-test"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a valid VCALENDAR and VEVENT structure", () => {
+    const calendar = createCalendarEvent(
+      baseRoute,
+      new Date("2026-07-21T12:34:56Z"),
+    );
+
+    expect(calendar).toContain("BEGIN:VCALENDAR\r\n");
+    expect(calendar).toContain("VERSION:2.0\r\n");
+    expect(calendar).toContain("BEGIN:VEVENT\r\n");
+    expect(calendar).toContain(
+      "DTSTAMP:20260721T123456Z\r\n",
+    );
+    expect(calendar).toContain(
+      "DTSTART;VALUE=DATE:20260815\r\n",
+    );
+    expect(calendar).toContain("SUMMARY:Pune to Goa\r\n");
+    expect(calendar).toContain("LOCATION:Goa\r\n");
+    expect(calendar).toContain("END:VEVENT\r\n");
+    expect(calendar.endsWith("END:VCALENDAR\r\n")).toBe(true);
+  });
+
+  it("escapes calendar-reserved characters", () => {
+    expect(
+      escapeCalendarText(
+        "Line one\nLine two, value; C:\\Trips",
+      ),
+    ).toBe("Line one\\nLine two\\, value\\; C:\\\\Trips");
+  });
+
+  it("omits optional fields without producing undefined text", () => {
+    const calendar = createCalendarEvent({
+      id: "route-minimal",
+      title: "Goa trip",
+      destination: "Goa",
+      departureDate: "2026-09-01",
+    });
+
+    expect(calendar).not.toContain("undefined");
+    expect(calendar).not.toContain("\r\nURL:");
+    expect(calendar).toContain(
+      "DESCRIPTION:Travel to Goa.\r\n",
+    );
+  });
+
+  it("formats valid dates and rejects impossible dates", () => {
+    expect(formatCalendarDate("2026-02-28")).toBe("20260228");
+    expect(() => formatCalendarDate("2026-02-30")).toThrow(
+      "Departure date is invalid.",
+    );
+  });
+
+  it("formats UTC timestamps", () => {
+    expect(
+      formatUtcTimestamp(
+        new Date("2026-01-02T03:04:05.000Z"),
+      ),
+    ).toBe("20260102T030405Z");
+  });
+
+  it("generates a stable event UID", () => {
+    expect(createStableEventUid(" Route 123 ")).toBe(
+      "route-123@travellersmeet",
+    );
+    expect(createStableEventUid(" Route 123 ")).toBe(
+      createStableEventUid(" Route 123 "),
+    );
+  });
+
+  it("creates readable and safe calendar filenames", () => {
+    expect(
+      createSafeCalendarFileName("Pune / Goa: Road Trip!"),
+    ).toBe("pune-goa-road-trip.ics");
+  });
+
+  it("includes date-time and duration when a time is selected", () => {
+    const calendar = createCalendarEvent({
+      ...baseRoute,
+      departureTime: "09:30",
+      durationMinutes: 120,
+    });
+
+    expect(calendar).toContain("DTSTART:20260815T093000\r\n");
+    expect(calendar).toContain("DTEND:20260815T113000\r\n");
+  });
+
+  it("downloads the ICS file and revokes the Blob URL", () => {
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:calendar-test");
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => undefined);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    downloadCalendarEvent(baseRoute);
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(click).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith(
+      "blob:calendar-test",
+    );
+    expect(
+      document.querySelector('a[download$=".ics"]'),
+    ).toBeNull();
+  });
+});

--- a/src/lib/calendar-export.ts
+++ b/src/lib/calendar-export.ts
@@ -1,0 +1,231 @@
+export interface CalendarRoute {
+  id: string;
+  title: string;
+  origin?: string;
+  destination: string;
+  departureDate: string;
+  departureTime?: string;
+  durationMinutes?: number;
+  notes?: string;
+  routeUrl?: string;
+}
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_PATTERN = /^\d{2}:\d{2}$/;
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+export function escapeCalendarText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\r\n|\r|\n/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;");
+}
+
+export function formatUtcTimestamp(date: Date): string {
+  return [
+    date.getUTCFullYear(),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    "T",
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+    "Z",
+  ].join("");
+}
+
+export function formatCalendarDate(date: string): string {
+  if (!DATE_ONLY_PATTERN.test(date)) {
+    throw new Error("Departure date must use YYYY-MM-DD format.");
+  }
+
+  const [year, month, day] = date.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    throw new Error("Departure date is invalid.");
+  }
+
+  return `${year}${pad(month)}${pad(day)}`;
+}
+
+export function formatLocalDateTime(
+  date: string,
+  time: string,
+): string {
+  const formattedDate = formatCalendarDate(date);
+
+  if (!TIME_PATTERN.test(time)) {
+    throw new Error("Departure time must use HH:mm format.");
+  }
+
+  const [hours, minutes] = time.split(":").map(Number);
+
+  if (hours > 23 || minutes > 59) {
+    throw new Error("Departure time is invalid.");
+  }
+
+  return `${formattedDate}T${pad(hours)}${pad(minutes)}00`;
+}
+
+export function createStableEventUid(routeId: string): string {
+  const normalizedId = routeId
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return `${normalizedId || "saved-route"}@travellersmeet`;
+}
+
+export function createSafeCalendarFileName(title: string): string {
+  const normalizedTitle = title
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9-_ ]+/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .toLowerCase();
+
+  return `${normalizedTitle || "saved-route"}.ics`;
+}
+
+function buildDescription(route: CalendarRoute): string {
+  const parts = [
+    route.origin
+      ? `Travel from ${route.origin} to ${route.destination}.`
+      : `Travel to ${route.destination}.`,
+    route.notes?.trim(),
+  ].filter(Boolean);
+
+  return parts.join("\n\n");
+}
+
+export function createCalendarEvent(
+  route: CalendarRoute,
+  now = new Date(),
+): string {
+  const title = route.title.trim() || "Saved travel route";
+  const destination = route.destination.trim();
+
+  if (!destination) {
+    throw new Error("Destination is required.");
+  }
+
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//TravellersMeet//Saved Route//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${createStableEventUid(route.id)}`,
+    `DTSTAMP:${formatUtcTimestamp(now)}`,
+  ];
+
+  if (route.departureTime) {
+    lines.push(
+      `DTSTART:${formatLocalDateTime(
+        route.departureDate,
+        route.departureTime,
+      )}`,
+    );
+
+    if (
+      typeof route.durationMinutes === "number" &&
+      Number.isFinite(route.durationMinutes) &&
+      route.durationMinutes > 0
+    ) {
+      const [year, month, day] = route.departureDate
+        .split("-")
+        .map(Number);
+      const [hours, minutes] = route.departureTime
+        .split(":")
+        .map(Number);
+
+      const start = new Date(
+        year,
+        month - 1,
+        day,
+        hours,
+        minutes,
+        0,
+      );
+      const end = new Date(
+        start.getTime() + route.durationMinutes * 60_000,
+      );
+
+      lines.push(
+        `DTEND:${[
+          end.getFullYear(),
+          pad(end.getMonth() + 1),
+          pad(end.getDate()),
+          "T",
+          pad(end.getHours()),
+          pad(end.getMinutes()),
+          "00",
+        ].join("")}`,
+      );
+    }
+  } else {
+    lines.push(
+      `DTSTART;VALUE=DATE:${formatCalendarDate(
+        route.departureDate,
+      )}`,
+    );
+  }
+
+  lines.push(
+    `SUMMARY:${escapeCalendarText(title)}`,
+    `DESCRIPTION:${escapeCalendarText(buildDescription(route))}`,
+    `LOCATION:${escapeCalendarText(destination)}`,
+  );
+
+  if (route.routeUrl?.trim()) {
+    lines.push(`URL:${route.routeUrl.trim()}`);
+  }
+
+  lines.push("END:VEVENT", "END:VCALENDAR", "");
+
+  return lines.join("\r\n");
+}
+
+export function downloadCalendarEvent(
+  route: CalendarRoute,
+): void {
+  if (
+    typeof document === "undefined" ||
+    typeof URL === "undefined"
+  ) {
+    throw new Error(
+      "Calendar downloads are only available in the browser.",
+    );
+  }
+
+  const content = createCalendarEvent(route);
+  const blob = new Blob([content], {
+    type: "text/calendar;charset=utf-8",
+  });
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+
+  try {
+    anchor.href = objectUrl;
+    anchor.download = createSafeCalendarFileName(route.title);
+    anchor.style.display = "none";
+    document.body.appendChild(anchor);
+    anchor.click();
+  } finally {
+    anchor.remove();
+    URL.revokeObjectURL(objectUrl);
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue

Closes #235

## 📝 Description

This PR adds browser-based calendar export for saved travel routes.

Saved routes do not currently persist a travel date, so the export action opens
an accessible dialog where the user selects the intended travel date and an
optional departure time. This keeps the feature within the issue's no-schema
and no-API-change constraints.

### Changes made

- Added a reusable iCalendar (`.ics`) generation utility.
- Added proper escaping for backslashes, new lines, commas, and semicolons.
- Added UTC `DTSTAMP`, stable `UID`, summary, description, location, and route URL.
- Added readable, filesystem-safe download names.
- Added an **Export to Calendar** action to each saved-route card.
- Added an accessible date/time dialog.
- Exported routes without a time as all-day events.
- Used stored route duration to set `DTEND` for timed events.
- Revoked temporary Blob URLs after downloads.
- Added an `aria-live` status message.
- Added unit tests for structure, escaping, date validation, timestamps, stable
  identifiers, safe filenames, optional fields, timed events, downloads, and
  Blob URL cleanup.

## 🛠️ Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🎨 UI/UX enhancement
- [ ] 📚 Documentation update
- [x] 🧪 Tests

## 🧪 Testing Performed

- [ ] `npx vitest run src/lib/__tests__/calendar-export.test.ts`
- [ ] `npm test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run lint`
- [ ] Imported an all-day `.ics` event into a calendar application
- [ ] Imported a timed `.ics` event into a calendar application
- [ ] Verified keyboard access and Escape-to-close
- [ ] Verified existing saved-route selection and map behavior
- [ ] Checked the browser console for new errors

## ✅ Scope Verification

- [x] No Prisma model or migration was added.
- [x] No API endpoint was added or changed.
- [x] No OAuth or calendar SDK was added.
- [x] No external dependency was added.
- [x] Existing saved-route CRUD behavior remains unchanged.