### PR TITLE
fix: blocking is one-directional in matches and ignored by connections

### DIFF
--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -128,6 +128,25 @@ export async function POST(req: NextRequest) {
 
   try {
     if (action === "send") {
+      // Blocks are two-way: don't allow a request if either user has blocked
+      // the other.
+      const block = await prisma.block.findFirst({
+        where: {
+          OR: [
+            { blockerId: currentUserId, blockedId: userId },
+            { blockerId: userId, blockedId: currentUserId },
+          ],
+        },
+        select: { id: true },
+      });
+
+      if (block) {
+        return NextResponse.json(
+          { error: "Unable to send a connection request to this user" },
+          { status: 403 }
+        );
+      }
+
       // Check for existing connection request
       const existing = await prisma.connectionRequest.findFirst({
         where: {

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -180,10 +180,14 @@ export async function GET(req: NextRequest) {
       },
     });
 
+    // Blocks are two-way: exclude both users I've blocked and users who have
+    // blocked me. Previously only { blockerId: currentUserId } was queried, so
+    // a user who blocked me still showed up in my matches.
     const blocks = await prisma.block.findMany({
       where: {
         OR: [
           { blockerId: currentUserId },
+          { blockedId: currentUserId },
         ],
       },
       select: {


### PR DESCRIPTION
Closes #337

### Problem
- **matches**: the block query used only `OR: [{ blockerId: currentUserId }]`, so it excluded only users *I* blocked. If **B blocks A**, A still saw B in matches — and the `block.blockerId === currentUserId ? … : …` ternary’s reverse branch was dead code because the reverse rows were never fetched.
- **connections**: `POST` (action `send`) never consulted `Block`, so a blocked user could still send connection requests.

### Fix
- matches: query blocks in **both** directions (`{ blockerId: currentUserId }` OR `{ blockedId: currentUserId }`); the existing ternary now correctly resolves "the other user" for each row, excluding both users I blocked and users who blocked me.
- connections: before sending a request, reject with `403` if a `Block` exists in either direction between the two users.

### Note / follow-up
Per-message enforcement inside existing conversations is intentionally left out here: conversation creation now goes through the block-checked connection flow, and group-chat block semantics (which participant?) need a product decision. Happy to follow up on that separately if you’d like.

### Testing
- `npx tsc --noEmit` clean on both changed routes.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._