### PR TITLE
feat: add health and readiness endpoints

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from "next/server";
+
+import { apiJson } from "@/lib/api-response";
+import { getRequestId } from "@/lib/request-id";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const requestId = getRequestId(request);
+
+  return apiJson(
+    {
+      status: "healthy",
+      timestamp: new Date().toISOString(),
+      requestId,
+    },
+    requestId,
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/src/app/api/ready/route.ts
+++ b/src/app/api/ready/route.ts
@@ -1,0 +1,32 @@
+import type { NextRequest } from "next/server";
+
+import { apiJson } from "@/lib/api-response";
+import {
+  getReadinessStatus,
+  runReadinessChecks,
+} from "@/lib/health-checks";
+import { getRequestId } from "@/lib/request-id";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const checks = await runReadinessChecks();
+  const status = getReadinessStatus(checks);
+
+  return apiJson(
+    {
+      status,
+      timestamp: new Date().toISOString(),
+      requestId,
+      checks,
+    },
+    requestId,
+    {
+      status: status === "unavailable" ? 503 : 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/src/lib/health-checks.ts
+++ b/src/lib/health-checks.ts
@@ -1,0 +1,163 @@
+import prisma from "@/lib/prisma";
+import redis from "@/lib/redis";
+
+const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 1_500;
+const MIN_HEALTH_CHECK_TIMEOUT_MS = 100;
+const MAX_HEALTH_CHECK_TIMEOUT_MS = 10_000;
+
+export type DependencyStatus = "up" | "down" | "skipped";
+
+export interface DependencyCheck {
+  status: DependencyStatus;
+  latencyMs: number;
+  required: boolean;
+}
+
+export interface ReadinessChecks {
+  database: DependencyCheck;
+  redis: DependencyCheck;
+}
+
+function parseTimeoutMs(
+  value = process.env.HEALTH_CHECK_TIMEOUT_MS,
+): number {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_HEALTH_CHECK_TIMEOUT_MS;
+  }
+
+  return Math.min(
+    MAX_HEALTH_CHECK_TIMEOUT_MS,
+    Math.max(
+      MIN_HEALTH_CHECK_TIMEOUT_MS,
+      Math.trunc(parsed),
+    ),
+  );
+}
+
+async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error("Dependency check timed out"));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function elapsedMilliseconds(startedAt: number): number {
+  return Math.max(
+    0,
+    Math.round(performance.now() - startedAt),
+  );
+}
+
+export async function checkDatabase(
+  timeoutMs = parseTimeoutMs(),
+): Promise<DependencyCheck> {
+  const startedAt = performance.now();
+
+  try {
+    await withTimeout(
+      prisma.$queryRaw`SELECT 1`,
+      timeoutMs,
+    );
+
+    return {
+      status: "up",
+      latencyMs: elapsedMilliseconds(startedAt),
+      required: true,
+    };
+  } catch {
+    return {
+      status: "down",
+      latencyMs: elapsedMilliseconds(startedAt),
+      required: true,
+    };
+  }
+}
+
+export async function checkRedis(
+  timeoutMs = parseTimeoutMs(),
+): Promise<DependencyCheck> {
+  const configured = Boolean(process.env.REDIS_URL);
+
+  if (!configured) {
+    return {
+      status: "skipped",
+      latencyMs: 0,
+      required: false,
+    };
+  }
+
+  const startedAt = performance.now();
+
+  if (!redis) {
+    return {
+      status: "down",
+      latencyMs: elapsedMilliseconds(startedAt),
+      required: false,
+    };
+  }
+
+  try {
+    await withTimeout(redis.ping(), timeoutMs);
+
+    return {
+      status: "up",
+      latencyMs: elapsedMilliseconds(startedAt),
+      required: false,
+    };
+  } catch {
+    return {
+      status: "down",
+      latencyMs: elapsedMilliseconds(startedAt),
+      required: false,
+    };
+  }
+}
+
+export async function runReadinessChecks(): Promise<ReadinessChecks> {
+  const [database, redisCheck] = await Promise.all([
+    checkDatabase(),
+    checkRedis(),
+  ]);
+
+  return {
+    database,
+    redis: redisCheck,
+  };
+}
+
+export function getReadinessStatus(
+  checks: ReadinessChecks,
+): "ready" | "degraded" | "unavailable" {
+  if (
+    checks.database.required &&
+    checks.database.status !== "up"
+  ) {
+    return "unavailable";
+  }
+
+  if (
+    Object.values(checks).some(
+      (check) => check.status === "down",
+    )
+  ) {
+    return "degraded";
+  }
+
+  return "ready";
+}


### PR DESCRIPTION
## Description

Implements production-ready liveness and readiness endpoints for Issue #324.

The application can now distinguish between a running Next.js process and a backend that is actually ready to serve requests.

## Endpoints

```http
GET /api/health
GET /api/ready
```

## Health Endpoint

`GET /api/health`:

* Confirms that the application process is running
* Does not query PostgreSQL or Redis
* Returns immediately with `200`
* Includes a timestamp and request ID
* Uses `Cache-Control: no-store`

## Readiness Endpoint

`GET /api/ready`:

* Checks PostgreSQL using a lightweight `SELECT 1`
* Checks Redis only when `REDIS_URL` is configured
* Runs dependency checks concurrently
* Applies a short timeout to every dependency check
* Reports dependency latency
* Returns `503` when PostgreSQL is unavailable
* Returns `200` with `degraded` status when optional Redis is unavailable
* Does not expose database URLs, credentials, hostnames, API keys, stack traces or raw dependency errors

## Example Response

```json
{
  "status": "ready",
  "timestamp": "2026-08-04T17:10:00.000Z",
  "requestId": "req_123",
  "checks": {
    "database": {
      "status": "up",
      "latencyMs": 8,
      "required": true
    },
    "redis": {
      "status": "up",
      "latencyMs": 4,
      "required": false
    }
  }
}
```

## Status Behaviour

* `healthy` — application process is running
* `ready` — all configured dependencies are available
* `degraded` — a configured optional dependency is unavailable
* `unavailable` — a required dependency is unavailable

## Security

* No connection strings or credentials are returned
* Raw dependency errors are not included in responses
* Every dependency check has a timeout
* Responses are not cacheable
* No database records are created by either endpoint

## Testing

* [x] Health endpoint returns `200`
* [x] Health endpoint does not query dependencies
* [x] Database success is reported correctly
* [x] Database failure produces unavailable readiness
* [x] Redis is skipped when unconfigured
* [x] Redis is checked when configured
* [x] Optional Redis failure produces degraded readiness
* [x] Readiness failures return `503` for required dependencies
* [x] Responses include request ID and timestamp
* [x] Responses use `Cache-Control: no-store`
* [x] Tests ensure secrets are not exposed
* [ ] Full lint run
* [ ] Full TypeScript check

## Files Changed

* `src/lib/health-checks.ts`
* `src/lib/__tests__/health-checks.test.ts`
* `src/app/api/health/route.ts`
* `src/app/api/health/__tests__/route.test.ts`
* `src/app/api/ready/route.ts`
* `src/app/api/ready/__tests__/route.test.ts`

Closes #324

## Screenshots
<img width="1197" height="421" alt="Screenshot 2026-08-04 225024" src="https://github.com/user-attachments/assets/b6ce3a1e-2e19-4c13-ad0f-5ca587d00df4" />
<img width="1195" height="459" alt="Screenshot 2026-08-04 225036" src="https://github.com/user-attachments/assets/f62207eb-0705-453e-94c7-12ccef0c96a3" />
<img width="1199" height="487" alt="Screenshot 2026-08-04 225041" src="https://github.com/user-attachments/assets/130cb476-3cf7-4a9e-b734-2991d3307fb7" />
<img width="1192" height="223" alt="Screenshot 2026-08-04 225059" src="https://github.com/user-attachments/assets/6a430298-4e3c-48d6-a454-27ffc9ccf135" />
