### PR TITLE
feat: add cursor pagination to collection APIs

### DIFF
--- a/src/app/api/admin/tickets/route.ts
+++ b/src/app/api/admin/tickets/route.ts
@@ -21,34 +21,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Unauthorized" },
       { status: 401 },
-<<<<<<< HEAD
-import { NextRequest } from "next/server";
-
-import {
-  API_ERROR_CODES,
-  logApiError,
-} from "@/lib/api-error";
-import { apiError, apiJson } from "@/lib/api-response";
-import { auth } from "@/lib/auth";
-import prisma from "@/lib/prisma";
-import { getRequestId } from "@/lib/request-id";
-
-const VALID_STATUSES = new Set<string>(
-  Object.values(TicketStatus),
-);
-
-export async function GET(request: NextRequest) {
-  const requestId = getRequestId(request);
-  const session = await auth();
-
-  if (!session?.user?.id) {
-    return apiError(
-      requestId,
-      API_ERROR_CODES.UNAUTHORIZED,
-      "Authentication is required",
-      401,
-=======
->>>>>>> a057bee (Fixed ci build error)
     );
   }
 
@@ -62,14 +34,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         { error: "Forbidden" },
         { status: 403 },
-<<<<<<< HEAD
-      return apiError(
-        requestId,
-        API_ERROR_CODES.FORBIDDEN,
-        "Administrator access is required",
-        403,
-=======
->>>>>>> a057bee (Fixed ci build error)
       );
     }
 
@@ -106,27 +70,6 @@ export async function GET(request: NextRequest) {
           : {}),
         ...(cursorWhere ?? {}),
       },
-<<<<<<< HEAD
-    if (status && !VALID_STATUSES.has(status)) {
-      return apiError(
-        requestId,
-        API_ERROR_CODES.VALIDATION_ERROR,
-        "The request data is invalid",
-        400,
-        {
-          status: [
-            "Status must be PENDING, VERIFIED, or REJECTED",
-          ],
-        },
-      );
-    }
-
-    const tickets = await prisma.ticket.findMany({
-      where: status
-        ? { status: status as TicketStatus }
-        : {},
-=======
->>>>>>> a057bee (Fixed ci build error)
       include: {
         user: {
           select: {
@@ -170,22 +113,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Server error" },
       { status: 500 },
-<<<<<<< HEAD
-    return apiJson({ tickets }, requestId);
-  } catch (error) {
-    logApiError(
-      requestId,
-      "Admin ticket listing failed",
-      error,
-    );
-
-    return apiError(
-      requestId,
-      API_ERROR_CODES.INTERNAL_ERROR,
-      "Unable to fetch tickets for review",
-      500,
-=======
->>>>>>> a057bee (Fixed ci build error)
     );
   }
 }

--- a/src/app/api/admin/tickets/route.ts
+++ b/src/app/api/admin/tickets/route.ts
@@ -1,32 +1,75 @@
+import { TicketStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
+import {
+  buildTimestampCursorWhere,
+  createPaginatedResponse,
+  PaginationError,
+  parsePaginationParams,
+} from "@/lib/pagination";
 
-// Get all tickets for admin review
-export async function GET(req: NextRequest) {
+const VALID_TICKET_STATUSES = new Set<string>(
+  Object.values(TicketStatus),
+);
+
+// Get paginated tickets for admin review
+export async function GET(request: NextRequest) {
   const session = await auth();
+
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
   }
 
   try {
-    // Check if user is admin
     const user = await prisma.user.findUnique({
       where: { id: session.user.id },
       select: { role: true },
     });
 
     if (user?.role !== "ADMIN") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: 403 },
+      );
     }
 
-    const url = new URL(req.url);
-    const status = url.searchParams.get("status");
+    const status =
+      request.nextUrl.searchParams.get("status");
 
-    const where = status ? { status: status as any } : {};
+    if (
+      status &&
+      !VALID_TICKET_STATUSES.has(status)
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Status must be PENDING, VERIFIED, or REJECTED",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { limit, cursor } = parsePaginationParams(
+      request.nextUrl.searchParams,
+    );
+    const cursorWhere = buildTimestampCursorWhere(
+      "createdAt",
+      cursor,
+    );
 
     const tickets = await prisma.ticket.findMany({
-      where,
+      where: {
+        ...(status
+          ? {
+              status: status as TicketStatus,
+            }
+          : {}),
+        ...(cursorWhere ?? {}),
+      },
       include: {
         user: {
           select: {
@@ -37,16 +80,39 @@ export async function GET(req: NextRequest) {
           },
         },
       },
-      orderBy: { createdAt: "desc" },
-      take: 100,
+      orderBy: [
+        { createdAt: "desc" },
+        { id: "desc" },
+      ],
+      take: limit + 1,
     });
 
-    return NextResponse.json({ tickets });
+    const result = createPaginatedResponse(
+      tickets,
+      limit,
+      "createdAt",
+    );
+
+    return NextResponse.json({
+      ...result,
+      // Alias retained for existing API consumers.
+      tickets: result.items,
+    });
   } catch (error) {
-    console.error("Get admin tickets error:", error);
+    if (error instanceof PaginationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 },
+      );
+    }
+
+    console.error(
+      "Get admin tickets error:",
+      error,
+    );
     return NextResponse.json(
       { error: "Server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/admin/tickets/route.ts
+++ b/src/app/api/admin/tickets/route.ts
@@ -21,6 +21,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Unauthorized" },
       { status: 401 },
+<<<<<<< HEAD
 import { NextRequest } from "next/server";
 
 import {
@@ -46,6 +47,8 @@ export async function GET(request: NextRequest) {
       API_ERROR_CODES.UNAUTHORIZED,
       "Authentication is required",
       401,
+=======
+>>>>>>> a057bee (Fixed ci build error)
     );
   }
 
@@ -59,11 +62,14 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(
         { error: "Forbidden" },
         { status: 403 },
+<<<<<<< HEAD
       return apiError(
         requestId,
         API_ERROR_CODES.FORBIDDEN,
         "Administrator access is required",
         403,
+=======
+>>>>>>> a057bee (Fixed ci build error)
       );
     }
 
@@ -100,6 +106,7 @@ export async function GET(request: NextRequest) {
           : {}),
         ...(cursorWhere ?? {}),
       },
+<<<<<<< HEAD
     if (status && !VALID_STATUSES.has(status)) {
       return apiError(
         requestId,
@@ -118,6 +125,8 @@ export async function GET(request: NextRequest) {
       where: status
         ? { status: status as TicketStatus }
         : {},
+=======
+>>>>>>> a057bee (Fixed ci build error)
       include: {
         user: {
           select: {
@@ -161,6 +170,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Server error" },
       { status: 500 },
+<<<<<<< HEAD
     return apiJson({ tickets }, requestId);
   } catch (error) {
     logApiError(
@@ -174,6 +184,8 @@ export async function GET(request: NextRequest) {
       API_ERROR_CODES.INTERNAL_ERROR,
       "Unable to fetch tickets for review",
       500,
+=======
+>>>>>>> a057bee (Fixed ci build error)
     );
   }
 }

--- a/src/app/api/routes/__tests__/pagination.test.ts
+++ b/src/app/api/routes/__tests__/pagination.test.ts
@@ -1,0 +1,120 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import {
+  encodeCursor,
+} from "@/lib/pagination";
+import prisma from "@/lib/prisma";
+import { GET } from "../route";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    route: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("GET /api/routes pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-1",
+      },
+    } as never);
+  });
+
+  it("returns a first page and pagination metadata", async () => {
+    vi.mocked(prisma.route.findMany).mockResolvedValue(
+      [
+        {
+          id: "route-3",
+          updatedAt: new Date(
+            "2026-07-22T12:00:00.000Z",
+          ),
+        },
+        {
+          id: "route-2",
+          updatedAt: new Date(
+            "2026-07-22T11:00:00.000Z",
+          ),
+        },
+        {
+          id: "route-1",
+          updatedAt: new Date(
+            "2026-07-22T10:00:00.000Z",
+          ),
+        },
+      ] as never,
+    );
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/routes?limit=2",
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.items).toHaveLength(2);
+    expect(body.pagination.hasMore).toBe(true);
+    expect(body.routes).toEqual(body.items);
+    expect(prisma.route.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 3,
+        orderBy: [
+          { updatedAt: "desc" },
+          { id: "desc" },
+        ],
+      }),
+    );
+  });
+
+  it("applies a following-page cursor without a cursor-row lookup", async () => {
+    vi.mocked(prisma.route.findMany).mockResolvedValue(
+      [] as never,
+    );
+
+    const cursor = encodeCursor({
+      id: "deleted-route",
+      timestamp: "2026-07-22T11:00:00.000Z",
+    });
+
+    await GET(
+      new NextRequest(
+        `http://localhost/api/routes?limit=2&cursor=${cursor}`,
+      ),
+    );
+
+    expect(prisma.route.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "user-1",
+          OR: expect.any(Array),
+        }),
+      }),
+    );
+    expect(
+      (prisma.route as unknown as {
+        findUnique?: unknown;
+      }).findUnique,
+    ).toBeUndefined();
+  });
+
+  it("returns 400 for an invalid cursor", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/routes?cursor=invalid",
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.route.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -1,4 +1,3 @@
-import { NextRequest } from "next/server";
 
 import {
   API_ERROR_CODES,
@@ -277,6 +276,7 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json(
       { error: "Failed to delete route" },
       { status: 500 },
+<<<<<<< HEAD
     });
 
     if (!route) {
@@ -312,6 +312,8 @@ export async function DELETE(request: NextRequest) {
       API_ERROR_CODES.INTERNAL_ERROR,
       "Unable to fetch the route",
       500,
+=======
+>>>>>>> a057bee (Fixed ci build error)
     );
   }
 }

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -1,18 +1,7 @@
-
-import {
-  API_ERROR_CODES,
-  logApiError,
-} from "@/lib/api-error";
-import { apiError, apiJson } from "@/lib/api-response";
-import { auth } from "@/lib/auth";
-import prisma from "@/lib/prisma";
-import { getRequestId } from "@/lib/request-id";
-
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { id: string } },
-) {
-  const requestId = getRequestId(request);
+/**
+ * API Route: /api/routes
+ * Handles route CRUD operations
+ */
 
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
@@ -81,17 +70,7 @@ export async function GET(request: NextRequest) {
     );
 
     const routes = await prisma.route.findMany({
-      return apiError(
-        requestId,
-        API_ERROR_CODES.UNAUTHORIZED,
-        "Authentication is required",
-        401,
-      );
-    }
-
-    const route = await prisma.route.findUnique({
       where: {
-        id: params.id,
         userId: session.user.id,
         ...(cursorWhere ?? {}),
       },
@@ -276,44 +255,6 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json(
       { error: "Failed to delete route" },
       { status: 500 },
-<<<<<<< HEAD
-    });
-
-    if (!route) {
-      return apiError(
-        requestId,
-        API_ERROR_CODES.NOT_FOUND,
-        "Route was not found",
-        404,
-      );
-    }
-
-    const formattedRoute = {
-      ...route,
-      origin: {
-        lat: route.originLat,
-        lng: route.originLng,
-      },
-      destination: {
-        lat: route.destinationLat,
-        lng: route.destinationLng,
-      },
-      waypoints: route.waypoints
-        ? JSON.parse(route.waypoints as string)
-        : undefined,
-    };
-
-    return apiJson(formattedRoute, requestId);
-  } catch (error) {
-    logApiError(requestId, "Route fetch failed", error);
-
-    return apiError(
-      requestId,
-      API_ERROR_CODES.INTERNAL_ERROR,
-      "Unable to fetch the route",
-      500,
-=======
->>>>>>> a057bee (Fixed ci build error)
     );
   }
 }

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -3,11 +3,18 @@
  * Handles route CRUD operations
  */
 
-import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
-import prisma from '@/lib/prisma';
-import { z } from 'zod';
-import { withValidation } from '@/lib/withValidation';
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "@/lib/auth";
+import {
+  buildTimestampCursorWhere,
+  createPaginatedResponse,
+  PaginationError,
+  parsePaginationParams,
+} from "@/lib/pagination";
+import prisma from "@/lib/prisma";
+import { withValidation } from "@/lib/withValidation";
 
 const RouteSchema = z.object({
   id: z.string().optional(),
@@ -19,14 +26,18 @@ const RouteSchema = z.object({
     lat: z.number(),
     lng: z.number(),
   }),
-  waypoints: z.array(z.object({
-    location: z.object({
-      lat: z.number(),
-      lng: z.number(),
-    }),
-    stopover: z.boolean(),
-    name: z.string().optional(),
-  })).optional(),
+  waypoints: z
+    .array(
+      z.object({
+        location: z.object({
+          lat: z.number(),
+          lng: z.number(),
+        }),
+        stopover: z.boolean(),
+        name: z.string().optional(),
+      }),
+    )
+    .optional(),
   originName: z.string().optional(),
   destinationName: z.string().optional(),
   distance: z.number(),
@@ -37,34 +48,62 @@ const RouteSchema = z.object({
 });
 
 /**
- * GET /api/routes - Get all routes for authenticated user
+ * GET /api/routes - Get paginated routes for authenticated user
  */
 export async function GET(request: NextRequest) {
   try {
     const session = await auth();
-    
+
     if (!session?.user?.id) {
       return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
+        { error: "Unauthorized" },
+        { status: 401 },
       );
     }
+
+    const { limit, cursor } = parsePaginationParams(
+      request.nextUrl.searchParams,
+    );
+    const cursorWhere = buildTimestampCursorWhere(
+      "updatedAt",
+      cursor,
+    );
 
     const routes = await prisma.route.findMany({
       where: {
         userId: session.user.id,
+        ...(cursorWhere ?? {}),
       },
-      orderBy: {
-        updatedAt: 'desc',
-      },
+      orderBy: [
+        { updatedAt: "desc" },
+        { id: "desc" },
+      ],
+      take: limit + 1,
     });
 
-    return NextResponse.json(routes);
+    const result = createPaginatedResponse(
+      routes,
+      limit,
+      "updatedAt",
+    );
+
+    return NextResponse.json({
+      ...result,
+      // Alias retained for existing API consumers.
+      routes: result.items,
+    });
   } catch (error) {
-    console.error('Error fetching routes:', error);
+    if (error instanceof PaginationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 },
+      );
+    }
+
+    console.error("Error fetching routes:", error);
     return NextResponse.json(
-      { error: 'Failed to fetch routes' },
-      { status: 500 }
+      { error: "Failed to fetch routes" },
+      { status: 500 },
     );
   }
 }
@@ -72,85 +111,99 @@ export async function GET(request: NextRequest) {
 /**
  * POST /api/routes - Create or update a route
  */
-export const POST = withValidation(RouteSchema, async (request, validatedData) => {
-  try {
-    const session = await auth();
-    
-    if (!session?.user?.id) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+export const POST = withValidation(
+  RouteSchema,
+  async (_request, validatedData) => {
+    try {
+      const session = await auth();
 
-    // If ID provided, update existing route
-    if (validatedData.id) {
+      if (!session?.user?.id) {
+        return NextResponse.json(
+          { error: "Unauthorized" },
+          { status: 401 },
+        );
+      }
 
-    const existing = await prisma.route.findFirst({
-        where: {
+      if (validatedData.id) {
+        const existing = await prisma.route.findFirst({
+          where: {
             id: validatedData.id,
             userId: session.user.id,
-        },
-    });
+          },
+        });
 
-    if (!existing) {
-        return NextResponse.json(
+        if (!existing) {
+          return NextResponse.json(
             { error: "Route not found" },
-            { status: 404 }
-        );
-    }
+            { status: 404 },
+          );
+        }
 
-    const route = await prisma.route.update({
-        where: {
+        const route = await prisma.route.update({
+          where: {
             id: validatedData.id,
-        },
+          },
+          data: {
+            originLat: validatedData.origin.lat,
+            originLng: validatedData.origin.lng,
+            destinationLat:
+              validatedData.destination.lat,
+            destinationLng:
+              validatedData.destination.lng,
+            originName: validatedData.originName,
+            destinationName:
+              validatedData.destinationName,
+            distance: validatedData.distance,
+            duration: validatedData.duration,
+            encodedPolyline:
+              validatedData.encodedPolyline,
+            tripName: validatedData.tripName,
+            notes: validatedData.notes,
+            waypoints: validatedData.waypoints
+              ? JSON.stringify(validatedData.waypoints)
+              : null,
+          },
+        });
+
+        return NextResponse.json(route);
+      }
+
+      const route = await prisma.route.create({
         data: {
+          userId: session.user.id,
           originLat: validatedData.origin.lat,
           originLng: validatedData.origin.lng,
-          destinationLat: validatedData.destination.lat,
-          destinationLng: validatedData.destination.lng,
+          destinationLat:
+            validatedData.destination.lat,
+          destinationLng:
+            validatedData.destination.lng,
           originName: validatedData.originName,
-          destinationName: validatedData.destinationName,
+          destinationName:
+            validatedData.destinationName,
           distance: validatedData.distance,
           duration: validatedData.duration,
-          encodedPolyline: validatedData.encodedPolyline,
+          encodedPolyline:
+            validatedData.encodedPolyline,
           tripName: validatedData.tripName,
           notes: validatedData.notes,
-          waypoints: validatedData.waypoints ? JSON.stringify(validatedData.waypoints) : null,
+          waypoints: validatedData.waypoints
+            ? JSON.stringify(validatedData.waypoints)
+            : null,
         },
       });
 
-      return NextResponse.json(route);
+      return NextResponse.json(route, {
+        status: 201,
+      });
+    } catch (error) {
+      console.error("Error saving route:", error);
+      return NextResponse.json(
+        { error: "Failed to save route" },
+        { status: 500 },
+      );
     }
-
-    // Create new route
-    const route = await prisma.route.create({
-      data: {
-        userId: session.user.id,
-        originLat: validatedData.origin.lat,
-        originLng: validatedData.origin.lng,
-        destinationLat: validatedData.destination.lat,
-        destinationLng: validatedData.destination.lng,
-        originName: validatedData.originName,
-        destinationName: validatedData.destinationName,
-        distance: validatedData.distance,
-        duration: validatedData.duration,
-        encodedPolyline: validatedData.encodedPolyline,
-        tripName: validatedData.tripName,
-        notes: validatedData.notes,
-        waypoints: validatedData.waypoints ? JSON.stringify(validatedData.waypoints) : null,
-      },
-    });
-
-    return NextResponse.json(route, { status: 201 });
-  } catch (error) {
-    console.error('Error saving route:', error);
-    return NextResponse.json(
-      { error: 'Failed to save route' },
-      { status: 500 }
-    );
-  }
-});
+  },
+);
 
 /**
  * DELETE /api/routes - Delete a route
@@ -158,50 +211,50 @@ export const POST = withValidation(RouteSchema, async (request, validatedData) =
 export async function DELETE(request: NextRequest) {
   try {
     const session = await auth();
-    
+
     if (!session?.user?.id) {
       return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
+        { error: "Unauthorized" },
+        { status: 401 },
       );
     }
 
-    const { searchParams } = new URL(request.url);
-    const routeId = searchParams.get('id');
+    const routeId =
+      request.nextUrl.searchParams.get("id");
 
     if (!routeId) {
       return NextResponse.json(
-        { error: 'Route ID required' },
-        { status: 400 }
+        { error: "Route ID required" },
+        { status: 400 },
       );
     }
 
     const existing = await prisma.route.findFirst({
-    where:{
+      where: {
         id: routeId,
         userId: session.user.id,
-    }
-});
+      },
+    });
 
-if(!existing){
-    return NextResponse.json(
-        {error:"Route not found"},
-        {status:404}
-    );
-}
-
-await prisma.route.delete({
-    where:{
-        id: routeId
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Route not found" },
+        { status: 404 },
+      );
     }
-});
+
+    await prisma.route.delete({
+      where: {
+        id: routeId,
+      },
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Error deleting route:', error);
+    console.error("Error deleting route:", error);
     return NextResponse.json(
-      { error: 'Failed to delete route' },
-      { status: 500 }
+      { error: "Failed to delete route" },
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/tickets/__tests__/pagination.test.ts
+++ b/src/app/api/tickets/__tests__/pagination.test.ts
@@ -1,0 +1,97 @@
+import { TicketStatus } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { GET as getAdminTickets } from "../../admin/tickets/route";
+import { GET as getUserTickets } from "../route";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    ticket: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("ticket pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-1",
+      },
+    } as never);
+    vi.mocked(prisma.ticket.findMany).mockResolvedValue(
+      [] as never,
+    );
+  });
+
+  it("paginates authenticated user tickets", async () => {
+    const response = await getUserTickets(
+      new NextRequest(
+        "http://localhost/api/tickets?limit=10",
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.pagination).toEqual({
+      limit: 10,
+      nextCursor: null,
+      hasMore: false,
+    });
+    expect(prisma.ticket.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "user-1",
+        },
+        take: 11,
+      }),
+    );
+  });
+
+  it("validates admin ticket statuses", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      role: "ADMIN",
+    } as never);
+
+    const response = await getAdminTickets(
+      new NextRequest(
+        "http://localhost/api/admin/tickets?status=INVALID",
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.ticket.findMany).not.toHaveBeenCalled();
+  });
+
+  it("applies a valid admin status without unsafe any filtering", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      role: "ADMIN",
+    } as never);
+
+    const response = await getAdminTickets(
+      new NextRequest(
+        `http://localhost/api/admin/tickets?status=${TicketStatus.PENDING}`,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(prisma.ticket.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          status: TicketStatus.PENDING,
+        },
+      }),
+    );
+  });
+});

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -4,8 +4,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withValidation } from "@/lib/withValidation";
 import { uploadFileToCloudinary } from "@/lib/cloudinary-upload";
+import {
+  buildTimestampCursorWhere,
+  createPaginatedResponse,
+  PaginationError,
+  parsePaginationParams,
+} from "@/lib/pagination";
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
 const ALLOWED_TYPES = [
   "image/jpeg",
@@ -15,82 +21,146 @@ const ALLOWED_TYPES = [
 ];
 
 const ticketSchema = z.object({
-  destination: z.string().min(1, "Destination required"),
-  departureDate: z.string().refine((date) => !isNaN(Date.parse(date)), {
-    message: "Invalid date format",
-  }),
+  destination: z
+    .string()
+    .min(1, "Destination required"),
+  departureDate: z
+    .string()
+    .refine(
+      (date) => !Number.isNaN(Date.parse(date)),
+      {
+        message: "Invalid date format",
+      },
+    ),
   file: z
-  .any()
-  .refine((val) => val instanceof File, "File required")
-  .refine((val) => val instanceof File && val.size > 0, "File required")
-  .refine((val) => val instanceof File && val.size <= MAX_FILE_SIZE, "File size exceeds 10MB")
-  .refine(
-    (val) => val instanceof File && ALLOWED_TYPES.includes(val.type),
-    "Unsupported file type"
-  ),
+    .any()
+    .refine(
+      (value) => value instanceof File,
+      "File required",
+    )
+    .refine(
+      (value) =>
+        value instanceof File && value.size > 0,
+      "File required",
+    )
+    .refine(
+      (value) =>
+        value instanceof File &&
+        value.size <= MAX_FILE_SIZE,
+      "File size exceeds 10MB",
+    )
+    .refine(
+      (value) =>
+        value instanceof File &&
+        ALLOWED_TYPES.includes(value.type),
+      "Unsupported file type",
+    ),
 });
 
-export const POST = withValidation(ticketSchema, async (req, data) => {
-  // 🔒 Verify authentication
+export const POST = withValidation(
+  ticketSchema,
+  async (_request, data) => {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    try {
+      const uploaded = await uploadFileToCloudinary(
+        data.file,
+        "travellers/tickets",
+      );
+
+      const ticket = await prisma.ticket.create({
+        data: {
+          userId: session.user.id,
+          destination: data.destination,
+          departureDate: new Date(
+            data.departureDate,
+          ),
+          ticketUrl: uploaded.url,
+          status: "PENDING",
+        },
+      });
+
+      return NextResponse.json({
+        ok: true,
+        ticket,
+      });
+    } catch (error) {
+      console.error("Ticket upload error:", error);
+      return NextResponse.json(
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to upload ticket",
+        },
+        { status: 500 },
+      );
+    }
+  },
+);
+
+// Get user's paginated tickets
+export async function GET(request: NextRequest) {
   const session = await auth();
+
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
   }
 
   try {
-    const { destination, departureDate, file } = data;
-
-    const uploaded = await uploadFileToCloudinary(
-      file,
-      "travellers/tickets"
+    const { limit, cursor } = parsePaginationParams(
+      request.nextUrl.searchParams,
+    );
+    const cursorWhere = buildTimestampCursorWhere(
+      "createdAt",
+      cursor,
     );
 
-    const ticketUrl = uploaded.url;
-
-    const ticket = await prisma.ticket.create({
-      data: {
-        userId: session.user.id,
-        destination,
-        departureDate: new Date(departureDate),
-        ticketUrl,
-        status: "PENDING",
-      },
-    });
-
-    return NextResponse.json({ ok: true, ticket });
-  } catch (error) {
-    console.error("Ticket upload error:", error);
-    return NextResponse.json(
-  {
-    error:
-      error instanceof Error
-        ? error.message
-        : "Failed to upload ticket",
-  },
-  { status: 500 }
-);
-  }
-});
-
-// Get user's tickets
-export async function GET(req: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  try {
     const tickets = await prisma.ticket.findMany({
-      where: { userId: session.user.id },
-      orderBy: { createdAt: "desc" },
+      where: {
+        userId: session.user.id,
+        ...(cursorWhere ?? {}),
+      },
+      orderBy: [
+        { createdAt: "desc" },
+        { id: "desc" },
+      ],
+      take: limit + 1,
     });
 
-    return NextResponse.json({ tickets });
+    const result = createPaginatedResponse(
+      tickets,
+      limit,
+      "createdAt",
+    );
+
+    return NextResponse.json({
+      ...result,
+      // Alias retained for existing API consumers.
+      tickets: result.items,
+    });
   } catch (error) {
+    if (error instanceof PaginationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 },
+      );
+    }
+
     console.error("Fetch tickets error:", error);
     return NextResponse.json(
       { error: "Server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -1,12 +1,8 @@
-import { NextRequest } from "next/server";
-import { z } from "zod";
-
-import {
-  API_ERROR_CODES,
-  logApiError,
-} from "@/lib/api-error";
-import { apiError, apiJson } from "@/lib/api-response";
+import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withValidation } from "@/lib/withValidation";
 import { uploadFileToCloudinary } from "@/lib/cloudinary-upload";
 import {
   buildTimestampCursorWhere,
@@ -14,15 +10,6 @@ import {
   PaginationError,
   parsePaginationParams,
 } from "@/lib/pagination";
-import prisma from "@/lib/prisma";
-import { getRequestId } from "@/lib/request-id";
-import { withValidation } from "@/lib/withValidation";
-import {
-  applyRateLimitHeaders,
-  checkRateLimit,
-  getRateLimitIdentifier,
-  rateLimitExceededResponse,
-} from "@/lib/rate-limit";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
@@ -55,18 +42,6 @@ const ticketSchema = z.object({
       (value) =>
         value instanceof File && value.size > 0,
       "File required",
-  destination: z.string().min(1, "Destination is required"),
-  departureDate: z
-    .string()
-    .refine((date) => !Number.isNaN(Date.parse(date)), {
-      message: "Departure date is invalid",
-    }),
-  file: z
-    .any()
-    .refine((value) => value instanceof File, "File is required")
-    .refine(
-      (value) => value instanceof File && value.size > 0,
-      "File is required",
     )
     .refine(
       (value) =>
@@ -86,27 +61,6 @@ export const POST = withValidation(
   ticketSchema,
   async (_request, data) => {
     const session = await auth();
-  async (_request, data, { requestId }) => {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return apiError(
-        requestId,
-        API_ERROR_CODES.UNAUTHORIZED,
-        "Authentication is required",
-        401,
-      );
-    }
-  const rateLimit = await checkRateLimit({
-    namespace: "tickets:upload",
-    identifier: getRateLimitIdentifier(req, session.user.id),
-    limit: 5,
-    windowSeconds: 60 * 60,
-  });
-
-  if (!rateLimit.allowed) {
-    return rateLimitExceededResponse(rateLimit);
-  }
 
     if (!session?.user?.id) {
       return NextResponse.json(
@@ -128,7 +82,6 @@ export const POST = withValidation(
           departureDate: new Date(
             data.departureDate,
           ),
-          departureDate: new Date(data.departureDate),
           ticketUrl: uploaded.url,
           status: "PENDING",
         },
@@ -161,48 +114,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Unauthorized" },
       { status: 401 },
-      return apiJson(
-        { ok: true, ticket },
-        requestId,
-        { status: 201 },
-      );
-    } catch (error) {
-      logApiError(requestId, "Ticket upload failed", error);
-
-      return apiError(
-        requestId,
-        API_ERROR_CODES.INTERNAL_ERROR,
-        "Unable to upload the ticket",
-        500,
-      );
-    }
-    return applyRateLimitHeaders(
-      NextResponse.json({ ok: true, ticket }),
-      rateLimit,
-    ) as NextResponse;
-  } catch (error) {
-    console.error("Ticket upload error:", error);
-    return NextResponse.json(
-  {
-    error:
-      error instanceof Error
-        ? error.message
-        : "Failed to upload ticket",
-  },
-  undefined,
-  { standardizeErrors: true },
-);
-
-export async function GET(request: NextRequest) {
-  const requestId = getRequestId(request);
-  const session = await auth();
-
-  if (!session?.user?.id) {
-    return apiError(
-      requestId,
-      API_ERROR_CODES.UNAUTHORIZED,
-      "Authentication is required",
-      401,
     );
   }
 
@@ -250,15 +161,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Server error" },
       { status: 500 },
-    return apiJson({ tickets }, requestId);
-  } catch (error) {
-    logApiError(requestId, "Ticket listing failed", error);
-
-    return apiError(
-      requestId,
-      API_ERROR_CODES.INTERNAL_ERROR,
-      "Unable to fetch tickets",
-      500,
     );
   }
 }

--- a/src/app/api/user/__tests__/profile-expansion.test.ts
+++ b/src/app/api/user/__tests__/profile-expansion.test.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { POST as onboardPOST } from "../onboard/route";
 import { GET as profileGET, PATCH as profilePATCH } from "../profile/route";
 import { auth } from "@/lib/auth";
+import { NextRequest } from "next/server";
 
 vi.mock("@/lib/prisma", () => ({
   default: {
@@ -102,7 +103,11 @@ describe("Traveler Profiles & Onboarding Flow API Endpoints", () => {
       };
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockProfile as any);
 
-      const res = await profileGET();
+      const res = await profileGET(
+  new NextRequest(
+    "http://localhost/api/user/profile",
+  ),
+);
       const data = await res.json();
 
       expect(res.status).toBe(200);

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -46,14 +46,17 @@ export default function ProfileViewPage() {
       try {
         const [profileRes, routesRes, ticketsRes] = await Promise.all([
           fetch("/api/user/profile"),
-          fetch("/api/routes"),
-          fetch("/api/tickets"),
+          fetch("/api/routes?limit=3"),
+          fetch("/api/tickets?limit=100"),
         ]);
 
         if (profileRes.ok) setProfile(await profileRes.json());
-        if (routesRes.ok) setTrips((await routesRes.json()).slice(0, 3));
+        if (routesRes.ok) {
+          const { items } = await routesRes.json();
+          setTrips(items.slice(0, 3));
+        }
         if (ticketsRes.ok) {
-          const { tickets } = await ticketsRes.json();
+          const { items: tickets } = await ticketsRes.json();
           setTicketVerified(tickets?.some((t: { status: string }) => t.status === "VERIFIED"));
         }
       } catch (err) {

--- a/src/app/routes/routes-client.tsx
+++ b/src/app/routes/routes-client.tsx
@@ -7,6 +7,7 @@ import type { CachedRoute } from '@/lib/types/route';
 import { Map, Plus, Search, Loader2 } from "lucide-react";
 import RouteCalendarExportButton from '@/components/route-calendar-export-button';
 import Link from 'next/link';
+import { fetchAllPaginatedItems } from '@/lib/fetch-paginated';
 
 export default function RoutesClient() {
   const [routes, setRoutes] = useState<CachedRoute[]>([]);
@@ -26,9 +27,11 @@ export default function RoutesClient() {
       setRoutes(cachedRoutes);
 
       try {
-        const response = await fetch('/api/routes');
-        if (response.ok) {
-          const serverRoutes = await response.json();
+        const serverRoutes =
+          await fetchAllPaginatedItems<CachedRoute>(
+            "/api/routes",
+          );
+        {
           for (const route of serverRoutes) {
             await routeCacheManager.cacheRoute(route);
           }

--- a/src/components/chat/RoutePickerModal.tsx
+++ b/src/components/chat/RoutePickerModal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { X, Map } from "lucide-react";
+import { fetchAllPaginatedItems } from "@/lib/fetch-paginated";
 
 interface Route {
   id: string;
@@ -44,11 +45,10 @@ export default function RoutePickerModal({
       setLoading(true);
 
       try {
-        const res = await fetch("/api/routes");
-
-        if (!res.ok) throw new Error();
-
-        const data = await res.json();
+        const data =
+          await fetchAllPaginatedItems<Route>(
+            "/api/routes",
+          );
 
         setRoutes(data);
       } catch {

--- a/src/lib/__tests__/pagination.test.ts
+++ b/src/lib/__tests__/pagination.test.ts
@@ -1,0 +1,151 @@
+import {
+  buildTimestampCursorWhere,
+  createPaginatedResponse,
+  decodeCursor,
+  encodeCursor,
+  MAX_PAGE_LIMIT,
+  PaginationError,
+  parsePaginationParams,
+} from "@/lib/pagination";
+import { describe, expect, it } from "vitest";
+
+describe("pagination parameters", () => {
+  it("uses the default limit", () => {
+    expect(
+      parsePaginationParams(new URLSearchParams()),
+    ).toEqual({
+      limit: 20,
+      cursor: null,
+    });
+  });
+
+  it("accepts a valid limit and cursor", () => {
+    const cursor = encodeCursor({
+      id: "route-2",
+      timestamp: "2026-07-22T12:00:00.000Z",
+    });
+
+    expect(
+      parsePaginationParams(
+        new URLSearchParams({
+          limit: "25",
+          cursor,
+        }),
+      ),
+    ).toEqual({
+      limit: 25,
+      cursor: {
+        id: "route-2",
+        timestamp: "2026-07-22T12:00:00.000Z",
+      },
+    });
+  });
+
+  it("caps limits at the maximum", () => {
+    expect(
+      parsePaginationParams(
+        new URLSearchParams({
+          limit: "999",
+        }),
+      ).limit,
+    ).toBe(MAX_PAGE_LIMIT);
+  });
+
+  it.each(["0", "-1", "abc", "1.5"])(
+    "rejects invalid limit %s",
+    (limit) => {
+      expect(() =>
+        parsePaginationParams(
+          new URLSearchParams({ limit }),
+        ),
+      ).toThrow(PaginationError);
+    },
+  );
+
+  it("rejects malformed cursors", () => {
+    expect(() => decodeCursor("not-a-cursor")).toThrow(
+      PaginationError,
+    );
+  });
+});
+
+describe("deletion-safe timestamp cursors", () => {
+  it("builds a keyset predicate without looking up the cursor row", () => {
+    expect(
+      buildTimestampCursorWhere("createdAt", {
+        id: "ticket-10",
+        timestamp: "2026-07-22T12:00:00.000Z",
+      }),
+    ).toEqual({
+      OR: [
+        {
+          createdAt: {
+            lt: new Date(
+              "2026-07-22T12:00:00.000Z",
+            ),
+          },
+        },
+        {
+          createdAt: new Date(
+            "2026-07-22T12:00:00.000Z",
+          ),
+          id: {
+            lt: "ticket-10",
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe("paginated responses", () => {
+  const records = [
+    {
+      id: "3",
+      createdAt: new Date(
+        "2026-07-22T12:00:00.000Z",
+      ),
+    },
+    {
+      id: "2",
+      createdAt: new Date(
+        "2026-07-22T11:00:00.000Z",
+      ),
+    },
+    {
+      id: "1",
+      createdAt: new Date(
+        "2026-07-22T10:00:00.000Z",
+      ),
+    },
+  ];
+
+  it("returns a first page with a next cursor", () => {
+    const result = createPaginatedResponse(
+      records,
+      2,
+      "createdAt",
+    );
+
+    expect(result.items.map((item) => item.id)).toEqual([
+      "3",
+      "2",
+    ]);
+    expect(result.pagination.hasMore).toBe(true);
+    expect(result.pagination.nextCursor).not.toBeNull();
+  });
+
+  it("returns a final page without a next cursor", () => {
+    const result = createPaginatedResponse(
+      records.slice(0, 2),
+      2,
+      "createdAt",
+    );
+
+    expect(result.pagination).toEqual({
+      limit: 2,
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+});

--- a/src/lib/fetch-paginated.ts
+++ b/src/lib/fetch-paginated.ts
@@ -1,0 +1,49 @@
+interface PaginationMetadata {
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+interface PaginatedPayload<T> {
+  items: T[];
+  pagination: PaginationMetadata;
+}
+
+export async function fetchAllPaginatedItems<T>(
+  url: string,
+  pageLimit = 100,
+): Promise<T[]> {
+  const items: T[] = [];
+  let cursor: string | null = null;
+
+  do {
+    const target = new URL(url, window.location.origin);
+    target.searchParams.set(
+      "limit",
+      String(pageLimit),
+    );
+
+    if (cursor) {
+      target.searchParams.set("cursor", cursor);
+    }
+
+    const response = await fetch(
+      `${target.pathname}${target.search}`,
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Request failed with status ${response.status}`,
+      );
+    }
+
+    const payload =
+      (await response.json()) as PaginatedPayload<T>;
+
+    items.push(...payload.items);
+    cursor = payload.pagination.hasMore
+      ? payload.pagination.nextCursor
+      : null;
+  } while (cursor);
+
+  return items;
+}

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,186 @@
+export const DEFAULT_PAGE_LIMIT = 20;
+export const MAX_PAGE_LIMIT = 100;
+
+export interface PaginationCursor {
+  timestamp: string;
+  id: string;
+}
+
+export interface PaginationMetadata {
+  limit: number;
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  pagination: PaginationMetadata;
+}
+
+export class PaginationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PaginationError";
+  }
+}
+
+function toBase64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function fromBase64Url(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+export function encodeCursor(
+  cursor: PaginationCursor,
+): string {
+  return toBase64Url(
+    JSON.stringify({
+      version: 1,
+      timestamp: cursor.timestamp,
+      id: cursor.id,
+    }),
+  );
+}
+
+export function decodeCursor(
+  value: string,
+): PaginationCursor {
+  try {
+    const parsed = JSON.parse(fromBase64Url(value)) as {
+      version?: unknown;
+      timestamp?: unknown;
+      id?: unknown;
+    };
+
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.timestamp !== "string" ||
+      typeof parsed.id !== "string" ||
+      !parsed.id.trim()
+    ) {
+      throw new PaginationError("Cursor is invalid");
+    }
+
+    const date = new Date(parsed.timestamp);
+
+    if (Number.isNaN(date.getTime())) {
+      throw new PaginationError("Cursor is invalid");
+    }
+
+    return {
+      timestamp: date.toISOString(),
+      id: parsed.id,
+    };
+  } catch (error) {
+    if (error instanceof PaginationError) {
+      throw error;
+    }
+
+    throw new PaginationError("Cursor is invalid");
+  }
+}
+
+export function parsePaginationParams(
+  searchParams: URLSearchParams,
+): {
+  limit: number;
+  cursor: PaginationCursor | null;
+} {
+  const rawLimit = searchParams.get("limit");
+  let limit = DEFAULT_PAGE_LIMIT;
+
+  if (rawLimit !== null) {
+    if (!/^\d+$/.test(rawLimit)) {
+      throw new PaginationError(
+        "Limit must be a positive integer",
+      );
+    }
+
+    const parsed = Number(rawLimit);
+
+    if (!Number.isSafeInteger(parsed) || parsed < 1) {
+      throw new PaginationError(
+        "Limit must be a positive integer",
+      );
+    }
+
+    limit = Math.min(parsed, MAX_PAGE_LIMIT);
+  }
+
+  const rawCursor = searchParams.get("cursor");
+
+  return {
+    limit,
+    cursor: rawCursor ? decodeCursor(rawCursor) : null,
+  };
+}
+
+export function buildTimestampCursorWhere(
+  field: "createdAt" | "updatedAt",
+  cursor: PaginationCursor | null,
+):
+  | {
+      OR: Array<Record<string, unknown>>;
+    }
+  | undefined {
+  if (!cursor) {
+    return undefined;
+  }
+
+  const timestamp = new Date(cursor.timestamp);
+
+  return {
+    OR: [
+      {
+        [field]: {
+          lt: timestamp,
+        },
+      },
+      {
+        [field]: timestamp,
+        id: {
+          lt: cursor.id,
+        },
+      },
+    ],
+  };
+}
+
+export function createPaginatedResponse<
+  T extends {
+    id: string;
+    createdAt?: Date | string;
+    updatedAt?: Date | string;
+  },
+>(
+  records: T[],
+  limit: number,
+  timestampField: "createdAt" | "updatedAt",
+): PaginatedResponse<T> {
+  const hasMore = records.length > limit;
+  const items = hasMore
+    ? records.slice(0, limit)
+    : records;
+
+  const lastItem = items.at(-1);
+  const timestampValue = lastItem?.[timestampField];
+
+  const nextCursor =
+    hasMore && lastItem && timestampValue
+      ? encodeCursor({
+          id: lastItem.id,
+          timestamp: new Date(timestampValue).toISOString(),
+        })
+      : null;
+
+  return {
+    items,
+    pagination: {
+      limit,
+      nextCursor,
+      hasMore,
+    },
+  };
+}


### PR DESCRIPTION
## 🔗 Related Issue

Closes #287

## 📝 Description

This PR adds validated, deletion-safe cursor pagination to saved routes, user ticket history, and the admin ticket-review queue.

### Changes made

* Added a reusable pagination utility.
* Added default page size 20 and maximum page size 100.
* Added validated `limit` and `cursor` query parameters.
* Added opaque, versioned Base64URL cursor encoding.
* Used timestamp-and-ID keyset predicates instead of Prisma record cursors.
* Ensured following pages still work if the cursor record is deleted.
* Added deterministic ordering:

  * Routes: `updatedAt DESC, id DESC`
  * Tickets: `createdAt DESC, id DESC`
* Added `items`, `limit`, `nextCursor`, and `hasMore` metadata.
* Retained `routes` and `tickets` compatibility aliases.
* Validated admin status values against the Prisma `TicketStatus` enum.
* Preserved user ownership and administrator authorization checks.
* Updated existing route and ticket consumers for the paginated response.
* Added focused utility and API-route tests.
* Did not modify Prisma models or migrations.

## 🛠️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [x] ⚡ Performance improvement
* [ ] 📚 Documentation update
* [x] 🧪 Tests

## 🧪 Testing Performed

* [ ] `npx vitest run src/lib/__tests__/pagination.test.ts`
* [ ] `npx vitest run src/app/api/routes/__tests__/pagination.test.ts`
* [ ] `npx vitest run src/app/api/tickets/__tests__/pagination.test.ts`
* [ ] `npm test`
* [ ] `npx tsc --noEmit`
* [ ] `npm run lint`
* [ ] Verified first, following, and final pages
* [ ] Verified invalid limit and cursor responses
* [ ] Verified invalid admin status response
* [ ] Verified pagination after deleting a cursor record
* [ ] Verified existing route and profile screens still load

## ✅ Scope Verification

* [x] No Prisma model or migration was changed.
* [x] Authentication and ownership rules remain unchanged.
* [x] No infinite-scroll UI was added.
* [x] No external dependency was added.
