### PR TITLE
feat: add secure account deletion workflow

### DIFF
--- a/prisma/migrations/20260804230000_add_asset_cleanup_jobs/migration.sql
+++ b/prisma/migrations/20260804230000_add_asset_cleanup_jobs/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "AssetCleanupJob" (
+    "id" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "publicId" TEXT NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "completedAt" TIMESTAMP(3),
+    "lastError" TEXT,
+    "nextAttemptAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AssetCleanupJob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AssetCleanupJob_ownerId_publicId_key"
+ON "AssetCleanupJob"("ownerId", "publicId");
+
+-- CreateIndex
+CREATE INDEX "AssetCleanupJob_ownerId_completedAt_idx"
+ON "AssetCleanupJob"("ownerId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "AssetCleanupJob_completedAt_nextAttemptAt_idx"
+ON "AssetCleanupJob"("completedAt", "nextAttemptAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -320,3 +320,22 @@ model Message {
   @@index([senderId])
   @@index([routeId])
 }
+
+model AssetCleanupJob {
+  id String @id @default(cuid())
+
+  ownerId  String
+  publicId String
+
+  attempts     Int       @default(0)
+  completedAt  DateTime?
+  lastError    String?
+  nextAttemptAt DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([ownerId, publicId])
+  @@index([ownerId, completedAt])
+  @@index([completedAt, nextAttemptAt])
+}

--- a/src/app/api/user/account/__tests__/route.test.ts
+++ b/src/app/api/user/account/__tests__/route.test.ts
@@ -15,6 +15,15 @@ vi.mock("@/lib/auth", () => ({
   auth: vi.fn(),
 }));
 
+type MockAuth = {
+  mockResolvedValue: (
+    value: unknown,
+  ) => void;
+};
+
+const mockedAuth =
+  auth as unknown as MockAuth;
+
 vi.mock("@/lib/account-deletion", () => ({
   deleteUserAccount: vi.fn(),
 }));
@@ -43,7 +52,7 @@ describe("DELETE /api/user/account", () => {
   });
 
   it("returns 401 for unauthenticated users", async () => {
-    vi.mocked(auth).mockResolvedValue(null);
+    mockedAuth.mockResolvedValue(null);
 
     const response = await DELETE(createRequest());
 
@@ -52,11 +61,11 @@ describe("DELETE /api/user/account", () => {
   });
 
   it("requires exact deletion confirmation", async () => {
-    vi.mocked(auth).mockResolvedValue({
+    mockedAuth.mockResolvedValue({
       user: {
         id: "user-1",
       },
-    } as never);
+    });
 
     const response = await DELETE(
       createRequest("delete"),
@@ -67,11 +76,11 @@ describe("DELETE /api/user/account", () => {
   });
 
   it("clears auth data and reports pending asset cleanup", async () => {
-    vi.mocked(auth).mockResolvedValue({
+    mockedAuth.mockResolvedValue({
       user: {
         id: "user-1",
       },
-    } as never);
+    });
     vi.mocked(deleteUserAccount).mockResolvedValue({
       alreadyDeleted: false,
       queuedAssets: 2,
@@ -101,11 +110,11 @@ describe("DELETE /api/user/account", () => {
   });
 
   it("returns a safe error when the transaction fails", async () => {
-    vi.mocked(auth).mockResolvedValue({
+    mockedAuth.mockResolvedValue({
       user: {
         id: "user-1",
       },
-    } as never);
+    });
     vi.mocked(deleteUserAccount).mockRejectedValue(
       new Error(
         "postgresql://secret:password@host/db",

--- a/src/app/api/user/account/__tests__/route.test.ts
+++ b/src/app/api/user/account/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from "next/server";
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { DELETE } from "@/app/api/user/account/route";
+import { deleteUserAccount } from "@/lib/account-deletion";
+import { auth } from "@/lib/auth";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/account-deletion", () => ({
+  deleteUserAccount: vi.fn(),
+}));
+
+function createRequest(
+  confirmation: unknown = "DELETE",
+) {
+  return new NextRequest(
+    "http://localhost/api/user/account",
+    {
+      method: "DELETE",
+      headers: {
+        "content-type": "application/json",
+        "X-Request-ID": "req_accountdelete123",
+      },
+      body: JSON.stringify({
+        confirmation,
+      }),
+    },
+  );
+}
+
+describe("DELETE /api/user/account", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for unauthenticated users", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+
+    const response = await DELETE(createRequest());
+
+    expect(response.status).toBe(401);
+    expect(deleteUserAccount).not.toHaveBeenCalled();
+  });
+
+  it("requires exact deletion confirmation", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-1",
+      },
+    } as never);
+
+    const response = await DELETE(
+      createRequest("delete"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(deleteUserAccount).not.toHaveBeenCalled();
+  });
+
+  it("clears auth data and reports pending asset cleanup", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-1",
+      },
+    } as never);
+    vi.mocked(deleteUserAccount).mockResolvedValue({
+      alreadyDeleted: false,
+      queuedAssets: 2,
+      cleanup: {
+        processed: 2,
+        deleted: 1,
+        pending: 1,
+      },
+    });
+
+    const response = await DELETE(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(
+      response.headers.get("Clear-Site-Data"),
+    ).toBe('"cookies", "storage"');
+    expect(body).toMatchObject({
+      deleted: true,
+      cleanupPending: true,
+      assets: {
+        queued: 2,
+        deleted: 1,
+        pending: 1,
+      },
+    });
+  });
+
+  it("returns a safe error when the transaction fails", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-1",
+      },
+    } as never);
+    vi.mocked(deleteUserAccount).mockRejectedValue(
+      new Error(
+        "postgresql://secret:password@host/db",
+      ),
+    );
+
+    const response = await DELETE(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(JSON.stringify(body)).not.toContain(
+      "password",
+    );
+  });
+});

--- a/src/app/api/user/account/route.ts
+++ b/src/app/api/user/account/route.ts
@@ -1,0 +1,109 @@
+import type { NextRequest } from "next/server";
+
+import {
+  API_ERROR_CODES,
+  logApiError,
+} from "@/lib/api-error";
+import {
+  apiError,
+  apiJson,
+} from "@/lib/api-response";
+import { deleteUserAccount } from "@/lib/account-deletion";
+import { auth } from "@/lib/auth";
+import { getRequestId } from "@/lib/request-id";
+
+const DELETE_CONFIRMATION = "DELETE";
+
+function clearAuthenticationCookies(
+  response: Response,
+): Response {
+  response.headers.set(
+    "Clear-Site-Data",
+    '"cookies", "storage"',
+  );
+  response.headers.set(
+    "Cache-Control",
+    "no-store",
+  );
+  return response;
+}
+
+export async function DELETE(request: NextRequest) {
+  const requestId = getRequestId(request);
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return apiError(
+      requestId,
+      API_ERROR_CODES.UNAUTHORIZED,
+      "Authentication is required",
+      401,
+    );
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return apiError(
+      requestId,
+      API_ERROR_CODES.BAD_REQUEST,
+      "Invalid request format",
+      400,
+    );
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("confirmation" in body) ||
+    body.confirmation !== DELETE_CONFIRMATION
+  ) {
+    return apiError(
+      requestId,
+      API_ERROR_CODES.VALIDATION_ERROR,
+      'Type "DELETE" to confirm account deletion',
+      400,
+    );
+  }
+
+  try {
+    const result = await deleteUserAccount(
+      session.user.id,
+    );
+
+    const response = apiJson(
+      {
+        deleted: true,
+        alreadyDeleted: result.alreadyDeleted,
+        assets: {
+          queued: result.queuedAssets,
+          deleted: result.cleanup.deleted,
+          pending: result.cleanup.pending,
+        },
+        cleanupPending:
+          result.cleanup.pending > 0,
+      },
+      requestId,
+      {
+        status: 200,
+      },
+    );
+
+    return clearAuthenticationCookies(response);
+  } catch (error) {
+    logApiError(
+      requestId,
+      "Account deletion failed",
+      error,
+    );
+
+    return apiError(
+      requestId,
+      API_ERROR_CODES.INTERNAL_ERROR,
+      "Unable to delete the account",
+      500,
+    );
+  }
+}

--- a/src/lib/__tests__/account-deletion.test.ts
+++ b/src/lib/__tests__/account-deletion.test.ts
@@ -1,0 +1,145 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { deleteUserAccount } from "@/lib/account-deletion";
+import {
+  extractCloudinaryPublicId,
+  processAssetCleanupJobs,
+} from "@/lib/cloudinary-delete";
+import prisma from "@/lib/prisma";
+
+vi.mock("@/lib/cloudinary-delete", () => ({
+  extractCloudinaryPublicId: vi.fn(),
+  processAssetCleanupJobs: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    $transaction: vi.fn(),
+  },
+}));
+
+function createTransactionMock() {
+  return {
+    user: {
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+    ticket: {
+      deleteMany: vi.fn(),
+    },
+    conversation: {
+      deleteMany: vi.fn(),
+    },
+    assetCleanupJob: {
+      createMany: vi.fn(),
+    },
+  };
+}
+
+describe("deleteUserAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(processAssetCleanupJobs).mockResolvedValue({
+      processed: 0,
+      deleted: 0,
+      pending: 0,
+    });
+  });
+
+  it("deletes user data transactionally and queues ticket assets", async () => {
+    const tx = createTransactionMock();
+
+    tx.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      tickets: [
+        {
+          ticketUrl:
+            "https://res.cloudinary.com/demo/image/upload/v1/travellers/tickets/one.png",
+        },
+      ],
+      conversations: [
+        {
+          id: "conversation-1",
+        },
+      ],
+    });
+
+    vi.mocked(extractCloudinaryPublicId).mockReturnValue(
+      "travellers/tickets/one",
+    );
+
+    vi.mocked(prisma.$transaction).mockImplementation(
+      async (callback: any) => callback(tx),
+    );
+
+    vi.mocked(processAssetCleanupJobs).mockResolvedValue({
+      processed: 1,
+      deleted: 1,
+      pending: 0,
+    });
+
+    const result = await deleteUserAccount("user-1");
+
+    expect(tx.assetCleanupJob.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          ownerId: "user-1",
+          publicId: "travellers/tickets/one",
+        },
+      ],
+      skipDuplicates: true,
+    });
+    expect(tx.ticket.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+      },
+    });
+    expect(tx.user.delete).toHaveBeenCalledWith({
+      where: {
+        id: "user-1",
+      },
+    });
+    expect(result.cleanup.pending).toBe(0);
+  });
+
+  it("is safe when the user was already deleted", async () => {
+    const tx = createTransactionMock();
+    tx.user.findUnique.mockResolvedValue(null);
+
+    vi.mocked(prisma.$transaction).mockImplementation(
+      async (callback: any) => callback(tx),
+    );
+
+    await expect(
+      deleteUserAccount("user-1"),
+    ).resolves.toMatchObject({
+      alreadyDeleted: true,
+      queuedAssets: 0,
+    });
+
+    expect(tx.user.delete).not.toHaveBeenCalled();
+    expect(processAssetCleanupJobs).toHaveBeenCalledWith(
+      "user-1",
+    );
+  });
+
+  it("does not run external cleanup after transaction failure", async () => {
+    vi.mocked(prisma.$transaction).mockRejectedValue(
+      new Error("database failure"),
+    );
+
+    await expect(
+      deleteUserAccount("user-1"),
+    ).rejects.toThrow("database failure");
+
+    expect(
+      processAssetCleanupJobs,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/cloudinary-account-cleanup.test.ts
+++ b/src/lib/__tests__/cloudinary-account-cleanup.test.ts
@@ -1,0 +1,126 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import cloudinary from "@/lib/cloudinary";
+import {
+  extractCloudinaryPublicId,
+  processAssetCleanupJobs,
+} from "@/lib/cloudinary-delete";
+import prisma from "@/lib/prisma";
+
+vi.mock("@/lib/cloudinary", () => ({
+  default: {
+    uploader: {
+      destroy: vi.fn(),
+    },
+  },
+  isCloudinaryConfigured: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    assetCleanupJob: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+describe("Cloudinary account cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts public IDs from versioned Cloudinary URLs", () => {
+    expect(
+      extractCloudinaryPublicId(
+        "https://res.cloudinary.com/demo/image/upload/v123/travellers/tickets/file-name.pdf",
+      ),
+    ).toBe("travellers/tickets/file-name");
+  });
+
+  it("marks successful cleanup jobs complete", async () => {
+    vi.mocked(
+      prisma.assetCleanupJob.findMany,
+    ).mockResolvedValue([
+      {
+        id: "job-1",
+        publicId: "travellers/tickets/one",
+        attempts: 0,
+      },
+    ] as never);
+    vi.mocked(
+      cloudinary.uploader.destroy,
+    ).mockResolvedValue({
+      result: "ok",
+    } as never);
+    vi.mocked(
+      prisma.assetCleanupJob.count,
+    ).mockResolvedValue(0);
+
+    const result = await processAssetCleanupJobs(
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      processed: 1,
+      deleted: 1,
+      pending: 0,
+    });
+    expect(
+      prisma.assetCleanupJob.update,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "job-1",
+        },
+        data: expect.objectContaining({
+          completedAt: expect.any(Date),
+          lastError: null,
+        }),
+      }),
+    );
+  });
+
+  it("keeps failed jobs pending without storing raw errors", async () => {
+    vi.mocked(
+      prisma.assetCleanupJob.findMany,
+    ).mockResolvedValue([
+      {
+        id: "job-1",
+        publicId: "travellers/tickets/one",
+        attempts: 0,
+      },
+    ] as never);
+    vi.mocked(
+      cloudinary.uploader.destroy,
+    ).mockRejectedValue(
+      new Error("secret cloudinary details"),
+    );
+    vi.mocked(
+      prisma.assetCleanupJob.count,
+    ).mockResolvedValue(1);
+
+    const result = await processAssetCleanupJobs(
+      "user-1",
+    );
+
+    expect(result.pending).toBe(1);
+    expect(
+      prisma.assetCleanupJob.update,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          lastError:
+            "Cloudinary asset cleanup failed",
+        }),
+      }),
+    );
+  });
+});

--- a/src/lib/account-deletion.ts
+++ b/src/lib/account-deletion.ts
@@ -1,0 +1,127 @@
+import type { Prisma } from "@prisma/client";
+
+import {
+  extractCloudinaryPublicId,
+  processAssetCleanupJobs,
+} from "@/lib/cloudinary-delete";
+import prisma from "@/lib/prisma";
+
+export interface DeleteAccountResult {
+  alreadyDeleted: boolean;
+  queuedAssets: number;
+  cleanup: {
+    processed: number;
+    deleted: number;
+    pending: number;
+  };
+}
+
+function uniquePublicIds(
+  tickets: Array<{ ticketUrl: string }>,
+): string[] {
+  return Array.from(
+    new Set(
+      tickets
+        .map(({ ticketUrl }) =>
+          extractCloudinaryPublicId(ticketUrl),
+        )
+        .filter(
+          (publicId): publicId is string =>
+            publicId !== null,
+        ),
+    ),
+  );
+}
+
+export async function deleteUserAccount(
+  userId: string,
+): Promise<DeleteAccountResult> {
+  const databaseResult = await prisma.$transaction(
+    async (tx: Prisma.TransactionClient) => {
+      const user = await tx.user.findUnique({
+        where: {
+          id: userId,
+        },
+        select: {
+          id: true,
+          tickets: {
+            select: {
+              ticketUrl: true,
+            },
+          },
+          conversations: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+
+      if (!user) {
+        return {
+          alreadyDeleted: true,
+          queuedAssets: 0,
+        };
+      }
+
+      const publicIds = uniquePublicIds(user.tickets);
+      const conversationIds = user.conversations.map(
+        ({ id }) => id,
+      );
+
+      if (publicIds.length > 0) {
+        await tx.assetCleanupJob.createMany({
+          data: publicIds.map((publicId) => ({
+            ownerId: userId,
+            publicId,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      // Ticket.user currently has no database cascade rule.
+      await tx.ticket.deleteMany({
+        where: {
+          userId,
+        },
+      });
+
+      // User deletion cascades accounts, sessions, routes,
+      // notifications, messages, requests, blocks, reports,
+      // and creator-owned meetup plans.
+      await tx.user.delete({
+        where: {
+          id: userId,
+        },
+      });
+
+      if (conversationIds.length > 0) {
+        await tx.conversation.deleteMany({
+          where: {
+            id: {
+              in: conversationIds,
+            },
+            users: {
+              none: {},
+            },
+            messages: {
+              none: {},
+            },
+          },
+        });
+      }
+
+      return {
+        alreadyDeleted: false,
+        queuedAssets: publicIds.length,
+      };
+    },
+  );
+
+  const cleanup = await processAssetCleanupJobs(userId);
+
+  return {
+    ...databaseResult,
+    cleanup,
+  };
+}

--- a/src/lib/cloudinary-delete.ts
+++ b/src/lib/cloudinary-delete.ts
@@ -1,6 +1,43 @@
 import cloudinary, {
   isCloudinaryConfigured,
 } from "@/lib/cloudinary";
+import prisma from "@/lib/prisma";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 5 * 60 * 1000;
+
+export interface CleanupJobSummary {
+  processed: number;
+  deleted: number;
+  pending: number;
+}
+
+export function extractCloudinaryPublicId(
+  assetUrl: string,
+): string | null {
+  try {
+    const url = new URL(assetUrl);
+    const uploadMarker = "/upload/";
+    const uploadIndex = url.pathname.indexOf(uploadMarker);
+
+    if (uploadIndex === -1) {
+      return null;
+    }
+
+    let assetPath = url.pathname.slice(
+      uploadIndex + uploadMarker.length,
+    );
+
+    assetPath = assetPath.replace(/^v\d+\//, "");
+    assetPath = decodeURIComponent(assetPath);
+    assetPath = assetPath.replace(/\.[^/.]+$/, "");
+
+    const publicId = assetPath.replace(/^\/+|\/+$/g, "");
+    return publicId || null;
+  } catch {
+    return null;
+  }
+}
 
 export async function deleteCloudinaryAsset(
   publicId: string,
@@ -17,4 +54,88 @@ export async function deleteCloudinaryAsset(
     resource_type: "auto",
     invalidate: true,
   });
+}
+
+export async function processAssetCleanupJobs(
+  ownerId: string,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+): Promise<CleanupJobSummary> {
+  const now = new Date();
+  const jobs = await prisma.assetCleanupJob.findMany({
+    where: {
+      ownerId,
+      completedAt: null,
+      attempts: {
+        lt: maxAttempts,
+      },
+      OR: [
+        {
+          nextAttemptAt: null,
+        },
+        {
+          nextAttemptAt: {
+            lte: now,
+          },
+        },
+      ],
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+
+  let deleted = 0;
+
+  for (const job of jobs) {
+    try {
+      await deleteCloudinaryAsset(job.publicId);
+
+      await prisma.assetCleanupJob.update({
+        where: {
+          id: job.id,
+        },
+        data: {
+          attempts: {
+            increment: 1,
+          },
+          completedAt: new Date(),
+          lastError: null,
+          nextAttemptAt: null,
+        },
+      });
+
+      deleted += 1;
+    } catch {
+      const nextAttempt = job.attempts + 1;
+
+      await prisma.assetCleanupJob.update({
+        where: {
+          id: job.id,
+        },
+        data: {
+          attempts: {
+            increment: 1,
+          },
+          lastError: "Cloudinary asset cleanup failed",
+          nextAttemptAt:
+            nextAttempt < maxAttempts
+              ? new Date(Date.now() + RETRY_DELAY_MS)
+              : null,
+        },
+      });
+    }
+  }
+
+  const pending = await prisma.assetCleanupJob.count({
+    where: {
+      ownerId,
+      completedAt: null,
+    },
+  });
+
+  return {
+    processed: jobs.length,
+    deleted,
+    pending,
+  };
 }


### PR DESCRIPTION
## Description

Implements the secure account-deletion workflow requested in Issue #323.

Authenticated users can now permanently delete their account and associated database data through a backend-only endpoint. Ticket assets stored in Cloudinary are queued for reliable cleanup, including retry handling when external deletion fails.

## Endpoint

```http
DELETE /api/user/account
```

Request body:

```json
{
  "confirmation": "DELETE"
}
```

## Changes

* Added an authenticated account-deletion endpoint
* Added exact deletion-confirmation validation
* Added transactional database cleanup
* Explicitly deletes tickets before deleting the user
* Deletes accounts, sessions and other dependent records through existing cascade relations
* Removes empty conversations after user removal
* Extracts Cloudinary public IDs from ticket URLs
* Added persistent Cloudinary cleanup jobs
* Added retry-safe external asset cleanup
* Added idempotent handling for already-deleted accounts
* Clears browser cookies and storage after successful deletion
* Added standardized request IDs and safe API errors
* Added focused unit and route tests

## Retry Safety

Cloudinary deletion occurs after the database transaction commits.

Before deleting the user, each ticket asset is recorded in the new `AssetCleanupJob` table. This means failed Cloudinary deletions are not lost when the user and ticket rows have already been removed.

Cleanup jobs track:

* Owner ID
* Cloudinary public ID
* Attempt count
* Completion time
* Next retry time
* Safe generic failure status

Raw Cloudinary errors, credentials and connection details are not stored or returned.

## Database Behaviour

The account deletion uses a Prisma transaction.

Inside the transaction:

1. The user, ticket URLs and related conversation IDs are retrieved.
2. Cloudinary cleanup jobs are created.
3. Ticket records are deleted.
4. The user record is deleted.
5. Empty conversations are removed.

If any database mutation fails, the transaction rolls back and the account remains unchanged.

## Response Behaviour

Successful cleanup:

```json
{
  "deleted": true,
  "alreadyDeleted": false,
  "assets": {
    "queued": 2,
    "deleted": 2,
    "pending": 0
  },
  "cleanupPending": false
}
```

Partial external cleanup:

```json
{
  "deleted": true,
  "alreadyDeleted": false,
  "assets": {
    "queued": 2,
    "deleted": 1,
    "pending": 1
  },
  "cleanupPending": true
}
```

## Security

* Authentication is required
* Confirmation must exactly equal `DELETE`
* Database mutations are transactional
* Authentication cookies and browser storage are cleared
* Cloudinary errors are not exposed
* Repeated deletion attempts are safe
* Request IDs are included in API responses

## Testing

* [x] Unauthenticated requests return `401`
* [x] Incorrect confirmation returns `400`
* [x] Database cleanup is transactional
* [x] Ticket assets are queued before account deletion
* [x] Existing deleted accounts are handled safely
* [x] Database failures prevent external cleanup
* [x] Cloudinary public IDs are extracted from stored URLs
* [x] Successful cleanup jobs are completed
* [x] Failed cleanup jobs remain pending
* [x] Raw external errors are not stored
* [x] Successful deletion clears client authentication data
* [ ] Full lint check
* [ ] Full TypeScript check
* [ ] Prisma migration applied locally

## Files Changed

* `prisma/schema.prisma`
* `prisma/migrations/20260804230000_add_asset_cleanup_jobs/migration.sql`
* `src/lib/account-deletion.ts`
* `src/lib/cloudinary-delete.ts`
* `src/lib/__tests__/account-deletion.test.ts`
* `src/lib/__tests__/cloudinary-account-cleanup.test.ts`
* `src/app/api/user/account/route.ts`
* `src/app/api/user/account/__tests__/route.test.ts`

Closes #323

## Screenshots
<img width="1200" height="471" alt="Screenshot 2026-08-04 225447" src="https://github.com/user-attachments/assets/3f964c48-5cea-4ecc-95a9-8bff248603fc" />
<img width="1204" height="468" alt="Screenshot 2026-08-04 225452" src="https://github.com/user-attachments/assets/f1c824db-b730-4260-8247-67249291c3e3" />
<img width="1204" height="479" alt="Screenshot 2026-08-04 225459" src="https://github.com/user-attachments/assets/f43ed467-69f7-4dff-a9c6-8ebb241371f6" />
