### PR TITLE
fix: messages attaches routeId without ownership check (IDOR)

### DIFF
--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -127,6 +127,22 @@ if ((!text || text.trim() === "") && !routeId) {
       return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
     }
 
+    // A shared route must belong to the sender — otherwise a user could attach
+    // (and expose the details of) another user's route by passing its id.
+    if (routeId) {
+      const route = await prisma.route.findFirst({
+        where: { id: routeId, userId },
+        select: { id: true },
+      });
+
+      if (!route) {
+        return NextResponse.json(
+          { error: "Route not found or not owned by you" },
+          { status: 403 }
+        );
+      }
+    }
+
     // Save message and update conversation's updatedAt timestamp
     const [message] = await prisma.$transaction([
   prisma.message.create({


### PR DESCRIPTION
Closes #336

### Problem
`POST /api/messages` stored whatever `routeId` was in the request body (`routeId: routeId ?? null`) with no verification that the route belongs to the sender. Since the message GET response includes full route details (origin/destination names + coordinates, distance, encoded polyline), a user could attach **any** route by id — including another user’s private route — and read its details back.

### Fix
When a `routeId` is supplied, verify it belongs to the sender (`route.userId === session.user.id`) before creating the message; return `403` otherwise. Text-only messages are unaffected.

### Testing
- `npx tsc --noEmit` clean on the changed route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._