### PR TITLE
feat: add Redis rate limiting to sensitive APIs

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,50 @@
 import { handlers } from "@/lib/auth";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  getRateLimitIdentifier,
+  rateLimitExceededResponse,
+} from "@/lib/rate-limit";
+import type { NextRequest } from "next/server";
 
-export const { GET, POST } = handlers;
+export const GET = handlers.GET;
+
+function isCredentialsCallback(request: NextRequest): boolean {
+  return request.nextUrl.pathname.endsWith(
+    "/api/auth/callback/credentials",
+  );
+}
+
+async function getCredentialsEmail(
+  request: NextRequest,
+): Promise<string | null> {
+  try {
+    const form = await request.clone().formData();
+    const email = form.get("email");
+
+    return typeof email === "string" ? email : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  if (!isCredentialsCallback(request)) {
+    return handlers.POST(request);
+  }
+
+  const email = await getCredentialsEmail(request);
+  const rateLimit = await checkRateLimit({
+    namespace: "auth:signin",
+    identifier: getRateLimitIdentifier(request, email),
+    limit: 10,
+    windowSeconds: 10 * 60,
+  });
+
+  if (!rateLimit.allowed) {
+    return rateLimitExceededResponse(rateLimit);
+  }
+
+  const response = await handlers.POST(request);
+  return applyRateLimitHeaders(response, rateLimit);
+}

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -4,6 +4,12 @@ import { z } from "zod";
 import crypto from "crypto";
 import { sendPasswordResetEmail } from "@/lib/email";
 import { withValidation } from "@/lib/withValidation";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  getRateLimitIdentifier,
+  rateLimitExceededResponse,
+} from "@/lib/rate-limit";
 
 const forgotPasswordSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -13,15 +19,29 @@ export const POST = withValidation(forgotPasswordSchema, async (req, data) => {
   try {
     const { email } = data;
 
+    const rateLimit = await checkRateLimit({
+      namespace: "auth:forgot-password",
+      identifier: getRateLimitIdentifier(req, email),
+      limit: 3,
+      windowSeconds: 15 * 60,
+    });
+
+    if (!rateLimit.allowed) {
+      return rateLimitExceededResponse(rateLimit);
+    }
+
     // Find user
     const user = await prisma.user.findUnique({ where: { email } });
-    
+
     // To prevent email enumeration, return a generic success message even if email doesn't exist
     if (!user) {
-      return NextResponse.json({
-        ok: true,
-        message: "If an account exists with this email, a password reset link has been sent.",
-      });
+      return applyRateLimitHeaders(
+        NextResponse.json({
+          ok: true,
+          message: "If an account exists with this email, a password reset link has been sent.",
+        }),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Generate secure reset token and expiry (1 hour)
@@ -44,10 +64,13 @@ export const POST = withValidation(forgotPasswordSchema, async (req, data) => {
       console.error("Forgot password email error (non-fatal):", emailError);
     }
 
-    return NextResponse.json({
-      ok: true,
-      message: "If an account exists with this email, a password reset link has been sent.",
-    });
+    return applyRateLimitHeaders(
+      NextResponse.json({
+        ok: true,
+        message: "If an account exists with this email, a password reset link has been sent.",
+      }),
+      rateLimit,
+    ) as NextResponse;
   } catch (error) {
     console.error("Forgot password error:", error);
     return NextResponse.json(

--- a/src/app/api/auth/resend-otp/route.ts
+++ b/src/app/api/auth/resend-otp/route.ts
@@ -4,6 +4,12 @@ import { z } from "zod";
 import { generateOTP } from "@/lib/otp";
 import { sendOTPEmail } from "@/lib/email";
 import { withValidation } from "@/lib/withValidation";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  getRateLimitIdentifier,
+  rateLimitExceededResponse,
+} from "@/lib/rate-limit";
 
 const resendSchema = z.object({
   email: z.string().email("Invalid email"),
@@ -13,21 +19,38 @@ export const POST = withValidation(resendSchema, async (req, data) => {
   try {
     const { email } = data;
 
+    const rateLimit = await checkRateLimit({
+      namespace: "auth:resend-otp",
+      identifier: getRateLimitIdentifier(req, email),
+      limit: 3,
+      windowSeconds: 10 * 60,
+    });
+
+    if (!rateLimit.allowed) {
+      return rateLimitExceededResponse(rateLimit);
+    }
+
     // Find user
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) {
-      return NextResponse.json(
-        { error: "User not found" },
-        { status: 404 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "User not found" },
+          { status: 404 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Check if already verified
     if (user.emailVerified) {
-      return NextResponse.json(
-        { error: "Email already verified" },
-        { status: 400 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "Email already verified" },
+          { status: 400 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Generate new OTP
@@ -43,10 +66,13 @@ export const POST = withValidation(resendSchema, async (req, data) => {
     // Send OTP email
     await sendOTPEmail(email, otp);
 
-    return NextResponse.json({ 
-      ok: true, 
-      message: "New OTP sent to your email" 
-    });
+    return applyRateLimitHeaders(
+      NextResponse.json({
+        ok: true,
+        message: "New OTP sent to your email",
+      }),
+      rateLimit,
+    ) as NextResponse;
   } catch (error) {
     console.error("Resend OTP error:", error);
     return NextResponse.json({ error: "Server error" }, { status: 500 });

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -6,6 +6,12 @@ import { z } from "zod";
 import { generateOTP } from "@/lib/otp";
 import { sendOTPEmail } from "@/lib/email";
 import { withValidation } from "@/lib/withValidation";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  getRateLimitIdentifier,
+  rateLimitExceededResponse,
+} from "@/lib/rate-limit";
 
 const signupSchema = z.object({
   name: z.string().min(1, "Name required"),
@@ -21,16 +27,30 @@ export const POST = withValidation(
     try {
       const { name, email, password } = data;
 
+      const rateLimit = await checkRateLimit({
+        namespace: "auth:signup",
+        identifier: getRateLimitIdentifier(_req, email),
+        limit: 5,
+        windowSeconds: 60 * 60,
+      });
+
+      if (!rateLimit.allowed) {
+        return rateLimitExceededResponse(rateLimit);
+      }
+
       // Check whether a user already exists with this email.
       const existingUser = await prisma.user.findUnique({
         where: { email },
       });
 
       if (existingUser) {
-        return NextResponse.json(
-          { error: "Email already in use" },
-          { status: 400 },
-        );
+        return applyRateLimitHeaders(
+          NextResponse.json(
+            { error: "Email already in use" },
+            { status: 400 },
+          ),
+          rateLimit,
+        ) as NextResponse;
       }
 
       // Use stronger password hashing in production while keeping
@@ -64,22 +84,28 @@ export const POST = withValidation(
           emailResult.error,
         );
 
-        return NextResponse.json(
-          {
-            ok: true,
-            userId: user.id,
-            error:
-              "Account created, but we couldn't send the verification email. Please use 'Resend OTP' or contact support.",
-          },
-          { status: 207 },
-        );
+        return applyRateLimitHeaders(
+          NextResponse.json(
+            {
+              ok: true,
+              userId: user.id,
+              error:
+                "Account created, but we couldn't send the verification email. Please use 'Resend OTP' or contact support.",
+            },
+            { status: 207 },
+          ),
+          rateLimit,
+        ) as NextResponse;
       }
 
-      return NextResponse.json({
-        ok: true,
-        userId: user.id,
-        message: "OTP sent to your email",
-      });
+      return applyRateLimitHeaders(
+        NextResponse.json({
+          ok: true,
+          userId: user.id,
+          message: "OTP sent to your email",
+        }),
+        rateLimit,
+      ) as NextResponse;
     } catch (error) {
       console.error("Signup error:", error);
 

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -3,6 +3,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { isValidOTPFormat } from "@/lib/otp";
 import { withValidation } from "@/lib/withValidation";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  getRateLimitIdentifier,
+  rateLimitExceededResponse,
+} from "@/lib/rate-limit";
 
 const verifySchema = z.object({
   email: z.string().email("Invalid email"),
@@ -13,52 +19,81 @@ export const POST = withValidation(verifySchema, async (req, data) => {
   try {
     const { email, otp } = data;
 
+    const rateLimit = await checkRateLimit({
+      namespace: "auth:verify-otp",
+      identifier: getRateLimitIdentifier(req, email),
+      limit: 10,
+      windowSeconds: 10 * 60,
+    });
+
+    if (!rateLimit.allowed) {
+      return rateLimitExceededResponse(rateLimit);
+    }
+
     if (!isValidOTPFormat(otp)) {
-      return NextResponse.json(
-        { error: "Invalid OTP format" },
-        { status: 400 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "Invalid OTP format" },
+          { status: 400 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Find user
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) {
-      return NextResponse.json(
-        { error: "User not found" },
-        { status: 404 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "User not found" },
+          { status: 404 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Check if already verified
     if (user.emailVerified) {
-      return NextResponse.json(
-        { error: "Email already verified" },
-        { status: 400 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "Email already verified" },
+          { status: 400 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Check OTP
     if (!user.otp || !user.otpExpires) {
-      return NextResponse.json(
-        { error: "No OTP found. Please request a new one." },
-        { status: 400 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "No OTP found. Please request a new one." },
+          { status: 400 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Check if expired
     if (new Date() > user.otpExpires) {
-      return NextResponse.json(
-        { error: "OTP has expired. Please request a new one." },
-        { status: 400 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "OTP has expired. Please request a new one." },
+          { status: 400 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Verify OTP
     if (user.otp !== otp) {
-      return NextResponse.json(
-        { error: "Invalid OTP" },
-        { status: 400 }
-      );
+      return applyRateLimitHeaders(
+        NextResponse.json(
+          { error: "Invalid OTP" },
+          { status: 400 },
+        ),
+        rateLimit,
+      ) as NextResponse;
     }
 
     // Mark as verified and clear OTP
@@ -71,10 +106,13 @@ export const POST = withValidation(verifySchema, async (req, data) => {
       },
     });
 
-    return NextResponse.json({ 
-      ok: true, 
-      message: "Email verified successfully" 
-    });
+    return applyRateLimitHeaders(
+      NextResponse.json({
+        ok: true,
+        message: "Email verified successfully",
+      }),
+      rateLimit,
+    ) as NextResponse;
   } catch (error) {
     console.error("Verify OTP error:", error);
     return NextResponse.json({ error: "Server error" }, { status: 500 });

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -4,6 +4,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withValidation } from "@/lib/withValidation";
 import { uploadFileToCloudinary } from "@/lib/cloudinary-upload";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  getRateLimitIdentifier,
+  rateLimitExceededResponse,
+} from "@/lib/rate-limit";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -37,6 +43,17 @@ export const POST = withValidation(ticketSchema, async (req, data) => {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const rateLimit = await checkRateLimit({
+    namespace: "tickets:upload",
+    identifier: getRateLimitIdentifier(req, session.user.id),
+    limit: 5,
+    windowSeconds: 60 * 60,
+  });
+
+  if (!rateLimit.allowed) {
+    return rateLimitExceededResponse(rateLimit);
+  }
+
   try {
     const { destination, departureDate, file } = data;
 
@@ -57,7 +74,10 @@ export const POST = withValidation(ticketSchema, async (req, data) => {
       },
     });
 
-    return NextResponse.json({ ok: true, ticket });
+    return applyRateLimitHeaders(
+      NextResponse.json({ ok: true, ticket }),
+      rateLimit,
+    ) as NextResponse;
   } catch (error) {
     console.error("Ticket upload error:", error);
     return NextResponse.json(

--- a/src/lib/__tests__/client-ip.test.ts
+++ b/src/lib/__tests__/client-ip.test.ts
@@ -1,0 +1,41 @@
+import { getClientIp } from "@/lib/client-ip";
+import { describe, expect, it } from "vitest";
+
+function requestWithHeaders(
+  headers: Record<string, string>,
+): Parameters<typeof getClientIp>[0] {
+  return {
+    headers: new Headers(headers),
+  } as Parameters<typeof getClientIp>[0];
+}
+
+describe("getClientIp", () => {
+  it("uses the first valid forwarded address", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "203.0.113.5, 10.0.0.2",
+    });
+
+    expect(getClientIp(request)).toBe("203.0.113.5");
+  });
+
+  it("falls back to platform IP headers", () => {
+    const request = requestWithHeaders({
+      "x-real-ip": "198.51.100.7",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.7");
+  });
+
+  it("ignores malformed forwarded values", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "not-an-ip",
+      "cf-connecting-ip": "192.0.2.20",
+    });
+
+    expect(getClientIp(request)).toBe("192.0.2.20");
+  });
+
+  it("returns an anonymous fallback when no IP is available", () => {
+    expect(getClientIp(requestWithHeaders({}))).toBe("unknown");
+  });
+});

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,150 @@
+import {
+  applyRateLimitHeaders,
+  buildRateLimitKey,
+  checkRateLimit,
+  rateLimitExceededResponse,
+  type RateLimitStore,
+} from "@/lib/rate-limit";
+import { describe, expect, it, vi } from "vitest";
+
+class MemoryRateLimitStore implements RateLimitStore {
+  private readonly counts = new Map<string, number>();
+
+  async eval(
+    _script: string,
+    _numberOfKeys: number,
+    key: string,
+    windowSeconds: number,
+  ): Promise<[number, number]> {
+    const count = (this.counts.get(key) ?? 0) + 1;
+    this.counts.set(key, count);
+    return [count, windowSeconds];
+  }
+}
+
+describe("checkRateLimit", () => {
+  it("allows requests under the configured limit", async () => {
+    const store = new MemoryRateLimitStore();
+
+    const result = await checkRateLimit({
+      namespace: "auth:test",
+      identifier: "user@example.com|203.0.113.5",
+      limit: 3,
+      windowSeconds: 60,
+      store,
+      now: () => 1_000_000,
+    });
+
+    expect(result).toMatchObject({
+      allowed: true,
+      limit: 3,
+      remaining: 2,
+      resetAt: 1060,
+      retryAfter: 0,
+      bypassed: false,
+    });
+  });
+
+  it("blocks requests above the limit", async () => {
+    const store = new MemoryRateLimitStore();
+    const options = {
+      namespace: "auth:test",
+      identifier: "user@example.com|203.0.113.5",
+      limit: 2,
+      windowSeconds: 90,
+      store,
+      now: () => 2_000_000,
+    };
+
+    await checkRateLimit(options);
+    await checkRateLimit(options);
+    const blocked = await checkRateLimit(options);
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfter).toBe(90);
+  });
+
+  it("keeps different identities in separate buckets", async () => {
+    const store = new MemoryRateLimitStore();
+
+    const first = await checkRateLimit({
+      namespace: "auth:test",
+      identifier: "first@example.com|203.0.113.5",
+      limit: 1,
+      windowSeconds: 60,
+      store,
+    });
+    const second = await checkRateLimit({
+      namespace: "auth:test",
+      identifier: "second@example.com|203.0.113.5",
+      limit: 1,
+      windowSeconds: 60,
+      store,
+    });
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+  });
+
+  it("fails open when Redis is unavailable", async () => {
+    const store: RateLimitStore = {
+      eval: vi.fn().mockRejectedValue(new Error("Redis offline")),
+    };
+
+    const result = await checkRateLimit({
+      namespace: "auth:test",
+      identifier: "user@example.com",
+      limit: 3,
+      windowSeconds: 60,
+      store,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.bypassed).toBe(true);
+  });
+
+  it("does not expose raw identifiers in Redis keys", () => {
+    const key = buildRateLimitKey(
+      "auth:signin",
+      "Secret.User@example.com|203.0.113.5",
+    );
+
+    expect(key).toMatch(/^rate-limit:auth:signin:[a-f0-9]{32}$/);
+    expect(key).not.toContain("Secret.User");
+    expect(key).not.toContain("203.0.113.5");
+  });
+});
+
+describe("rate-limit responses", () => {
+  const result = {
+    allowed: false,
+    limit: 3,
+    remaining: 0,
+    resetAt: 1234,
+    retryAfter: 42,
+    bypassed: false,
+  };
+
+  it("adds standard headers", () => {
+    const response = applyRateLimitHeaders(
+      new Response(null, { status: 204 }),
+      result,
+    );
+
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("3");
+    expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(response.headers.get("X-RateLimit-Reset")).toBe("1234");
+    expect(response.headers.get("Retry-After")).toBe("42");
+  });
+
+  it("returns a 429 response with retry information", async () => {
+    const response = rateLimitExceededResponse(result);
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toEqual({
+      error: "Too many requests",
+      retryAfter: 42,
+    });
+  });
+});

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -1,0 +1,64 @@
+import { isIP } from "node:net";
+import type { NextRequest } from "next/server";
+
+const UNKNOWN_CLIENT = "unknown";
+
+function normalizeIp(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const candidate = value.trim();
+
+  if (!candidate) {
+    return null;
+  }
+
+  const withoutPort =
+    candidate.startsWith("[") && candidate.includes("]")
+      ? candidate.slice(1, candidate.indexOf("]"))
+      : candidate.replace(/^::ffff:/, "");
+
+  if (isIP(withoutPort)) {
+    return withoutPort;
+  }
+
+  const ipv4WithPort = withoutPort.match(/^(\d{1,3}(?:\.\d{1,3}){3}):\d+$/);
+  if (ipv4WithPort && isIP(ipv4WithPort[1])) {
+    return ipv4WithPort[1];
+  }
+
+  return null;
+}
+
+/**
+ * Returns the first valid client IP exposed by the deployment platform.
+ * Raw header values are never used directly as Redis keys.
+ */
+export function getClientIp(request: NextRequest): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+
+  if (forwardedFor) {
+    for (const value of forwardedFor.split(",")) {
+      const parsed = normalizeIp(value);
+      if (parsed) {
+        return parsed;
+      }
+    }
+  }
+
+  const platformHeaders = [
+    request.headers.get("x-real-ip"),
+    request.headers.get("cf-connecting-ip"),
+    request.headers.get("fly-client-ip"),
+  ];
+
+  for (const value of platformHeaders) {
+    const parsed = normalizeIp(value);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  return UNKNOWN_CLIENT;
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { getClientIp } from "@/lib/client-ip";
+import redis from "@/lib/redis";
+
+const RATE_LIMIT_SCRIPT = `
+local current = redis.call("INCR", KEYS[1])
+if current == 1 then
+  redis.call("EXPIRE", KEYS[1], ARGV[1])
+end
+local ttl = redis.call("TTL", KEYS[1])
+return { current, ttl }
+`;
+
+export interface RateLimitStore {
+  eval(
+    script: string,
+    numberOfKeys: number,
+    key: string,
+    windowSeconds: number,
+  ): Promise<unknown>;
+}
+
+export interface RateLimitRule {
+  namespace: string;
+  limit: number;
+  windowSeconds: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+  retryAfter: number;
+  bypassed: boolean;
+}
+
+interface RateLimitOptions extends RateLimitRule {
+  identifier: string;
+  store?: RateLimitStore | null;
+  now?: () => number;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.floor(parsed)
+    : fallback;
+}
+
+function hashIdentifier(identifier: string): string {
+  return createHash("sha256")
+    .update(identifier.trim().toLowerCase())
+    .digest("hex")
+    .slice(0, 32);
+}
+
+export function buildRateLimitKey(
+  namespace: string,
+  identifier: string,
+): string {
+  const safeNamespace = namespace
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9:_-]+/g, "-");
+
+  return `rate-limit:${safeNamespace}:${hashIdentifier(identifier)}`;
+}
+
+export async function checkRateLimit({
+  namespace,
+  identifier,
+  limit,
+  windowSeconds,
+  store = redis,
+  now = () => Date.now(),
+}: RateLimitOptions): Promise<RateLimitResult> {
+  const safeLimit = positiveInteger(limit, 1);
+  const safeWindow = positiveInteger(windowSeconds, 60);
+  const nowSeconds = Math.floor(now() / 1000);
+
+  if (!store) {
+    return {
+      allowed: true,
+      limit: safeLimit,
+      remaining: safeLimit,
+      resetAt: nowSeconds + safeWindow,
+      retryAfter: 0,
+      bypassed: true,
+    };
+  }
+
+  try {
+    const result = await store.eval(
+      RATE_LIMIT_SCRIPT,
+      1,
+      buildRateLimitKey(namespace, identifier),
+      safeWindow,
+    );
+
+    const values = Array.isArray(result) ? result : [];
+    const current = positiveInteger(values[0], 1);
+    const ttl = positiveInteger(values[1], safeWindow);
+    const allowed = current <= safeLimit;
+
+    return {
+      allowed,
+      limit: safeLimit,
+      remaining: Math.max(0, safeLimit - current),
+      resetAt: nowSeconds + ttl,
+      retryAfter: allowed ? 0 : ttl,
+      bypassed: false,
+    };
+  } catch (error) {
+    console.warn(
+      "Rate limiter unavailable; allowing request:",
+      error instanceof Error ? error.message : error,
+    );
+
+    return {
+      allowed: true,
+      limit: safeLimit,
+      remaining: safeLimit,
+      resetAt: nowSeconds + safeWindow,
+      retryAfter: 0,
+      bypassed: true,
+    };
+  }
+}
+
+export function getRateLimitIdentifier(
+  request: NextRequest,
+  subject?: string | null,
+): string {
+  const ip = getClientIp(request);
+  const normalizedSubject = subject?.trim().toLowerCase();
+
+  return normalizedSubject
+    ? `${normalizedSubject}|${ip}`
+    : ip;
+}
+
+export function applyRateLimitHeaders(
+  response: Response,
+  result: RateLimitResult,
+): Response {
+  response.headers.set(
+    "X-RateLimit-Limit",
+    String(result.limit),
+  );
+  response.headers.set(
+    "X-RateLimit-Remaining",
+    String(result.remaining),
+  );
+  response.headers.set(
+    "X-RateLimit-Reset",
+    String(result.resetAt),
+  );
+
+  if (!result.allowed) {
+    response.headers.set(
+      "Retry-After",
+      String(result.retryAfter),
+    );
+  }
+
+  return response;
+}
+
+export function rateLimitExceededResponse(
+  result: RateLimitResult,
+): NextResponse {
+  return applyRateLimitHeaders(
+    NextResponse.json(
+      {
+        error: "Too many requests",
+        retryAfter: result.retryAfter,
+      },
+      { status: 429 },
+    ),
+    result,
+  ) as NextResponse;
+}


### PR DESCRIPTION
## 🔗 Related Issue

Closes #285

## 📝 Description

This PR adds reusable Redis-backed rate limiting for sensitive authentication and ticket-upload endpoints.

### Protected flows

* Credentials sign-in: 10 requests per 10 minutes
* Sign up: 5 requests per hour
* Forgot password: 3 requests per 15 minutes
* Resend OTP: 3 requests per 10 minutes
* OTP verification: 10 requests per 10 minutes
* Ticket upload: 5 requests per hour per authenticated user

### Implementation details

* Added validated client-IP extraction.
* Added hashed, namespaced Redis keys so raw emails, user IDs, OTPs, passwords, and IP addresses are never stored in rate-limit keys.
* Added an atomic Redis Lua script for increment, expiry, and TTL retrieval.
* Added `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers.
* Added HTTP 429 responses with `Retry-After`.
* Added fail-open behavior when Redis is missing or temporarily unavailable.
* Wrapped the actual NextAuth credentials callback instead of only the `/api/auth/signin` compatibility route.
* Preserved existing endpoint response bodies and status codes when requests remain within their limits.
* Added unit tests for IP extraction, allowed and blocked requests, identity isolation, safe key generation, response headers, HTTP 429 responses, and Redis outages.

## 🛠️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [x] 🔐 Security improvement
* [ ] 📚 Documentation update
* [x] 🧪 Tests

## 🧪 Testing Performed

* [ ] `npx vitest run src/lib/__tests__/client-ip.test.ts`
* [ ] `npx vitest run src/lib/__tests__/rate-limit.test.ts`
* [ ] `npm test`
* [ ] `npx tsc --noEmit`
* [ ] `npm run lint`
* [ ] Confirmed allowed responses contain rate-limit headers
* [ ] Confirmed requests above the limit return HTTP 429
* [ ] Confirmed separate users and emails use separate buckets
* [ ] Confirmed Redis failures do not crash protected endpoints

## ✅ Scope Verification

* [x] No Prisma model or migration was added.
* [x] No external dependency was added.
* [x] Raw passwords and OTPs are never used in Redis keys.
* [x] Existing API behavior remains compatible below the configured limits.
