### PR TITLE
fix(spatial): import maplibre bindings from installed @vis.gl/react-maplibre (#317)

### DIFF
--- a/src/components/spatial/TravelHeatmap.tsx
+++ b/src/components/spatial/TravelHeatmap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Map, { Source, Layer } from "react-map-gl/maplibre";
+import Map, { Source, Layer } from "@vis.gl/react-maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { Loader2 } from "lucide-react";
 


### PR DESCRIPTION
## fix #317

## Description

`TravelHeatmap` imported `react-map-gl/maplibre`, but that package isn't installed — `package.json` ships `@vis.gl/react-maplibre@^8` (the v8 rename of `react-map-gl`). The stale import made `tsc --noEmit` fail with `TS2307: Cannot find module 'react-map-gl/maplibre'` and broke `next build`, so `main` was red on type-check/build in CI.

One-line fix: import the bindings from the installed `@vis.gl/react-maplibre` package (its v8 API still exports `Map`, `Source`, `Layer`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Dependencies

- None. Uses the already-declared `@vis.gl/react-maplibre@^8`; removes the phantom `react-map-gl/maplibre` import.

## Checklist
- [x] Lints pass (`npm run lint`)
- [x] Builds locally — `npx tsc --noEmit` is green after the change (was `TS2307` before)
- [ ] Tests added/updated (no logic change — import path only)
- [x] My changes do not generate new console warnings or errors
- [x] This is already assigned Issue to me, not an unassigned issue.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
