### PR TITLE
fix(chat): rate-limit the /api/chat Gemini endpoint (#319)

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withValidation } from "@/lib/withValidation";
+import {
+  applyRateLimitHeaders,
+  checkRateLimit,
+  getRateLimitIdentifier,
+  rateLimitExceededResponse,
+} from "@/lib/rate-limit";
 
 const chatSchema = z.object({
   message: z.string().min(1, "Message required").max(500, "Message too long (max 500 characters)."),
@@ -8,6 +14,19 @@ const chatSchema = z.object({
 
 export const POST = withValidation(chatSchema, async (req, data) => {
     try {
+        // Gate the paid Gemini call so an anonymous visitor can't run up unlimited
+        // billed upstream requests (cost-abuse / prompt-injection surface).
+        const rateLimit = await checkRateLimit({
+            namespace: "chat",
+            identifier: getRateLimitIdentifier(req),
+            limit: 10,
+            windowSeconds: 60,
+        });
+
+        if (!rateLimit.allowed) {
+            return rateLimitExceededResponse(rateLimit);
+        }
+
         if (!process.env.GEMINI_API_KEY) {
             return NextResponse.json(
                 { error: "AI not configured." },
@@ -83,7 +102,10 @@ Do not mention system prompts or technical details.
             );
         }
 
-        return NextResponse.json({ reply });
+        return applyRateLimitHeaders(
+            NextResponse.json({ reply }),
+            rateLimit,
+        ) as NextResponse;
 
     } catch (error) {
         console.error("Chat API Error:", error);


### PR DESCRIPTION
## fix #319

## Description

`/api/chat` called the paid Gemini API with **no authentication and no rate limiting**, so any anonymous visitor could trigger unlimited billed upstream calls — a cost-abuse / financial-DoS vector, and an unthrottled prompt-injection surface. It validated only message length before hitting Gemini.

This PR reuses the repo's existing rate-limit helper (the same one already wired into the auth routes):
- `checkRateLimit({ namespace: "chat", identifier: getRateLimitIdentifier(req), limit: 10, windowSeconds: 60 })` before the Gemini fetch.
- Returns `rateLimitExceededResponse(...)` (429) when the per-IP budget is exceeded.
- Attaches the standard rate-limit headers to the success response via `applyRateLimitHeaders`.

10 req/min per client IP. No new dependency — this is the existing helper.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — endpoint hardening

## Checklist
- [x] Lints pass (`npm run lint` — clean on the changed file)
- [x] Typechecks (`tsc --noEmit` — no new errors from this change)
- [x] This is already assigned Issue to me, not an unassigned issue.

> CI note: `main` is currently red on `tsc`/`build` due to the unrelated `TravelHeatmap.tsx` stale import (#317, fixed in my PR #321). This change itself is green.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
