### PR TITLE
fix: meetup-checklist has no auth — require session + conversation membership

### DIFF
--- a/src/app/api/meetup-checklist/route.ts
+++ b/src/app/api/meetup-checklist/route.ts
@@ -1,12 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+
+// A checklist item belongs to a MeetupPlan, which belongs to a Conversation.
+// A user may read/modify it only if they are a member of that conversation.
+async function canAccessMeetupPlan(meetupPlanId: string, userId: string) {
+  const plan = await prisma.meetupPlan.findFirst({
+    where: {
+      id: meetupPlanId,
+      conversation: { users: { some: { id: userId } } },
+    },
+    select: { id: true },
+  });
+  return Boolean(plan);
+}
 
 export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { searchParams } = new URL(req.url);
   const meetupPlanId = searchParams.get("meetupPlanId");
 
   if (!meetupPlanId) {
     return NextResponse.json([], { status: 200 });
+  }
+
+  if (!(await canAccessMeetupPlan(meetupPlanId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const items = await prisma.meetupChecklistItem.findMany({
@@ -23,7 +46,23 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const body = await req.json();
+
+  if (!body.meetupPlanId) {
+    return NextResponse.json(
+      { error: "meetupPlanId is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await canAccessMeetupPlan(body.meetupPlanId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const item = await prisma.meetupChecklistItem.create({
     data: {
@@ -36,7 +75,25 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const body = await req.json();
+
+  const existing = await prisma.meetupChecklistItem.findUnique({
+    where: { id: body.id },
+    select: { meetupPlanId: true },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (!(await canAccessMeetupPlan(existing.meetupPlanId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const item = await prisma.meetupChecklistItem.update({
     where: {


### PR DESCRIPTION
Closes #334

### Problem
`/api/meetup-checklist` had **no authentication or authorization** on any handler. Anyone (including unauthenticated callers) could:
- **GET** every checklist item for any `meetupPlanId`,
- **POST** new items onto any plan,
- **PATCH** (edit / mark complete) any item by id.

### Fix
- Require a valid session (`auth()`) on GET/POST/PATCH → `401` otherwise.
- Verify the caller is a member of the plan’s conversation before acting (`meetupPlan.conversation.users.some({ id: userId })`), resolving the plan via `meetupPlanId` for GET/POST and via the item’s `meetupPlanId` for PATCH. Non-members get `403`; unknown item ids get `404`.

Same membership pattern used in `/api/conversations` and the meetup-plans fix.

### Testing
- `npx tsc --noEmit` clean on the changed route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._