### PR TITLE
fix: meetup-plans IDOR — enforce conversation membership

### DIFF
--- a/src/app/api/meetup-plans/route.ts
+++ b/src/app/api/meetup-plans/route.ts
@@ -20,9 +20,15 @@ export async function GET(req: NextRequest) {
     return NextResponse.json([]);
   }
 
+  // Only return the plan if the caller is a member of its conversation,
+  // otherwise any authenticated user could read another conversation's plan
+  // by guessing the conversationId.
   const plan = await prisma.meetupPlan.findFirst({
     where: {
       conversationId,
+      conversation: {
+        users: { some: { id: session.user.id } },
+      },
     },
     include: {
       checklist: true,
@@ -52,8 +58,24 @@ export async function POST(req: NextRequest) {
     notes,
     routeId,
   } = body;
- 
-  console.log(prisma);
+
+  // The caller must belong to the conversation they're creating a plan in,
+  // otherwise they could attach a meetup plan to any conversation.
+  const conversation = await prisma.conversation.findFirst({
+    where: {
+      id: conversationId,
+      users: { some: { id: session.user.id } },
+    },
+    select: { id: true },
+  });
+
+  if (!conversation) {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: 403 }
+    );
+  }
+
   const meetup = await prisma.meetupPlan.create({
   data: {
     conversationId,


### PR DESCRIPTION
Closes #335

### Problem
- **GET** `/api/meetup-plans?conversationId=…` fetched the plan purely by `conversationId` with no membership check, so any authenticated user could read another conversation’s meetup plan and its checklist by guessing/enumerating the id.
- **POST** created a plan for any `conversationId` without verifying the caller belongs to that conversation.

### Fix
- GET now scopes the query with `conversation: { users: { some: { id: session.user.id } } }`, returning `null` for non-members.
- POST verifies the caller is a member of the target conversation and returns `403` otherwise, before creating the plan.

Uses the same membership pattern (`users: { some: { id } }`) already used in `/api/conversations`.

### Testing
- `npx tsc --noEmit` clean on the changed route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._