### PR TITLE
fix: invalidate stale match-search caches

### DIFF
--- a/src/app/api/admin/tickets/[id]/__tests__/cache-invalidation.test.ts
+++ b/src/app/api/admin/tickets/[id]/__tests__/cache-invalidation.test.ts
@@ -1,0 +1,155 @@
+import { NextRequest } from "next/server";
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { auth } from "@/lib/auth";
+import { invalidateMatchCachesForTicket } from "@/lib/match-cache";
+import { createNotification } from "@/lib/notifications";
+import prisma from "@/lib/prisma";
+import { PATCH } from "../route";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    ticket: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/match-cache", () => ({
+  invalidateMatchCachesForTicket: vi.fn(),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  createNotification: vi.fn(),
+}));
+
+const existingTicket = {
+  id: "ticket-1",
+  destination: "Goa",
+  departureDate: new Date(
+    "2026-08-15T00:00:00.000Z",
+  ),
+  status: "PENDING",
+};
+
+const updatedTicket = {
+  ...existingTicket,
+  status: "VERIFIED",
+  user: {
+    id: "traveller-1",
+    name: "Traveller",
+    email: "traveller@example.com",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(auth).mockResolvedValue({
+    user: { id: "admin-1" },
+  } as never);
+  vi.mocked(
+    prisma.user.findUnique,
+  ).mockResolvedValue({
+    role: "ADMIN",
+  } as never);
+  vi.mocked(
+    prisma.ticket.findUnique,
+  ).mockResolvedValue(
+    existingTicket as never,
+  );
+  vi.mocked(
+    prisma.ticket.update,
+  ).mockResolvedValue(
+    updatedTicket as never,
+  );
+});
+
+describe("admin ticket cache invalidation", () => {
+  it.each(["VERIFIED", "REJECTED"])(
+    "invalidates matching windows when status becomes %s",
+    async (status) => {
+      vi.mocked(
+        prisma.ticket.update,
+      ).mockResolvedValue({
+        ...updatedTicket,
+        status,
+      } as never);
+
+      const response = await PATCH(
+        new NextRequest(
+          "http://localhost/api/admin/tickets/ticket-1",
+          {
+            method: "PATCH",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ status }),
+          },
+        ),
+        {
+          params: { id: "ticket-1" },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(
+        invalidateMatchCachesForTicket,
+      ).toHaveBeenCalledWith(
+        {
+          destination: "Goa",
+          departureDate:
+            existingTicket.departureDate,
+        },
+        {
+          destination: "Goa",
+          departureDate:
+            existingTicket.departureDate,
+        },
+      );
+      expect(
+        createNotification,
+      ).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not fail verification when invalidation fails safely", async () => {
+    vi.mocked(
+      invalidateMatchCachesForTicket,
+    ).mockResolvedValue(undefined);
+
+    const response = await PATCH(
+      new NextRequest(
+        "http://localhost/api/admin/tickets/ticket-1",
+        {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            status: "VERIFIED",
+          }),
+        },
+      ),
+      {
+        params: { id: "ticket-1" },
+      },
+    );
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/app/api/admin/tickets/[id]/route.ts
+++ b/src/app/api/admin/tickets/[id]/route.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 import { createNotification } from "@/lib/notifications";
+import { invalidateMatchCachesForTicket } from "@/lib/match-cache";
 import { z } from "zod";
 
 const updateSchema = z.object({
@@ -13,19 +14,25 @@ export async function PATCH(
   { params }: { params: { id: string } }
 ) {
   const session = await auth();
+
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 }
+    );
   }
 
   try {
-    // Check if user is admin
     const user = await prisma.user.findUnique({
       where: { id: session.user.id },
       select: { role: true },
     });
 
     if (user?.role !== "ADMIN") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: 403 }
+      );
     }
 
     const body = await req.json();
@@ -33,8 +40,29 @@ export async function PATCH(
 
     if (!result.success) {
       return NextResponse.json(
-        { error: "Invalid status", details: result.error.flatten() },
+        {
+          error: "Invalid status",
+          details: result.error.flatten(),
+        },
         { status: 400 }
+      );
+    }
+
+    const existingTicket =
+      await prisma.ticket.findUnique({
+        where: { id: params.id },
+        select: {
+          id: true,
+          destination: true,
+          departureDate: true,
+          status: true,
+        },
+      });
+
+    if (!existingTicket) {
+      return NextResponse.json(
+        { error: "Ticket not found" },
+        { status: 404 }
       );
     }
 
@@ -54,30 +82,49 @@ export async function PATCH(
       },
     });
 
-  if (status === "VERIFIED") {
-  await createNotification({
-    userId: ticket.user.id,
-    type: "TICKET_VERIFIED",
-    title: "Ticket verified",
-    content:
-      "Your travel ticket has been verified. You can now appear in traveller matches.",
-    link: "/dashboard",
-  });
-}
+    await invalidateMatchCachesForTicket(
+      {
+        destination: ticket.destination,
+        departureDate: ticket.departureDate,
+      },
+      {
+        destination: existingTicket.destination,
+        departureDate:
+          existingTicket.departureDate,
+      }
+    );
 
-if (status === "REJECTED") {
-  await createNotification({
-    userId: ticket.user.id,
-    type: "TICKET_REJECTED",
-    title: "Ticket rejected",
-    content:
-      "Your uploaded ticket was rejected. Please upload a valid ticket.",
-    link: "/upload",
-  });
-}
-    return NextResponse.json({ ok: true, ticket });
+    if (status === "VERIFIED") {
+      await createNotification({
+        userId: ticket.user.id,
+        type: "TICKET_VERIFIED",
+        title: "Ticket verified",
+        content:
+          "Your travel ticket has been verified. You can now appear in traveller matches.",
+        link: "/dashboard",
+      });
+    }
+
+    if (status === "REJECTED") {
+      await createNotification({
+        userId: ticket.user.id,
+        type: "TICKET_REJECTED",
+        title: "Ticket rejected",
+        content:
+          "Your uploaded ticket was rejected. Please upload a valid ticket.",
+        link: "/upload",
+      });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      ticket,
+    });
   } catch (error) {
-    console.error("Ticket verification error:", error);
+    console.error(
+      "Ticket verification error:",
+      error
+    );
     return NextResponse.json(
       { error: "Server error" },
       { status: 500 }
@@ -85,14 +132,17 @@ if (status === "REJECTED") {
   }
 }
 
-// Get single ticket (admin only)
 export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const session = await auth();
+
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 }
+    );
   }
 
   try {
@@ -102,7 +152,10 @@ export async function GET(
     });
 
     if (user?.role !== "ADMIN") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: 403 }
+      );
     }
 
     const ticket = await prisma.ticket.findUnique({
@@ -120,7 +173,10 @@ export async function GET(
     });
 
     if (!ticket) {
-      return NextResponse.json({ error: "Ticket not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Ticket not found" },
+        { status: 404 }
+      );
     }
 
     return NextResponse.json({ ticket });

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -6,7 +6,6 @@ import {
   readMatchCache,
   writeMatchCache,
 } from "@/lib/match-cache";
-import { NextRequest } from "next/server";
 import redis from "@/lib/redis";
 import { createNotification } from "@/lib/notifications";
 import { API_ERROR_CODES, logApiError } from "@/lib/api-error";
@@ -83,6 +82,7 @@ export async function GET(req: NextRequest) {
       401,
     );
   }
+  
 
   const url = new URL(req.url);
   const destination = url.searchParams.get("destination");

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -1,14 +1,16 @@
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import {
   buildMatchCacheKey,
   readMatchCache,
   writeMatchCache,
 } from "@/lib/match-cache";
-import redis from "@/lib/redis";
 import { createNotification } from "@/lib/notifications";
-import { API_ERROR_CODES, logApiError } from "@/lib/api-error";
+import {
+  API_ERROR_CODES,
+  logApiError,
+} from "@/lib/api-error";
 import { apiError, apiJson } from "@/lib/api-response";
 import { getRequestId } from "@/lib/request-id";
 
@@ -16,29 +18,34 @@ function calculateRelevance(
   currentUser: any,
   matchedUser: any,
   departureDate: Date,
-  targetDate: Date
-) {
-  if (!currentUser) return 50;
+  targetDate: Date,
+): number {
+  if (!currentUser) {
+    return 50;
+  }
 
   let score = 0;
 
-  // 1. Shared Languages: +20 points per language (capped at 40)
   if (currentUser.languages && matchedUser.languages) {
-    const sharedLangs = currentUser.languages.filter((l: string) =>
-      matchedUser.languages.includes(l)
+    const sharedLanguages = currentUser.languages.filter(
+      (language: string) => matchedUser.languages.includes(language),
     );
-    score += Math.min(sharedLangs.length * 20, 40);
+
+    score += Math.min(sharedLanguages.length * 20, 40);
   }
 
-  // 2. Shared Interests: +15 points per interest (capped at 30)
-  if (currentUser.travelInterests && matchedUser.travelInterests) {
-    const sharedInterests = currentUser.travelInterests.filter((i: string) =>
-      matchedUser.travelInterests.includes(i)
+  if (
+    currentUser.travelInterests &&
+    matchedUser.travelInterests
+  ) {
+    const sharedInterests = currentUser.travelInterests.filter(
+      (interest: string) =>
+        matchedUser.travelInterests.includes(interest),
     );
+
     score += Math.min(sharedInterests.length * 15, 30);
   }
 
-  // 3. Same Budget Range: +20 points
   if (
     currentUser.budgetRange &&
     matchedUser.budgetRange &&
@@ -47,7 +54,6 @@ function calculateRelevance(
     score += 20;
   }
 
-  // 4. Same Travel Style: +10 points
   if (
     currentUser.travelStyle &&
     matchedUser.travelStyle &&
@@ -56,24 +62,28 @@ function calculateRelevance(
     score += 10;
   }
 
-  // 5. Date proximity: +20 points (same day), +10 (1 day diff), +5 (2 days diff)
-  const diffTime = Math.abs(departureDate.getTime() - targetDate.getTime());
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) {
+  const difference = Math.abs(
+    departureDate.getTime() - targetDate.getTime(),
+  );
+  const differenceInDays = Math.ceil(
+    difference / (1000 * 60 * 60 * 24),
+  );
+
+  if (differenceInDays === 0) {
     score += 20;
-  } else if (diffDays === 1) {
+  } else if (differenceInDays === 1) {
     score += 10;
-  } else if (diffDays === 2) {
+  } else if (differenceInDays === 2) {
     score += 5;
   }
 
-  // Max score: 40 + 30 + 20 + 10 + 20 = 120 points. Normalize to percentage match.
   return Math.round((score / 120) * 100);
 }
 
 export async function GET(req: NextRequest) {
   const requestId = getRequestId(req);
   const session = await auth();
+
   if (!session?.user?.id) {
     return apiError(
       requestId,
@@ -82,7 +92,8 @@ export async function GET(req: NextRequest) {
       401,
     );
   }
-  
+
+  const currentUserId = session.user.id;
 
   const url = new URL(req.url);
   const destination = url.searchParams.get("destination");
@@ -103,42 +114,75 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  // Extract advanced filters
   const genderFilter = url.searchParams.get("gender");
-  const tripPurposeFilter = url.searchParams.get("tripPurpose");
-  const ageMin = url.searchParams.get("ageMin") ? parseInt(url.searchParams.get("ageMin")!) : null;
-  const ageMax = url.searchParams.get("ageMax") ? parseInt(url.searchParams.get("ageMax")!) : null;
-  const filterStartDate = url.searchParams.get("startDate") ? new Date(url.searchParams.get("startDate")!) : null;
-  const filterEndDate = url.searchParams.get("endDate") ? new Date(url.searchParams.get("endDate")!) : null;
-  const page = parseInt(url.searchParams.get("page") || "1");
-  const limit = parseInt(url.searchParams.get("limit") || "10");
+  const tripPurposeFilter =
+    url.searchParams.get("tripPurpose");
+
+  const ageMinRaw = url.searchParams.get("ageMin");
+  const ageMaxRaw = url.searchParams.get("ageMax");
+  const startDateRaw =
+    url.searchParams.get("startDate");
+  const endDateRaw = url.searchParams.get("endDate");
+
+  const ageMin = ageMinRaw
+    ? Number.parseInt(ageMinRaw, 10)
+    : null;
+  const ageMax = ageMaxRaw
+    ? Number.parseInt(ageMaxRaw, 10)
+    : null;
+  const filterStartDate = startDateRaw
+    ? new Date(startDateRaw)
+    : null;
+  const filterEndDate = endDateRaw
+    ? new Date(endDateRaw)
+    : null;
+
+  const parsedPage = Number.parseInt(
+    url.searchParams.get("page") ?? "1",
+    10,
+  );
+  const parsedLimit = Number.parseInt(
+    url.searchParams.get("limit") ?? "10",
+    10,
+  );
+
+  const page =
+    Number.isFinite(parsedPage) && parsedPage > 0
+      ? parsedPage
+      : 1;
+  const limit =
+    Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? Math.min(parsedLimit, 100)
+      : 10;
 
   try {
-    console.log("===== MATCH API CALLED =====");
-    console.log("User:", session.user.id);
-    console.log("Destination:", destination);
-    console.log("Date:", date);
     const cacheKey = await buildMatchCacheKey({
       destination,
       date,
-      userId: session.user.id,
+      userId: currentUserId,
       filters: {
         gender: genderFilter,
         tripPurpose: tripPurposeFilter,
         ageMin,
         ageMax,
-        startDate: filterStartDate?.toISOString(),
-        endDate: filterEndDate?.toISOString(),
+        startDate:
+          filterStartDate &&
+          !Number.isNaN(filterStartDate.getTime())
+            ? filterStartDate.toISOString()
+            : null,
+        endDate:
+          filterEndDate &&
+          !Number.isNaN(filterEndDate.getTime())
+            ? filterEndDate.toISOString()
+            : null,
       },
     });
-    const cacheKey = `matches:${destination.toLowerCase()}:${date}:${session.user.id}`;
 
-    // Get all blocked user IDs (both blocker and blocked)
     const blocks = await prisma.block.findMany({
       where: {
         OR: [
-          { blockerId: session.user!.id },
-          { blockedId: session.user!.id },
+          { blockerId: session.user.id },
+          { blockedId: session.user.id },
         ],
       },
       select: {
@@ -146,22 +190,32 @@ export async function GET(req: NextRequest) {
         blockedId: true,
       },
     });
-    const blockedUserIds = blocks.map((b) =>
-      b.blockerId === session.user!.id ? b.blockedId : b.blockerId
-    );
 
-    // Check cache. Redis failures safely fall back to the database.
-    const parsedMatches =
+    const blockedUserIds = blocks.map(
+  (block: {
+    blockerId: string;
+    blockedId: string;
+  }) =>
+    block.blockerId === currentUserId
+      ? block.blockedId
+      : block.blockerId,
+);
+
+    const cachedMatches =
       await readMatchCache<any[]>(cacheKey);
 
-    if (parsedMatches) {
-      // Filter out any newly blocked users from cached results
-      const filteredMatches = parsedMatches.filter(
-        (m: any) => !blockedUserIds.includes(m.userId)
+    if (cachedMatches) {
+      const filteredMatches = cachedMatches.filter(
+        (match: any) =>
+          !blockedUserIds.includes(match.userId),
       );
+
       const total = filteredMatches.length;
       const skip = (page - 1) * limit;
-      const paginatedMatches = filteredMatches.slice(skip, skip + limit);
+      const paginatedMatches = filteredMatches.slice(
+        skip,
+        skip + limit,
+      );
       const hasMore = skip + limit < total;
 
       return apiJson(
@@ -177,9 +231,10 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    // Load current user profile details for scoring comparisons
     const currentUser = await prisma.user.findUnique({
-      where: { id: session.user!.id },
+      where: {
+        id: session.user.id,
+      },
       select: {
         languages: true,
         travelInterests: true,
@@ -189,12 +244,29 @@ export async function GET(req: NextRequest) {
       },
     });
 
-    // Find verified tickets for same destination within ±3 days (or custom filter window)
     const targetDate = new Date(date);
+
+    if (Number.isNaN(targetDate.getTime())) {
+      return apiError(
+        requestId,
+        API_ERROR_CODES.VALIDATION_ERROR,
+        "The request data is invalid",
+        400,
+        {
+          date: ["Date is invalid"],
+        },
+      );
+    }
+
     const defaultStartDate = new Date(targetDate);
-    defaultStartDate.setDate(defaultStartDate.getDate() - 3);
+    defaultStartDate.setDate(
+      defaultStartDate.getDate() - 3,
+    );
+
     const defaultEndDate = new Date(targetDate);
-    defaultEndDate.setDate(defaultEndDate.getDate() + 3);
+    defaultEndDate.setDate(
+      defaultEndDate.getDate() + 3,
+    );
 
     const whereClause: any = {
       destination: {
@@ -202,16 +274,30 @@ export async function GET(req: NextRequest) {
         mode: "insensitive",
       },
       departureDate: {
-        gte: filterStartDate || defaultStartDate,
-        lte: filterEndDate || defaultEndDate,
+        gte:
+          filterStartDate &&
+          !Number.isNaN(filterStartDate.getTime())
+            ? filterStartDate
+            : defaultStartDate,
+        lte:
+          filterEndDate &&
+          !Number.isNaN(filterEndDate.getTime())
+            ? filterEndDate
+            : defaultEndDate,
       },
       status: "VERIFIED",
       userId: {
-        notIn: [session.user.id, ...blockedUserIds],
+        notIn: [
+          session.user.id,
+          ...blockedUserIds,
+        ],
       },
     };
 
-    if (tripPurposeFilter && tripPurposeFilter !== "All") {
+    if (
+      tripPurposeFilter &&
+      tripPurposeFilter !== "All"
+    ) {
       whereClause.tripPurpose = {
         equals: tripPurposeFilter,
         mode: "insensitive",
@@ -219,23 +305,39 @@ export async function GET(req: NextRequest) {
     }
 
     const userWhere: any = {};
-    if (genderFilter && genderFilter !== "All") {
+
+    if (
+      genderFilter &&
+      genderFilter !== "All"
+    ) {
       userWhere.gender = {
         equals: genderFilter,
         mode: "insensitive",
       };
     }
+
     if (ageMin !== null || ageMax !== null) {
       userWhere.age = {};
-      if (ageMin !== null) userWhere.age.gte = ageMin;
-      if (ageMax !== null) userWhere.age.lte = ageMax;
+
+      if (
+        ageMin !== null &&
+        Number.isFinite(ageMin)
+      ) {
+        userWhere.age.gte = ageMin;
+      }
+
+      if (
+        ageMax !== null &&
+        Number.isFinite(ageMax)
+      ) {
+        userWhere.age.lte = ageMax;
+      }
     }
 
     if (Object.keys(userWhere).length > 0) {
       whereClause.user = userWhere;
     }
 
-    // Fetch up to 100 candidate tickets to prevent high-memory queries
     const matches = await prisma.ticket.findMany({
       where: whereClause,
       take: 100,
@@ -259,49 +361,45 @@ export async function GET(req: NextRequest) {
       },
     });
 
-    const foundMatches = matches || [];
-    console.log("Matches found:", foundMatches.length);
-    // Save to cache. The helper retains the existing five-minute TTL.
-    await writeMatchCache(cacheKey, foundMatches);
+    const scoredMatches = matches
+      .map((match: any) => ({
+        ...match,
+        relevanceScore: calculateRelevance(
+          currentUser,
+          match.user,
+          new Date(match.departureDate),
+          targetDate,
+        ),
+      }))
+      .sort(
+        (first: any, second: any) =>
+          second.relevanceScore -
+          first.relevanceScore,
+      );
 
-    if (foundMatches.length > 0) {
-      console.log("Creating MATCH_FOUND notification...");
+    await writeMatchCache(
+      cacheKey,
+      scoredMatches,
+    );
+
+    if (scoredMatches.length > 0) {
       await createNotification({
         userId: session.user.id,
         type: "MATCH_FOUND",
         title: "New traveller match found",
-        content: `We found ${foundMatches.length} traveller${foundMatches.length > 1 ? "s" : ""} matching your destination and travel date.`,
+        content: `We found ${scoredMatches.length} traveller${
+          scoredMatches.length > 1 ? "s" : ""
+        } matching your destination and travel date.`,
         link: "/dashboard",
       });
-      console.log("Notification created.");
-    }
-    // Rank and score matches by compatibility
-    const scoredMatches = foundMatches.map((match: any) => {
-      const score = calculateRelevance(
-        currentUser,
-        match.user,
-        new Date(match.departureDate),
-        targetDate
-      );
-      return {
-        ...match,
-        relevanceScore: score,
-      };
-    }).sort((a: any, b: any) => b.relevanceScore - a.relevanceScore);
-
-    // Save full scored matches list to cache (TTL: 5 minutes)
-    try {
-      if (redis) {
-        await redis.set(cacheKey, JSON.stringify(scoredMatches), "EX", 300);
-      }
-    } catch {
-      console.warn("Redis unavailable. Cache write skipped.");
     }
 
-    // Apply pagination
     const total = scoredMatches.length;
     const skip = (page - 1) * limit;
-    const paginatedMatches = scoredMatches.slice(skip, skip + limit);
+    const paginatedMatches = scoredMatches.slice(
+      skip,
+      skip + limit,
+    );
     const hasMore = skip + limit < total;
 
     return apiJson(
@@ -316,7 +414,12 @@ export async function GET(req: NextRequest) {
       requestId,
     );
   } catch (error) {
-    logApiError(requestId, "Match search failed", error);
+    logApiError(
+      requestId,
+      "Match search failed",
+      error,
+    );
+
     return apiError(
       requestId,
       API_ERROR_CODES.INTERNAL_ERROR,

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -1,7 +1,11 @@
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
-import redis from "@/lib/redis";
+import {
+  buildMatchCacheKey,
+  readMatchCache,
+  writeMatchCache,
+} from "@/lib/match-cache";
 import { createNotification } from "@/lib/notifications";
 
 function calculateRelevance(
@@ -95,8 +99,20 @@ export async function GET(req: NextRequest) {
     console.log("User:", session.user.id);
     console.log("Destination:", destination);
     console.log("Date:", date);
-    const cacheKey = `matches:${destination.toLowerCase()}:${date}:${session.user.id}`;
-    
+    const cacheKey = await buildMatchCacheKey({
+      destination,
+      date,
+      userId: session.user.id,
+      filters: {
+        gender: genderFilter,
+        tripPurpose: tripPurposeFilter,
+        ageMin,
+        ageMax,
+        startDate: filterStartDate?.toISOString(),
+        endDate: filterEndDate?.toISOString(),
+      },
+    });
+
     // Get all blocked user IDs (both blocker and blocked)
     const blocks = await prisma.block.findMany({
       where: {
@@ -114,18 +130,11 @@ export async function GET(req: NextRequest) {
       b.blockerId === session.user!.id ? b.blockedId : b.blockerId
     );
 
-    // Check cache (skip if Redis is unavailable)
-    let cachedMatches: string | null = null;
-    try {
-      if (redis) {
-        cachedMatches = await redis.get(cacheKey);
-      }
-    } catch {
-      console.warn("Redis unavailable. Skipping cache.");
-    }
+    // Check cache. Redis failures safely fall back to the database.
+    const parsedMatches =
+      await readMatchCache<any[]>(cacheKey);
 
-    if (cachedMatches) {
-      const parsedMatches: any[] = JSON.parse(cachedMatches);
+    if (parsedMatches) {
       // Filter out any newly blocked users from cached results
       const filteredMatches = parsedMatches.filter(
         (m: any) => !blockedUserIds.includes(m.userId)
@@ -229,14 +238,8 @@ export async function GET(req: NextRequest) {
 
     const foundMatches = matches || [];
     console.log("Matches found:", foundMatches.length);
-    // Save to cache (TTL: 5 minutes)
-    try {
-      if (redis) {
-        await redis.set(cacheKey, JSON.stringify(foundMatches), "EX", 300);
-      }
-    } catch {
-      console.warn("Redis unavailable. Cache not saved.");
-    }
+    // Save to cache. The helper retains the existing five-minute TTL.
+    await writeMatchCache(cacheKey, foundMatches);
 
     if (foundMatches.length > 0) {
       console.log("Creating MATCH_FOUND notification...");

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -181,8 +181,7 @@ export async function GET(req: NextRequest) {
     const blocks = await prisma.block.findMany({
       where: {
         OR: [
-          { blockerId: session.user.id },
-          { blockedId: session.user.id },
+          { blockerId: currentUserId },
         ],
       },
       select: {

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -1,25 +1,12 @@
-import { NextRequest } from "next/server";
-import { z } from "zod";
-
-import {
-  API_ERROR_CODES,
-  logApiError,
-} from "@/lib/api-error";
-import { apiError, apiJson } from "@/lib/api-response";
+import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withValidation } from "@/lib/withValidation";
 import { uploadFileToCloudinary } from "@/lib/cloudinary-upload";
 import { invalidateMatchCachesForTicket } from "@/lib/match-cache";
-import prisma from "@/lib/prisma";
-import { getRequestId } from "@/lib/request-id";
-import { withValidation } from "@/lib/withValidation";
-import {
-  applyRateLimitHeaders,
-  checkRateLimit,
-  getRateLimitIdentifier,
-  rateLimitExceededResponse,
-} from "@/lib/rate-limit";
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
 const ALLOWED_TYPES = [
   "image/jpeg",
@@ -29,83 +16,47 @@ const ALLOWED_TYPES = [
 ];
 
 const ticketSchema = z.object({
-  destination: z.string().min(1, "Destination is required"),
-  departureDate: z
-    .string()
-    .refine((date) => !Number.isNaN(Date.parse(date)), {
-      message: "Departure date is invalid",
-    }),
+  destination: z.string().min(1, "Destination required"),
+  departureDate: z.string().refine((date) => !isNaN(Date.parse(date)), {
+    message: "Invalid date format",
+  }),
   file: z
-    .any()
-    .refine((value) => value instanceof File, "File is required")
-    .refine(
-      (value) => value instanceof File && value.size > 0,
-      "File is required",
-    )
-    .refine(
-      (value) =>
-        value instanceof File &&
-        value.size <= MAX_FILE_SIZE,
-      "File size exceeds 10MB",
-    )
-    .refine(
-      (value) =>
-        value instanceof File &&
-        ALLOWED_TYPES.includes(value.type),
-      "Unsupported file type",
-    ),
+  .any()
+  .refine((val) => val instanceof File, "File required")
+  .refine((val) => val instanceof File && val.size > 0, "File required")
+  .refine((val) => val instanceof File && val.size <= MAX_FILE_SIZE, "File size exceeds 10MB")
+  .refine(
+    (val) => val instanceof File && ALLOWED_TYPES.includes(val.type),
+    "Unsupported file type"
+  ),
 });
 
-export const POST = withValidation(
-  ticketSchema,
-  async (_request, data, { requestId }) => {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return apiError(
-        requestId,
-        API_ERROR_CODES.UNAUTHORIZED,
-        "Authentication is required",
-        401,
-      );
-    }
-  const rateLimit = await checkRateLimit({
-    namespace: "tickets:upload",
-    identifier: getRateLimitIdentifier(req, session.user.id),
-    limit: 5,
-    windowSeconds: 60 * 60,
-  });
-
-  if (!rateLimit.allowed) {
-    return rateLimitExceededResponse(rateLimit);
+export const POST = withValidation(ticketSchema, async (req, data) => {
+  // 🔒 Verify authentication
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {
     const { destination, departureDate, file } = data;
 
-    try {
-      const uploaded = await uploadFileToCloudinary(
-        data.file,
-        "travellers/tickets",
-      );
+    const uploaded = await uploadFileToCloudinary(
+      file,
+      "travellers/tickets"
+    );
 
-      const ticket = await prisma.ticket.create({
-        data: {
-          userId: session.user.id,
-          destination: data.destination,
-          departureDate: new Date(data.departureDate),
-          ticketUrl: uploaded.url,
-          status: "PENDING",
-        },
-      });
+    const ticketUrl = uploaded.url;
 
-      return apiJson(
-        { ok: true, ticket },
-        requestId,
-        { status: 201 },
-      );
-    } catch (error) {
-      logApiError(requestId, "Ticket upload failed", error);
+    const ticket = await prisma.ticket.create({
+      data: {
+        userId: session.user.id,
+        destination,
+        departureDate: new Date(departureDate),
+        ticketUrl,
+        status: "PENDING",
+      },
+    });
 
     await invalidateMatchCachesForTicket({
       destination: ticket.destination,
@@ -113,17 +64,6 @@ export const POST = withValidation(
     });
 
     return NextResponse.json({ ok: true, ticket });
-      return apiError(
-        requestId,
-        API_ERROR_CODES.INTERNAL_ERROR,
-        "Unable to upload the ticket",
-        500,
-      );
-    }
-    return applyRateLimitHeaders(
-      NextResponse.json({ ok: true, ticket }),
-      rateLimit,
-    ) as NextResponse;
   } catch (error) {
     console.error("Ticket upload error:", error);
     return NextResponse.json(
@@ -133,21 +73,16 @@ export const POST = withValidation(
         ? error.message
         : "Failed to upload ticket",
   },
-  undefined,
-  { standardizeErrors: true },
+  { status: 500 }
 );
+  }
+});
 
-export async function GET(request: NextRequest) {
-  const requestId = getRequestId(request);
+// Get user's tickets
+export async function GET(req: NextRequest) {
   const session = await auth();
-
   if (!session?.user?.id) {
-    return apiError(
-      requestId,
-      API_ERROR_CODES.UNAUTHORIZED,
-      "Authentication is required",
-      401,
-    );
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {
@@ -156,15 +91,12 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: "desc" },
     });
 
-    return apiJson({ tickets }, requestId);
+    return NextResponse.json({ tickets });
   } catch (error) {
-    logApiError(requestId, "Ticket listing failed", error);
-
-    return apiError(
-      requestId,
-      API_ERROR_CODES.INTERNAL_ERROR,
-      "Unable to fetch tickets",
-      500,
+    console.error("Fetch tickets error:", error);
+    return NextResponse.json(
+      { error: "Server error" },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/tickets/route.ts
+++ b/src/app/api/tickets/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withValidation } from "@/lib/withValidation";
 import { uploadFileToCloudinary } from "@/lib/cloudinary-upload";
+import { invalidateMatchCachesForTicket } from "@/lib/match-cache";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -55,6 +56,11 @@ export const POST = withValidation(ticketSchema, async (req, data) => {
         ticketUrl,
         status: "PENDING",
       },
+    });
+
+    await invalidateMatchCachesForTicket({
+      destination: ticket.destination,
+      departureDate: ticket.departureDate,
     });
 
     return NextResponse.json({ ok: true, ticket });

--- a/src/app/api/user/__tests__/profile-expansion.test.ts
+++ b/src/app/api/user/__tests__/profile-expansion.test.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { POST as onboardPOST } from "../onboard/route";
 import { GET as profileGET, PATCH as profilePATCH } from "../profile/route";
 import { auth } from "@/lib/auth";
+ import { NextRequest } from "next/server";
 
 vi.mock("@/lib/prisma", () => ({
   default: {
@@ -102,7 +103,13 @@ describe("Traveler Profiles & Onboarding Flow API Endpoints", () => {
       };
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockProfile as any);
 
-      const res = await profileGET();
+     
+
+const res = await profileGET(
+  new NextRequest(
+    "http://localhost/api/user/profile",
+  ),
+);
       const data = await res.json();
 
       expect(res.status).toBe(200);

--- a/src/app/api/user/__tests__/profile-expansion.test.ts
+++ b/src/app/api/user/__tests__/profile-expansion.test.ts
@@ -3,7 +3,7 @@ import prisma from "@/lib/prisma";
 import { POST as onboardPOST } from "../onboard/route";
 import { GET as profileGET, PATCH as profilePATCH } from "../profile/route";
 import { auth } from "@/lib/auth";
- import { NextRequest } from "next/server";
+import { NextRequest } from "next/server";
 
 vi.mock("@/lib/prisma", () => ({
   default: {

--- a/src/app/api/user/__tests__/profile-expansion.test.ts
+++ b/src/app/api/user/__tests__/profile-expansion.test.ts
@@ -106,7 +106,6 @@ describe("Traveler Profiles & Onboarding Flow API Endpoints", () => {
      
 
 const res = await profileGET(
-      const res = await profileGET(
   new NextRequest(
     "http://localhost/api/user/profile",
   ),

--- a/src/lib/__tests__/match-cache.test.ts
+++ b/src/lib/__tests__/match-cache.test.ts
@@ -1,0 +1,282 @@
+import {
+  buildMatchCacheKey,
+  getAffectedMatchDates,
+  getMatchCacheVersion,
+  invalidateMatchCachesForTicket,
+  MATCH_CACHE_TTL,
+  normalizeMatchDestination,
+  readMatchCache,
+  writeMatchCache,
+  type MatchCacheStore,
+} from "@/lib/match-cache";
+import { describe, expect, it, vi } from "vitest";
+
+class MemoryStore implements MatchCacheStore {
+  readonly values = new Map<string, string>();
+  readonly expirations = new Map<string, number>();
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async set(
+    key: string,
+    value: string | number,
+    mode?: string,
+    duration?: number,
+  ): Promise<"OK"> {
+    this.values.set(key, String(value));
+    if (mode === "EX" && duration) {
+      this.expirations.set(key, duration);
+    }
+    return "OK";
+  }
+
+  async incr(key: string): Promise<number> {
+    const next =
+      Number(this.values.get(key) ?? "0") + 1;
+    this.values.set(key, String(next));
+    return next;
+  }
+
+  async expire(
+    key: string,
+    seconds: number,
+  ): Promise<number> {
+    this.expirations.set(key, seconds);
+    return 1;
+  }
+}
+
+describe("match-cache keys", () => {
+  it("normalizes destination values consistently", () => {
+    expect(
+      normalizeMatchDestination("  NEW   Delhi "),
+    ).toBe("new delhi");
+  });
+
+  it("creates the same key for equivalent destinations", async () => {
+    const store = new MemoryStore();
+
+    const first = await buildMatchCacheKey(
+      {
+        destination: "New Delhi",
+        date: "2026-08-15",
+        userId: "user-1",
+      },
+      store,
+    );
+    const second = await buildMatchCacheKey(
+      {
+        destination: " new   DELHI ",
+        date: "2026-08-15",
+        userId: "user-1",
+      },
+      store,
+    );
+
+    expect(first).toBe(second);
+  });
+
+  it("separates advanced filter combinations", async () => {
+    const store = new MemoryStore();
+
+    const first = await buildMatchCacheKey(
+      {
+        destination: "Goa",
+        date: "2026-08-15",
+        userId: "user-1",
+        filters: { gender: "Female" },
+      },
+      store,
+    );
+    const second = await buildMatchCacheKey(
+      {
+        destination: "Goa",
+        date: "2026-08-15",
+        userId: "user-1",
+        filters: { gender: "Male" },
+      },
+      store,
+    );
+
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("cache reads and writes", () => {
+  it("supports cache miss and cache hit", async () => {
+    const store = new MemoryStore();
+    const key = "matches:test";
+
+    await expect(
+      readMatchCache(key, store),
+    ).resolves.toBeNull();
+
+    await writeMatchCache(
+      key,
+      [{ userId: "user-2" }],
+      store,
+    );
+
+    await expect(
+      readMatchCache(key, store),
+    ).resolves.toEqual([
+      { userId: "user-2" },
+    ]);
+    expect(store.expirations.get(key)).toBe(
+      MATCH_CACHE_TTL,
+    );
+  });
+});
+
+describe("cache invalidation", () => {
+  it("invalidates the seven default search dates around a ticket", async () => {
+    const store = new MemoryStore();
+
+    await invalidateMatchCachesForTicket(
+      {
+        destination: "Goa",
+        departureDate: "2026-08-15",
+      },
+      null,
+      store,
+    );
+
+    expect(
+      getAffectedMatchDates("2026-08-15"),
+    ).toEqual([
+      "2026-08-12",
+      "2026-08-13",
+      "2026-08-14",
+      "2026-08-15",
+      "2026-08-16",
+      "2026-08-17",
+      "2026-08-18",
+    ]);
+
+    for (const date of getAffectedMatchDates(
+      "2026-08-15",
+    )) {
+      await expect(
+        getMatchCacheVersion(
+          "goa",
+          date,
+          store,
+        ),
+      ).resolves.toBe(1);
+    }
+  });
+
+  it("changes cache keys after approval or rejection invalidation", async () => {
+    const store = new MemoryStore();
+    const input = {
+      destination: "Goa",
+      date: "2026-08-15",
+      userId: "search-user",
+    };
+
+    const before = await buildMatchCacheKey(
+      input,
+      store,
+    );
+
+    await invalidateMatchCachesForTicket(
+      {
+        destination: "Goa",
+        departureDate: "2026-08-15",
+      },
+      null,
+      store,
+    );
+
+    const after = await buildMatchCacheKey(
+      input,
+      store,
+    );
+
+    expect(before).toContain(":v0");
+    expect(after).toContain(":v1");
+    expect(after).not.toBe(before);
+  });
+
+  it("invalidates old and new windows after destination or date changes", async () => {
+    const store = new MemoryStore();
+
+    await invalidateMatchCachesForTicket(
+      {
+        destination: "Mumbai",
+        departureDate: "2026-09-10",
+      },
+      {
+        destination: "Goa",
+        departureDate: "2026-08-15",
+      },
+      store,
+    );
+
+    await expect(
+      getMatchCacheVersion(
+        "Goa",
+        "2026-08-15",
+        store,
+      ),
+    ).resolves.toBe(1);
+    await expect(
+      getMatchCacheVersion(
+        "Mumbai",
+        "2026-09-10",
+        store,
+      ),
+    ).resolves.toBe(1);
+  });
+
+  it("fails safely when Redis is unavailable", async () => {
+    const broken: MatchCacheStore = {
+      get: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Redis unavailable"),
+        ),
+      set: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Redis unavailable"),
+        ),
+      incr: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Redis unavailable"),
+        ),
+      expire: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Redis unavailable"),
+        ),
+    };
+    const warn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      getMatchCacheVersion(
+        "Goa",
+        "2026-08-15",
+        broken,
+      ),
+    ).resolves.toBe(0);
+    await expect(
+      invalidateMatchCachesForTicket(
+        {
+          destination: "Goa",
+          departureDate: "2026-08-15",
+        },
+        null,
+        broken,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/src/lib/match-cache.ts
+++ b/src/lib/match-cache.ts
@@ -100,7 +100,7 @@ function filterFingerprint(
 export async function getMatchCacheVersion(
   destination: string,
   date: string,
-  store: MatchCacheStore | null = redis,
+  store: MatchCacheStore | null = redis as unknown as MatchCacheStore | null,
 ): Promise<number> {
   if (!store) {
     return 0;
@@ -126,7 +126,7 @@ export async function getMatchCacheVersion(
 
 export async function buildMatchCacheKey(
   input: MatchCacheKeyInput,
-  store: MatchCacheStore | null = redis,
+  store: MatchCacheStore | null = redis as unknown as MatchCacheStore | null,
 ): Promise<string> {
   const destination =
     normalizeMatchDestination(input.destination);
@@ -149,7 +149,7 @@ export async function buildMatchCacheKey(
 
 export async function readMatchCache<T>(
   key: string,
-  store: MatchCacheStore | null = redis,
+  store: MatchCacheStore | null = redis as unknown as MatchCacheStore | null,
 ): Promise<T | null> {
   if (!store) {
     return null;
@@ -170,7 +170,7 @@ export async function readMatchCache<T>(
 export async function writeMatchCache<T>(
   key: string,
   value: T,
-  store: MatchCacheStore | null = redis,
+  store: MatchCacheStore | null = redis as unknown as MatchCacheStore | null,
 ): Promise<void> {
   if (!store) {
     return;
@@ -239,7 +239,7 @@ async function incrementVersion(
 export async function invalidateMatchCachesForTicket(
   current: TicketCacheIdentity,
   previous?: TicketCacheIdentity | null,
-  store: MatchCacheStore | null = redis,
+  store: MatchCacheStore | null = redis as unknown as MatchCacheStore | null,
 ): Promise<void> {
   if (!store) {
     return;

--- a/src/lib/match-cache.ts
+++ b/src/lib/match-cache.ts
@@ -1,0 +1,288 @@
+import { createHash } from "node:crypto";
+import type Redis from "ioredis";
+
+import redis from "@/lib/redis";
+
+const MATCH_CACHE_TTL_SECONDS = 5 * 60;
+const DEFAULT_WINDOW_DAYS = 3;
+
+export interface MatchCacheFilters {
+  gender?: string | null;
+  tripPurpose?: string | null;
+  ageMin?: number | null;
+  ageMax?: number | null;
+  startDate?: string | null;
+  endDate?: string | null;
+}
+
+export interface MatchCacheKeyInput {
+  destination: string;
+  date: string;
+  userId: string;
+  filters?: MatchCacheFilters;
+}
+
+export interface TicketCacheIdentity {
+  destination: string;
+  departureDate: Date | string;
+}
+
+export interface MatchCacheStore {
+  get(key: string): Promise<string | null>;
+  set(
+    key: string,
+    value: string | number,
+    mode?: string,
+    duration?: number,
+  ): Promise<unknown>;
+  incr(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<number>;
+}
+
+export function normalizeMatchDestination(
+  destination: string,
+): string {
+  return destination
+    .normalize("NFKC")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLocaleLowerCase("en");
+}
+
+export function normalizeMatchDate(
+  value: Date | string,
+): string {
+  const date =
+    value instanceof Date
+      ? value
+      : /^\d{4}-\d{2}-\d{2}$/.test(value)
+        ? new Date(`${value}T00:00:00.000Z`)
+        : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Match cache date is invalid.");
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+function versionKey(
+  destination: string,
+  date: string,
+): string {
+  return `matches-version:${normalizeMatchDestination(
+    destination,
+  )}:${normalizeMatchDate(date)}`;
+}
+
+function filterFingerprint(
+  filters: MatchCacheFilters = {},
+): string {
+  const canonical = JSON.stringify({
+    gender: filters.gender ?? null,
+    tripPurpose: filters.tripPurpose ?? null,
+    ageMin: filters.ageMin ?? null,
+    ageMax: filters.ageMax ?? null,
+    startDate: filters.startDate
+      ? normalizeMatchDate(filters.startDate)
+      : null,
+    endDate: filters.endDate
+      ? normalizeMatchDate(filters.endDate)
+      : null,
+  });
+
+  return createHash("sha256")
+    .update(canonical)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export async function getMatchCacheVersion(
+  destination: string,
+  date: string,
+  store: MatchCacheStore | null = redis,
+): Promise<number> {
+  if (!store) {
+    return 0;
+  }
+
+  try {
+    const raw = await store.get(
+      versionKey(destination, date),
+    );
+    const parsed = Number(raw);
+
+    return Number.isSafeInteger(parsed) && parsed >= 0
+      ? parsed
+      : 0;
+  } catch (error) {
+    console.warn(
+      "Match-cache version unavailable:",
+      error instanceof Error ? error.message : error,
+    );
+    return 0;
+  }
+}
+
+export async function buildMatchCacheKey(
+  input: MatchCacheKeyInput,
+  store: MatchCacheStore | null = redis,
+): Promise<string> {
+  const destination =
+    normalizeMatchDestination(input.destination);
+  const date = normalizeMatchDate(input.date);
+  const version = await getMatchCacheVersion(
+    destination,
+    date,
+    store,
+  );
+
+  return [
+    "matches",
+    destination,
+    date,
+    input.userId,
+    filterFingerprint(input.filters),
+    `v${version}`,
+  ].join(":");
+}
+
+export async function readMatchCache<T>(
+  key: string,
+  store: MatchCacheStore | null = redis,
+): Promise<T | null> {
+  if (!store) {
+    return null;
+  }
+
+  try {
+    const cached = await store.get(key);
+    return cached ? (JSON.parse(cached) as T) : null;
+  } catch (error) {
+    console.warn(
+      "Match cache unavailable; skipping read:",
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+export async function writeMatchCache<T>(
+  key: string,
+  value: T,
+  store: MatchCacheStore | null = redis,
+): Promise<void> {
+  if (!store) {
+    return;
+  }
+
+  try {
+    await store.set(
+      key,
+      JSON.stringify(value),
+      "EX",
+      MATCH_CACHE_TTL_SECONDS,
+    );
+  } catch (error) {
+    console.warn(
+      "Match cache unavailable; skipping write:",
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
+function addUtcDays(
+  date: Date,
+  days: number,
+): Date {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+export function getAffectedMatchDates(
+  departureDate: Date | string,
+  windowDays = DEFAULT_WINDOW_DAYS,
+): string[] {
+  const normalized = normalizeMatchDate(departureDate);
+  const center = new Date(
+    `${normalized}T00:00:00.000Z`,
+  );
+  const dates: string[] = [];
+
+  for (
+    let offset = -windowDays;
+    offset <= windowDays;
+    offset += 1
+  ) {
+    dates.push(
+      normalizeMatchDate(addUtcDays(center, offset)),
+    );
+  }
+
+  return dates;
+}
+
+async function incrementVersion(
+  destination: string,
+  date: string,
+  store: MatchCacheStore,
+): Promise<void> {
+  const key = versionKey(destination, date);
+  await store.incr(key);
+
+  // Prevent permanent accumulation of version keys while retaining a
+  // generous fallback period for old cache entries to expire.
+  await store.expire(key, 30 * 24 * 60 * 60);
+}
+
+export async function invalidateMatchCachesForTicket(
+  current: TicketCacheIdentity,
+  previous?: TicketCacheIdentity | null,
+  store: MatchCacheStore | null = redis,
+): Promise<void> {
+  if (!store) {
+    return;
+  }
+
+  const identities = [previous, current].filter(
+    (value): value is TicketCacheIdentity =>
+      Boolean(value),
+  );
+  const keys = new Set<string>();
+
+  for (const identity of identities) {
+    const destination =
+      normalizeMatchDestination(
+        identity.destination,
+      );
+
+    for (const date of getAffectedMatchDates(
+      identity.departureDate,
+    )) {
+      keys.add(`${destination}\u0000${date}`);
+    }
+  }
+
+  try {
+    await Promise.all(
+      [...keys].map((entry) => {
+        const [destination, date] =
+          entry.split("\u0000");
+        return incrementVersion(
+          destination,
+          date,
+          store,
+        );
+      }),
+    );
+  } catch (error) {
+    console.warn(
+      "Match-cache invalidation failed:",
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
+export const MATCH_CACHE_TTL =
+  MATCH_CACHE_TTL_SECONDS;


### PR DESCRIPTION
## 🔗 Related Issue

Closes #289

## 📝 Description

This PR centralizes match-cache key generation and invalidates stale match results whenever relevant ticket data or verification status changes.

### Changes made

* Added a reusable match-cache utility.
* Added consistent Unicode, whitespace, and case normalization for destination cache keys.
* Added versioned destination/date cache namespaces.
* Added advanced-filter fingerprints to prevent different filter combinations from sharing the same cache entry.
* Preserved the existing five-minute cache TTL.
* Invalidated the ticket date and the three days on either side to match the existing traveller-search window.
* Invalidated both previous and current destination/date windows for future ticket update support.
* Invalidated match caches after ticket creation.
* Invalidated match caches after admin verification or rejection.
* Preserved the current match API response contract, including `cached`.
* Avoided Redis `KEYS` and other production-wide cache scans.
* Made cache reads, writes, and invalidations fail safely when Redis is unavailable.
* Added tests for cache hit, cache miss, ticket approval, rejection, old/new destination/date changes, affected date windows, filter-specific keys, and Redis failure.

## 🛠️ Type of Change

* [x] 🐛 Cache consistency fix
* [x] ✨ Backend enhancement
* [x] ⚡ Performance/reliability improvement
* [ ] 📚 Documentation update
* [x] 🧪 Tests

## 🧪 Testing Performed

* [ ] `npx vitest run src/lib/__tests__/match-cache.test.ts`
* [ ] `npx vitest run "src/app/api/admin/tickets/[id]/__tests__/cache-invalidation.test.ts"`
* [ ] `npm test`
* [ ] `npx tsc --noEmit`
* [ ] `npm run lint`
* [ ] Verified repeated identical searches return `cached: true`
* [ ] Verified ticket approval causes the next search to return `cached: false`
* [ ] Verified ticket rejection invalidates stale verified results
* [ ] Verified new ticket upload invalidates affected date windows
* [ ] Verified Redis failures do not block search, upload, or verification

## ✅ Scope Verification

* [x] Matching ranking and date-window logic were not changed.
* [x] No new match filters were added.
* [x] No Prisma model or migration was changed.
* [x] No real-time notification system was added.
* [x] No external dependency was added.
