### PR TITLE
feat: add notification deduplication and expiry cleanup

### DIFF
--- a/prisma/migrations/20260804221600_add_notification_deduplication_and_expiry/migration.sql
+++ b/prisma/migrations/20260804221600_add_notification_deduplication_and_expiry/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "Notification"
+ADD COLUMN "dedupeKey" TEXT,
+ADD COLUMN "expiresAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Notification_userId_dedupeKey_key"
+ON "Notification"("userId", "dedupeKey");
+
+-- CreateIndex
+CREATE INDEX "Notification_expiresAt_idx"
+ON "Notification"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,22 +15,22 @@ model User {
   image        String? @db.Text // Profile avatar (base64 data URI)
 
   // ✅ NEW PROFILE FIELDS (Safe Additions)
-  bio                 String?     @db.Text
-  location            String?
-  homeLocation        String?
-  phone               String?
-  isDeleted           Boolean     @default(false)  // Soft delete support
-  onboarded           Boolean     @default(false)  // Onboarding status
+  bio          String? @db.Text
+  location     String?
+  homeLocation String?
+  phone        String?
+  isDeleted    Boolean @default(false) // Soft delete support
+  onboarded    Boolean @default(false) // Onboarding status
 
   // ✅ EXPANDED TRAVELER PROFILE FIELDS
-  languages           String[]
-  travelInterests     String[]
-  accommodationPrefs  String[]
-  budgetRange         String?
-  socialLinks         String[]
-  age                 Int?
-  gender              String?
-  travelStyle         String?
+  languages          String[]
+  travelInterests    String[]
+  accommodationPrefs String[]
+  budgetRange        String?
+  socialLinks        String[]
+  age                Int?
+  gender             String?
+  travelStyle        String?
 
   role              Role      @default(USER)
   emailVerified     Boolean   @default(false)
@@ -94,18 +94,17 @@ model Ticket {
   destination   String
   departureDate DateTime
   ticketUrl     String
-  status        TicketStatus  @default(PENDING)
+  status        TicketStatus @default(PENDING)
   tripPurpose   String?
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
 
   @@index([destination, departureDate])
   @@index([userId])
 }
 
 model Notification {
-  id String @id @default(cuid())
-
+  id     String @id @default(cuid())
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId String
 
@@ -116,13 +115,17 @@ model Notification {
 
   read Boolean @default(false)
 
-  link String?
+  link      String?
+  dedupeKey String?
+  expiresAt DateTime?
 
   createdAt DateTime @default(now())
 
+  @@unique([userId, dedupeKey])
   @@index([userId])
   @@index([read])
   @@index([createdAt])
+  @@index([expiresAt])
 }
 
 enum TicketStatus {

--- a/src/app/api/internal/notifications/cleanup/__tests__/route.test.ts
+++ b/src/app/api/internal/notifications/cleanup/__tests__/route.test.ts
@@ -1,0 +1,122 @@
+import { NextRequest } from "next/server";
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { POST } from "@/app/api/internal/notifications/cleanup/route";
+import { cleanupExpiredNotifications } from "@/lib/notifications";
+
+vi.mock("@/lib/notifications", async () => {
+  const actual =
+    await vi.importActual<
+      typeof import("@/lib/notifications")
+    >("@/lib/notifications");
+
+  return {
+    ...actual,
+    cleanupExpiredNotifications: vi.fn(),
+  };
+});
+
+function createRequest(
+  secret?: string,
+  limit?: string,
+) {
+  const url = new URL(
+    "http://localhost/api/internal/notifications/cleanup",
+  );
+
+  if (limit !== undefined) {
+    url.searchParams.set("limit", limit);
+  }
+
+  return new NextRequest(url, {
+    method: "POST",
+    headers: secret
+      ? {
+          "x-notification-cleanup-secret":
+            secret,
+        }
+      : undefined,
+  });
+}
+
+describe("notification cleanup route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NOTIFICATION_CLEANUP_SECRET =
+      "cleanup-secret";
+  });
+
+  it("rejects invalid secrets", async () => {
+    const response = await POST(
+      createRequest("wrong-secret"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(
+      cleanupExpiredNotifications,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("validates the requested batch size", async () => {
+    const response = await POST(
+      createRequest("cleanup-secret", "invalid"),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns cleanup results without exposing the secret", async () => {
+    vi.mocked(
+      cleanupExpiredNotifications,
+    ).mockResolvedValue({
+      deletedCount: 25,
+      hasMore: true,
+      batchSize: 25,
+    });
+
+    const response = await POST(
+      createRequest("cleanup-secret", "25"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(
+      response.headers.get("Cache-Control"),
+    ).toBe("no-store");
+    expect(body).toMatchObject({
+      deletedCount: 25,
+      hasMore: true,
+      batchSize: 25,
+    });
+    expect(JSON.stringify(body)).not.toContain(
+      "cleanup-secret",
+    );
+  });
+
+  it("returns a safe error when cleanup fails", async () => {
+    vi.mocked(
+      cleanupExpiredNotifications,
+    ).mockRejectedValue(
+      new Error("database unavailable"),
+    );
+
+    const response = await POST(
+      createRequest("cleanup-secret"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error.message).toBe(
+      "Unable to clean up expired notifications",
+    );
+    expect(JSON.stringify(body)).not.toContain(
+      "database unavailable",
+    );
+  });
+});

--- a/src/app/api/internal/notifications/cleanup/route.ts
+++ b/src/app/api/internal/notifications/cleanup/route.ts
@@ -1,0 +1,130 @@
+import { timingSafeEqual } from "node:crypto";
+import type { NextRequest } from "next/server";
+
+import {
+  API_ERROR_CODES,
+  logApiError,
+} from "@/lib/api-error";
+import {
+  apiError,
+  apiJson,
+} from "@/lib/api-response";
+import {
+  cleanupExpiredNotifications,
+  normalizeCleanupBatchSize,
+} from "@/lib/notifications";
+import { getRequestId } from "@/lib/request-id";
+
+const CLEANUP_SECRET_HEADER =
+  "x-notification-cleanup-secret";
+
+function secretsMatch(
+  providedSecret: string | null,
+  expectedSecret: string | undefined,
+): boolean {
+  if (!providedSecret || !expectedSecret) {
+    return false;
+  }
+
+  const provided = Buffer.from(providedSecret);
+  const expected = Buffer.from(expectedSecret);
+
+  return (
+    provided.length === expected.length &&
+    timingSafeEqual(provided, expected)
+  );
+}
+
+function parseLimit(request: NextRequest): number {
+  const rawLimit =
+    request.nextUrl.searchParams.get("limit");
+
+  if (rawLimit === null) {
+    return normalizeCleanupBatchSize();
+  }
+
+  const parsedLimit = Number(rawLimit);
+
+  if (
+    !Number.isInteger(parsedLimit) ||
+    parsedLimit < 1
+  ) {
+    throw new Error(
+      "Limit must be a positive integer",
+    );
+  }
+
+  return normalizeCleanupBatchSize(parsedLimit);
+}
+
+export async function POST(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const expectedSecret =
+    process.env.NOTIFICATION_CLEANUP_SECRET;
+  const providedSecret =
+    request.headers.get(CLEANUP_SECRET_HEADER);
+
+  if (
+    !secretsMatch(
+      providedSecret,
+      expectedSecret,
+    )
+  ) {
+    return apiError(
+      requestId,
+      API_ERROR_CODES.UNAUTHORIZED,
+      "Invalid cleanup credentials",
+      401,
+    );
+  }
+
+  let batchSize: number;
+
+  try {
+    batchSize = parseLimit(request);
+  } catch (error) {
+    return apiError(
+      requestId,
+      API_ERROR_CODES.VALIDATION_ERROR,
+      error instanceof Error
+        ? error.message
+        : "Invalid cleanup limit",
+      400,
+    );
+  }
+
+  try {
+    const result =
+      await cleanupExpiredNotifications(
+        batchSize,
+      );
+
+    return apiJson(
+      {
+        deletedCount: result.deletedCount,
+        hasMore: result.hasMore,
+        batchSize: result.batchSize,
+      },
+      requestId,
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    logApiError(
+      requestId,
+      "Notification cleanup failed",
+      error,
+    );
+
+    return apiError(
+      requestId,
+      API_ERROR_CODES.INTERNAL_ERROR,
+      "Unable to clean up expired notifications",
+      500,
+    );
+  }
+}

--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,196 @@
+import { NotificationType } from "@prisma/client";
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  cleanupExpiredNotifications,
+  createNotification,
+  normalizeCleanupBatchSize,
+} from "@/lib/notifications";
+import prisma from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    notification: {
+      create: vi.fn(),
+      upsert: vi.fn(),
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+describe("notification deduplication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates ordinary notifications without a dedupe key", async () => {
+    vi.mocked(
+      prisma.notification.create,
+    ).mockResolvedValue({
+      id: "notification-1",
+    } as never);
+
+    await createNotification({
+      userId: "user-1",
+      type: NotificationType.MESSAGE,
+      title: "Message",
+      content: "You have a message",
+    });
+
+    expect(
+      prisma.notification.create,
+    ).toHaveBeenCalledOnce();
+    expect(
+      prisma.notification.upsert,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("uses the user and dedupe key for idempotent creation", async () => {
+    vi.mocked(
+      prisma.notification.upsert,
+    ).mockResolvedValue({
+      id: "notification-1",
+    } as never);
+
+    await createNotification({
+      userId: "user-1",
+      type: NotificationType.MATCH_FOUND,
+      title: "Match found",
+      content: "A matching traveller was found",
+      dedupeKey: "match-found:ticket-1:user-1",
+    });
+
+    expect(
+      prisma.notification.upsert,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_dedupeKey: {
+            userId: "user-1",
+            dedupeKey:
+              "match-found:ticket-1:user-1",
+          },
+        },
+        update: {},
+      }),
+    );
+  });
+
+  it("allows the same dedupe key for different users", async () => {
+    vi.mocked(
+      prisma.notification.upsert,
+    ).mockResolvedValue({
+      id: "notification",
+    } as never);
+
+    for (const userId of ["user-1", "user-2"]) {
+      await createNotification({
+        userId,
+        type: NotificationType.MESSAGE,
+        title: "Message",
+        content: "Content",
+        dedupeKey: "event-1",
+      });
+    }
+
+    expect(
+      prisma.notification.upsert,
+    ).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          userId_dedupeKey: {
+            userId: "user-1",
+            dedupeKey: "event-1",
+          },
+        },
+      }),
+    );
+    expect(
+      prisma.notification.upsert,
+    ).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          userId_dedupeKey: {
+            userId: "user-2",
+            dedupeKey: "event-1",
+          },
+        },
+      }),
+    );
+  });
+});
+
+describe("notification cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes cleanup batch limits", () => {
+    expect(normalizeCleanupBatchSize()).toBe(100);
+    expect(normalizeCleanupBatchSize(0)).toBe(1);
+    expect(normalizeCleanupBatchSize(900)).toBe(500);
+  });
+
+  it("deletes one batch and reports more expired rows", async () => {
+    vi.mocked(
+      prisma.notification.findMany,
+    ).mockResolvedValue([
+      { id: "one" },
+      { id: "two" },
+      { id: "three" },
+    ] as never);
+    vi.mocked(
+      prisma.notification.deleteMany,
+    ).mockResolvedValue({
+      count: 2,
+    });
+
+    const result =
+      await cleanupExpiredNotifications(
+        2,
+        new Date("2026-08-04T00:00:00Z"),
+      );
+
+    expect(result).toEqual({
+      deletedCount: 2,
+      hasMore: true,
+      batchSize: 2,
+    });
+    expect(
+      prisma.notification.deleteMany,
+    ).toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: ["one", "two"],
+        },
+      },
+    });
+  });
+
+  it("does not delete when no expired rows exist", async () => {
+    vi.mocked(
+      prisma.notification.findMany,
+    ).mockResolvedValue([]);
+
+    await expect(
+      cleanupExpiredNotifications(20),
+    ).resolves.toEqual({
+      deletedCount: 0,
+      hasMore: false,
+      batchSize: 20,
+    });
+
+    expect(
+      prisma.notification.deleteMany,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,12 +1,50 @@
-import prisma from "@/lib/prisma";
-import { NotificationType } from "@prisma/client";
+import {
+  NotificationType,
+  type Notification,
+} from "@prisma/client";
 
-interface CreateNotificationParams {
+import prisma from "@/lib/prisma";
+
+const DEFAULT_CLEANUP_BATCH_SIZE = 100;
+const MAX_CLEANUP_BATCH_SIZE = 500;
+
+export interface CreateNotificationParams {
   userId: string;
   type: NotificationType;
   title: string;
   content: string;
   link?: string;
+  dedupeKey?: string;
+  expiresAt?: Date;
+}
+
+export interface NotificationCleanupResult {
+  deletedCount: number;
+  hasMore: boolean;
+  batchSize: number;
+}
+
+function normalizeOptionalValue(
+  value: string | undefined,
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+export function normalizeCleanupBatchSize(
+  requestedLimit?: number,
+): number {
+  if (
+    requestedLimit === undefined ||
+    !Number.isFinite(requestedLimit)
+  ) {
+    return DEFAULT_CLEANUP_BATCH_SIZE;
+  }
+
+  return Math.min(
+    MAX_CLEANUP_BATCH_SIZE,
+    Math.max(1, Math.trunc(requestedLimit)),
+  );
 }
 
 export async function createNotification({
@@ -15,19 +53,102 @@ export async function createNotification({
   title,
   content,
   link,
-}: CreateNotificationParams) {
-  return prisma.notification.create({
-    data: {
-      userId,
-      type,
-      title,
-      content,
-      link,
+  dedupeKey,
+  expiresAt,
+}: CreateNotificationParams): Promise<Notification> {
+  const normalizedDedupeKey =
+    normalizeOptionalValue(dedupeKey);
+  const normalizedLink = normalizeOptionalValue(link);
+
+  const data = {
+    userId,
+    type,
+    title,
+    content,
+    link: normalizedLink,
+    dedupeKey: normalizedDedupeKey,
+    expiresAt,
+  };
+
+  if (!normalizedDedupeKey) {
+    return prisma.notification.create({
+      data,
+    });
+  }
+
+  return prisma.notification.upsert({
+    where: {
+      userId_dedupeKey: {
+        userId,
+        dedupeKey: normalizedDedupeKey,
+      },
     },
+    update: {},
+    create: data,
   });
 }
 
-export async function getUnreadNotificationCount(userId: string) {
+export async function cleanupExpiredNotifications(
+  requestedLimit?: number,
+  now = new Date(),
+): Promise<NotificationCleanupResult> {
+  const batchSize =
+    normalizeCleanupBatchSize(requestedLimit);
+
+  const expiredNotifications =
+    await prisma.notification.findMany({
+      where: {
+        expiresAt: {
+          lte: now,
+        },
+      },
+      select: {
+        id: true,
+      },
+      orderBy: [
+        {
+          expiresAt: "asc",
+        },
+        {
+          id: "asc",
+        },
+      ],
+      take: batchSize + 1,
+    });
+
+  const hasMore =
+    expiredNotifications.length > batchSize;
+  const idsToDelete = expiredNotifications
+    .slice(0, batchSize)
+    .map(({ id }) => id);
+
+  if (idsToDelete.length === 0) {
+    return {
+      deletedCount: 0,
+      hasMore: false,
+      batchSize,
+    };
+  }
+
+  const result =
+    await prisma.notification.deleteMany({
+      where: {
+        id: {
+          in: idsToDelete,
+        },
+      },
+    });
+
+  return {
+    deletedCount: result.count,
+    hasMore,
+    batchSize,
+  };
+}
+
+export async function getUnreadNotificationCount(
+  userId: string,
+) {
   return prisma.notification.count({
     where: {
       userId,
@@ -36,7 +157,10 @@ export async function getUnreadNotificationCount(userId: string) {
   });
 }
 
-export async function markNotificationAsRead(id: string, userId: string) {
+export async function markNotificationAsRead(
+  id: string,
+  userId: string,
+) {
   return prisma.notification.updateMany({
     where: {
       id,
@@ -48,7 +172,9 @@ export async function markNotificationAsRead(id: string, userId: string) {
   });
 }
 
-export async function markAllNotificationsAsRead(userId: string) {
+export async function markAllNotificationsAsRead(
+  userId: string,
+) {
   return prisma.notification.updateMany({
     where: {
       userId,


### PR DESCRIPTION
## Description

Implements notification deduplication, expiry handling and protected batch cleanup for Issue #325.

Backend workflows can safely retry notification creation without producing duplicate records when a stable deduplication key is supplied.

## Changes

* Added optional `dedupeKey` to the `Notification` Prisma model
* Added optional `expiresAt` timestamp
* Added a composite unique constraint on `userId` and `dedupeKey`
* Added an index on `expiresAt`
* Updated the shared notification helper to support deduplication and expiry
* Added idempotent notification creation using Prisma `upsert`
* Preserved normal creation behaviour when no deduplication key is supplied
* Added bounded expired-notification cleanup
* Added a protected internal cleanup endpoint
* Added request-ID and standardized API error handling
* Added unit and route tests

## Cleanup Endpoint

```http
POST /api/internal/notifications/cleanup?limit=100
```

Required header:

```http
x-notification-cleanup-secret: <server-secret>
```

The endpoint:

* Accepts batch sizes from 1 to 500
* Deletes expired notifications oldest-first
* Returns the deleted count
* Reports whether more expired notifications remain
* Uses `Cache-Control: no-store`
* Does not expose the configured secret or database errors

## Notification Creation

Notifications with a deduplication key are created idempotently:

```ts
await createNotification({
  userId,
  type: NotificationType.MATCH_FOUND,
  title: "New traveller match found",
  content: "A matching traveller was found.",
  dedupeKey: `match-found:${ticketId}:${userId}`,
  expiresAt,
});
```

Notifications without a `dedupeKey` retain the existing insert behaviour.

## Database Changes

* Added `Notification.dedupeKey`
* Added `Notification.expiresAt`
* Added unique constraint:

  * `userId`
  * `dedupeKey`
* Added expiry index for cleanup queries

## Testing

* [x] Ordinary notifications are created normally
* [x] Duplicate keys use idempotent creation
* [x] The same key can be used by different users
* [x] Cleanup deletes only the requested batch
* [x] Cleanup reports whether more records remain
* [x] Empty cleanup batches are handled safely
* [x] Invalid cleanup secrets return `401`
* [x] Invalid limits return `400`
* [x] Database failures return safe `500` responses
* [ ] Prisma migration applied locally
* [ ] Full TypeScript check
* [ ] Full lint check

## Files Changed

* `prisma/schema.prisma`
* `prisma/migrations/20260804221600_add_notification_deduplication_and_expiry/migration.sql`
* `src/lib/notifications.ts`
* `src/lib/__tests__/notifications.test.ts`
* `src/app/api/internal/notifications/cleanup/route.ts`
* `src/app/api/internal/notifications/cleanup/__tests__/route.test.ts`

Closes #325

## Screenshots
<img width="1223" height="329" alt="Screenshot 2026-08-04 223925" src="https://github.com/user-attachments/assets/13860008-9d93-4f7e-8093-c9f5abf8f749" />
<img width="1189" height="442" alt="Screenshot 2026-08-04 223931" src="https://github.com/user-attachments/assets/ce76d421-e7a9-4d67-a858-3b5d60754a38" />
<img width="1181" height="468" alt="Screenshot 2026-08-04 223936" src="https://github.com/user-attachments/assets/d8b73f2d-67dc-486c-9bd9-1a33a592afc5" />
