### PR TITLE
fix(auth): generate OTP with CSPRNG and store/compare it hashed (#316)

### DIFF
--- a/src/app/api/auth/resend-otp/route.ts
+++ b/src/app/api/auth/resend-otp/route.ts
@@ -1,7 +1,7 @@
 import prisma from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { generateOTP } from "@/lib/otp";
+import { generateOTP, hashOTP } from "@/lib/otp";
 import { sendOTPEmail } from "@/lib/email";
 import { withValidation } from "@/lib/withValidation";
 import {
@@ -60,7 +60,7 @@ export const POST = withValidation(resendSchema, async (req, data) => {
     // Update user with new OTP
     await prisma.user.update({
       where: { email },
-      data: { otp, otpExpires },
+      data: { otp: hashOTP(otp), otpExpires },
     });
 
     // Send OTP email

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { hash } from "bcryptjs";
 import { z } from "zod";
 
-import { generateOTP } from "@/lib/otp";
+import { generateOTP, hashOTP } from "@/lib/otp";
 import { sendOTPEmail } from "@/lib/email";
 import { withValidation } from "@/lib/withValidation";
 import {
@@ -70,7 +70,7 @@ export const POST = withValidation(
           name,
           email,
           passwordHash,
-          otp,
+          otp: hashOTP(otp),
           otpExpires,
         },
       });

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,7 +1,7 @@
 import prisma from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { isValidOTPFormat } from "@/lib/otp";
+import { isValidOTPFormat, verifyOTP } from "@/lib/otp";
 import { withValidation } from "@/lib/withValidation";
 import {
   applyRateLimitHeaders,
@@ -85,8 +85,8 @@ export const POST = withValidation(verifySchema, async (req, data) => {
       ) as NextResponse;
     }
 
-    // Verify OTP
-    if (user.otp !== otp) {
+    // Verify OTP against the stored hash (constant-time).
+    if (!verifyOTP(otp, user.otp)) {
       return applyRateLimitHeaders(
         NextResponse.json(
           { error: "Invalid OTP" },

--- a/src/lib/__tests__/otp.test.ts
+++ b/src/lib/__tests__/otp.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { generateOTP, hashOTP, verifyOTP, isValidOTPFormat } from "../otp";
+
+describe("otp", () => {
+  it("generateOTP returns a 6-digit numeric code", () => {
+    for (let i = 0; i < 200; i++) {
+      const otp = generateOTP();
+      expect(isValidOTPFormat(otp)).toBe(true);
+      const n = Number(otp);
+      expect(n).toBeGreaterThanOrEqual(100000);
+      expect(n).toBeLessThanOrEqual(999999);
+    }
+  });
+
+  it("hashOTP is deterministic and never returns the plaintext", () => {
+    const otp = "123456";
+    const hash = hashOTP(otp);
+    expect(hash).toBe(hashOTP(otp));
+    expect(hash).not.toBe(otp);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/); // sha256 hex
+  });
+
+  it("verifyOTP accepts the matching code and rejects a wrong one", () => {
+    const otp = generateOTP();
+    const stored = hashOTP(otp);
+    expect(verifyOTP(otp, stored)).toBe(true);
+    expect(verifyOTP("000000", stored)).toBe(false);
+  });
+
+  it("verifyOTP rejects null/empty stored hashes and legacy plaintext", () => {
+    expect(verifyOTP("123456", null)).toBe(false);
+    expect(verifyOTP("123456", undefined)).toBe(false);
+    expect(verifyOTP("123456", "")).toBe(false);
+    expect(verifyOTP("123456", "123456")).toBe(false); // legacy plaintext no longer matches
+  });
+});

--- a/src/lib/otp.ts
+++ b/src/lib/otp.ts
@@ -1,8 +1,28 @@
+import { randomInt, createHash, timingSafeEqual } from "crypto";
+
 /**
- * Generate a 6-digit OTP
+ * Generate a 6-digit OTP using a cryptographically secure RNG.
  */
 export function generateOTP(): string {
-  return Math.floor(100000 + Math.random() * 900000).toString();
+  // randomInt is a CSPRNG; the upper bound is exclusive, so this yields 100000-999999.
+  return randomInt(100000, 1000000).toString();
+}
+
+/**
+ * Hash an OTP for storage, so a read of the users table never exposes a live code.
+ */
+export function hashOTP(otp: string): string {
+  return createHash("sha256").update(otp).digest("hex");
+}
+
+/**
+ * Constant-time comparison of a submitted OTP against a stored hash.
+ */
+export function verifyOTP(otp: string, storedHash: string | null | undefined): boolean {
+  if (!storedHash) return false;
+  const submitted = Buffer.from(hashOTP(otp), "hex");
+  const stored = Buffer.from(storedHash, "hex");
+  return submitted.length === stored.length && timingSafeEqual(submitted, stored);
 }
 
 /**


### PR DESCRIPTION
## fix #316

## Description

The email-verification OTP was generated with `Math.random()` and stored + compared in **plaintext** — two problems on the account-verification trust boundary:

- `Math.random()` isn't a CSPRNG, so a 6-digit code drawn from it is predictable rather than genuinely random.
- Because the code sat in `user.otp` in plaintext, any read of the users table (or a backup/log) exposed live OTPs.

This PR:
- `generateOTP()` now uses `crypto.randomInt(100000, 1000000)` (Node stdlib CSPRNG).
- Stores only a **sha256 hash** of the code (`hashOTP`) — the plaintext is still emailed to the user, but never persisted.
- `verify-otp` compares the submitted code against the stored hash with a **constant-time** check (`timingSafeEqual`).

Legacy plaintext codes no longer verify; since OTPs expire after 10 minutes, any in-flight code just needs a resend after deploy. No schema change (the existing `otp String?` column now holds a hash).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — security hardening

## Checklist
- [x] Lints pass (`npm run lint`)
- [x] Tests added — `src/lib/__tests__/otp.test.ts` covers generation range, hash determinism, and verify accept/reject (4 passing)
- [x] This is already assigned Issue to me, not an unassigned issue.

> Heads-up on CI: `main` is currently red on `tsc`/`build` because of an unrelated stale import in `TravelHeatmap.tsx` (issue #317, fixed in my separate PR #321). This change itself typechecks cleanly — once #321 lands, this PR's build goes green.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
