### PR TITLE
fix(matches): remove 100-row cap so total is accurate and all matches reachable (#320)

### DIFF
--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -339,9 +339,13 @@ export async function GET(req: NextRequest) {
       whereClause.user = userWhere;
     }
 
+    // Relevance is scored/sorted in memory, so the full candidate set (bounded
+    // by the destination + date-window + status filters in whereClause) has to
+    // be fetched to rank correctly and report an accurate total. The result is
+    // cached below, so this scan runs once per window and every subsequent page
+    // is served from the cache rather than re-querying.
     const matches = await prisma.ticket.findMany({
       where: whereClause,
-      take: 100,
       select: {
         id: true,
         destination: true,


### PR DESCRIPTION
## fix #320

## Description

`/api/matches` queried with `take: 100`, then scored, sorted and paginated the result set **in memory**. Once a destination/date window had more than 100 matching tickets:
- `total` maxed out at 100 (`const total = scoredMatches.length`),
- `hasMore` went false early,
- and any match past #100 was unreachable.

Relevance is scored in memory (`calculateRelevance` over the current user + target date), so DB-side `skip/take` can't be used without losing the global ranking. The fix is to drop the arbitrary `take: 100` so the full candidate set — already bounded by the `destination` + date-window + status filters in `whereClause` — is ranked and counted correctly.

The scored list is written to the match cache, and the cache-hit branch already slices the full list per page, so the scan runs **once per window** and subsequent pages are served from the cache rather than re-querying. `total` / `hasMore` are now accurate and every match is reachable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] Lints pass (`npm run lint` — clean on the changed file)
- [x] Typechecks (`tsc --noEmit` — no new errors from this change)
- [x] This is already assigned Issue to me, not an unassigned issue.

> CI note: `main` is currently red on `tsc`/`build` due to the unrelated `TravelHeatmap.tsx` stale import (#317, fixed in my PR #321). This change itself is green.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
