### PR TITLE
fix(safety): enforce blocks across the messaging surface

### DIFF
--- a/src/app/api/connections/__tests__/route.test.ts
+++ b/src/app/api/connections/__tests__/route.test.ts
@@ -16,6 +16,10 @@ vi.mock("@/lib/prisma", () => ({
       findFirst: vi.fn(),
       create: vi.fn(),
     },
+    block: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -31,6 +35,8 @@ describe("Connections API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (auth as any).mockResolvedValue({ user: { id: "user-1", name: "User 1" } });
+    // Default: neither user has blocked the other.
+    (prisma.block.findFirst as any).mockResolvedValue(null);
   });
 
   describe("GET /api/connections", () => {
@@ -82,6 +88,34 @@ describe("Connections API", () => {
       expect(data.success).toBe(true);
       expect(data.conversationId).toBe("conv-1");
       expect(prisma.conversation.create).toHaveBeenCalled();
+    });
+
+    it("refuses to send a request when either side has blocked the other", async () => {
+      (prisma.block.findFirst as any).mockResolvedValue({ id: "block-1" });
+
+      const req = {
+        json: async () => ({ action: "send", userId: "user-2" }),
+      };
+
+      const res = await POST(req as any);
+
+      expect(res.status).toBe(403);
+      expect(prisma.connectionRequest.create).not.toHaveBeenCalled();
+    });
+
+    it("refuses to accept a request created before the block", async () => {
+      (prisma.connectionRequest.findUnique as any).mockResolvedValue({ id: "req-1", senderId: "user-2", receiverId: "user-1", status: "PENDING" });
+      (prisma.block.findFirst as any).mockResolvedValue({ id: "block-1" });
+
+      const req = {
+        json: async () => ({ action: "accept", userId: "user-2" }),
+      };
+
+      const res = await POST(req as any);
+
+      expect(res.status).toBe(403);
+      expect(prisma.connectionRequest.update).not.toHaveBeenCalled();
+      expect(prisma.conversation.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
+import { isBlockedBetween } from "@/lib/blocking";
 import { triggerPusher } from "@/lib/pusher";
 
 export async function GET(req: NextRequest) {
@@ -130,17 +131,7 @@ export async function POST(req: NextRequest) {
     if (action === "send") {
       // Blocks are two-way: don't allow a request if either user has blocked
       // the other.
-      const block = await prisma.block.findFirst({
-        where: {
-          OR: [
-            { blockerId: currentUserId, blockedId: userId },
-            { blockerId: userId, blockedId: currentUserId },
-          ],
-        },
-        select: { id: true },
-      });
-
-      if (block) {
+      if (await isBlockedBetween(currentUserId, userId)) {
         return NextResponse.json(
           { error: "Unable to send a connection request to this user" },
           { status: 403 }
@@ -220,6 +211,16 @@ export async function POST(req: NextRequest) {
 
       if (!request || request.status !== "PENDING") {
         return NextResponse.json({ error: "No pending connection request found" }, { status: 404 });
+      }
+
+      // A block may have been created after the request was sent. Accepting it
+      // would open a conversation between two people who cannot message each
+      // other, so refuse instead of creating a dead thread.
+      if (await isBlockedBetween(currentUserId, userId)) {
+        return NextResponse.json(
+          { error: "Unable to accept a connection request from this user" },
+          { status: 403 }
+        );
       }
 
       // Update connection request

--- a/src/app/api/conversations/__tests__/route.test.ts
+++ b/src/app/api/conversations/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { GET } from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    conversation: {
+      findMany: vi.fn(),
+    },
+    block: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+function request() {
+  return new NextRequest("http://localhost/api/conversations");
+}
+
+describe("GET /api/conversations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.conversation.findMany).mockResolvedValue(
+      [] as never,
+    );
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("does not add a block filter when nothing is blocked", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue(
+      [] as never,
+    );
+
+    await GET(request());
+
+    expect(prisma.conversation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          users: {
+            some: { id: "user-1" },
+          },
+        },
+      }),
+    );
+  });
+
+  it("excludes conversations that include a blocked user", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue([
+      { blockerId: "user-1", blockedId: "user-2" },
+      { blockerId: "user-3", blockedId: "user-1" },
+    ] as never);
+
+    await GET(request());
+
+    expect(prisma.conversation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          users: {
+            some: { id: "user-1" },
+            none: { id: { in: ["user-2", "user-3"] } },
+          },
+        },
+      }),
+    );
+  });
+
+  it("formats the sidebar payload", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue(
+      [] as never,
+    );
+    vi.mocked(prisma.conversation.findMany).mockResolvedValue([
+      {
+        id: "conv-1",
+        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-08-02T00:00:00.000Z"),
+        users: [{ id: "user-2", name: "Nadia" }],
+        messages: [{ id: "msg-1", text: "See you there" }],
+      },
+    ] as never);
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.conversations).toHaveLength(1);
+    expect(body.conversations[0].otherUser.name).toBe("Nadia");
+    expect(body.conversations[0].lastMessage.text).toBe(
+      "See you there",
+    );
+  });
+
+  it("returns nulls for an empty conversation", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue(
+      [] as never,
+    );
+    vi.mocked(prisma.conversation.findMany).mockResolvedValue([
+      {
+        id: "conv-2",
+        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-08-01T00:00:00.000Z"),
+        users: [],
+        messages: [],
+      },
+    ] as never);
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(body.conversations[0].otherUser).toBeNull();
+    expect(body.conversations[0].lastMessage).toBeNull();
+  });
+});

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
+import { getBlockedUserIds } from "@/lib/blocking";
 
 export async function GET(req: NextRequest) {
   const session = await auth();
@@ -11,10 +12,17 @@ export async function GET(req: NextRequest) {
   const userId = session.user.id;
 
   try {
+    // Resolve the block set once instead of per conversation: a thread with
+    // somebody on either side of a block must not appear in the sidebar at all.
+    const blockedUserIds = await getBlockedUserIds(userId);
+
     const conversations = await prisma.conversation.findMany({
       where: {
         users: {
           some: { id: userId },
+          ...(blockedUserIds.length > 0
+            ? { none: { id: { in: blockedUserIds } } }
+            : {}),
         },
       },
       include: {

--- a/src/app/api/messages/__tests__/route.test.ts
+++ b/src/app/api/messages/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
+import { triggerPusher } from "@/lib/pusher";
 import { GET, POST } from "../route";
 
 vi.mock("@/lib/prisma", () => ({
@@ -14,6 +15,13 @@ vi.mock("@/lib/prisma", () => ({
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    block: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    route: {
+      findFirst: vi.fn(),
+    },
     $transaction: vi.fn((promises) => Promise.all(promises)),
   },
 }));
@@ -26,10 +34,20 @@ vi.mock("@/lib/pusher", () => ({
   triggerPusher: vi.fn(() => Promise.resolve()),
 }));
 
+/** The shape `loadConversationForUser` selects. */
+function conversationWith(...userIds: string[]) {
+  return {
+    id: "conv-1",
+    users: userIds.map((id) => ({ id })),
+  };
+}
+
 describe("Messages API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (auth as any).mockResolvedValue({ user: { id: "user-1", name: "User 1" } });
+    // Default: no block between the participants.
+    (prisma.block.findFirst as any).mockResolvedValue(null);
   });
 
   describe("GET /api/messages", () => {
@@ -42,7 +60,9 @@ describe("Messages API", () => {
     });
 
     it("returns messages for a valid conversation", async () => {
-      (prisma.conversation.findFirst as any).mockResolvedValue({ id: "conv-1" });
+      (prisma.conversation.findFirst as any).mockResolvedValue(
+        conversationWith("user-1", "user-2"),
+      );
       (prisma.message.findMany as any).mockResolvedValue([{ id: "msg-1", text: "Hello" }]);
 
       const req = {
@@ -53,12 +73,50 @@ describe("Messages API", () => {
       expect(res.status).toBe(200);
       expect(data.messages).toHaveLength(1);
     });
+
+    it("returns 403 when the other participant is blocked", async () => {
+      (prisma.conversation.findFirst as any).mockResolvedValue(
+        conversationWith("user-1", "user-2"),
+      );
+      (prisma.block.findFirst as any).mockResolvedValue({ id: "block-1" });
+
+      const req = {
+        url: "http://localhost:3000/api/messages?conversationId=conv-1",
+      };
+      const res = await GET(req as any);
+
+      expect(res.status).toBe(403);
+      expect(prisma.message.findMany).not.toHaveBeenCalled();
+    });
+
+    it("checks the block against the other participants only", async () => {
+      (prisma.conversation.findFirst as any).mockResolvedValue(
+        conversationWith("user-1", "user-2"),
+      );
+      (prisma.message.findMany as any).mockResolvedValue([]);
+
+      const req = {
+        url: "http://localhost:3000/api/messages?conversationId=conv-1",
+      };
+      await GET(req as any);
+
+      expect(prisma.block.findFirst).toHaveBeenCalledWith({
+        where: {
+          OR: [
+            { blockerId: "user-1", blockedId: { in: ["user-2"] } },
+            { blockerId: { in: ["user-2"] }, blockedId: "user-1" },
+          ],
+        },
+        select: { id: true },
+      });
+    });
   });
 
   describe("POST /api/messages", () => {
     it("sends a message and triggers pusher", async () => {
-      (prisma.conversation.findFirst as any).mockResolvedValue({ id: "conv-1" });
-      (prisma.conversation.findUnique as any).mockResolvedValue({ users: [{ id: "user-1" }, { id: "user-2" }] });
+      (prisma.conversation.findFirst as any).mockResolvedValue(
+        conversationWith("user-1", "user-2"),
+      );
       (prisma.message.create as any).mockResolvedValue({ id: "msg-2", text: "New message" });
       (prisma.conversation.update as any).mockResolvedValue({ id: "conv-1" });
 
@@ -71,6 +129,64 @@ describe("Messages API", () => {
       expect(res.status).toBe(200);
       expect(data.success).toBe(true);
       expect(data.message.text).toBe("New message");
+    });
+
+    it("notifies every participant sidebar without re-querying the conversation", async () => {
+      (prisma.conversation.findFirst as any).mockResolvedValue(
+        conversationWith("user-1", "user-2"),
+      );
+      (prisma.message.create as any).mockResolvedValue({ id: "msg-2", text: "New message" });
+      (prisma.conversation.update as any).mockResolvedValue({ id: "conv-1" });
+
+      const req = {
+        json: async () => ({ conversationId: "conv-1", text: "New message" }),
+      };
+
+      await POST(req as any);
+
+      expect(prisma.conversation.findUnique).not.toHaveBeenCalled();
+      expect(triggerPusher).toHaveBeenCalledWith(
+        "private-user-user-1",
+        "conversation-updated",
+        expect.objectContaining({ conversationId: "conv-1" }),
+      );
+      expect(triggerPusher).toHaveBeenCalledWith(
+        "private-user-user-2",
+        "conversation-updated",
+        expect.objectContaining({ conversationId: "conv-1" }),
+      );
+    });
+
+    it("returns 403 and writes nothing when the sender is blocked", async () => {
+      (prisma.conversation.findFirst as any).mockResolvedValue(
+        conversationWith("user-1", "user-2"),
+      );
+      (prisma.block.findFirst as any).mockResolvedValue({ id: "block-1" });
+
+      const req = {
+        json: async () => ({ conversationId: "conv-1", text: "Still here" }),
+      };
+
+      const res = await POST(req as any);
+
+      expect(res.status).toBe(403);
+      expect(prisma.message.create).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(triggerPusher).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the caller is not a participant", async () => {
+      (prisma.conversation.findFirst as any).mockResolvedValue(null);
+
+      const req = {
+        json: async () => ({ conversationId: "conv-9", text: "Hello?" }),
+      };
+
+      const res = await POST(req as any);
+
+      expect(res.status).toBe(404);
+      expect(prisma.block.findFirst).not.toHaveBeenCalled();
+      expect(prisma.message.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -1,7 +1,47 @@
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
+import { isBlockedBetween } from "@/lib/blocking";
 import { triggerPusher } from "@/lib/pusher";
+
+const BLOCKED_CONVERSATION_ERROR =
+  "This conversation is unavailable because one of you has blocked the other";
+
+/**
+ * Loads a conversation only if the caller belongs to it, along with the ids of
+ * the other participants so callers can run a block check without a second
+ * round-trip.
+ */
+async function loadConversationForUser(
+  conversationId: string,
+  userId: string,
+): Promise<{ id: string; counterpartIds: string[] } | null> {
+  const conversation = await prisma.conversation.findFirst({
+    where: {
+      id: conversationId,
+      users: {
+        some: { id: userId },
+      },
+    },
+    select: {
+      id: true,
+      users: { select: { id: true } },
+    },
+  });
+
+  if (!conversation) {
+    return null;
+  }
+
+  const users: Array<{ id: string }> = conversation.users ?? [];
+
+  return {
+    id: conversation.id,
+    counterpartIds: users
+      .map((user) => user.id)
+      .filter((id) => id !== userId),
+  };
+}
 
 export async function GET(req: NextRequest) {
   const session = await auth();
@@ -19,17 +59,19 @@ export async function GET(req: NextRequest) {
 
   try {
     // Check if user is participant of conversation
-    const conversation = await prisma.conversation.findFirst({
-      where: {
-        id: conversationId,
-        users: {
-          some: { id: userId },
-        },
-      },
-    });
+    const conversation = await loadConversationForUser(conversationId, userId);
 
     if (!conversation) {
       return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    // A block hides the history in both directions, so neither side can keep
+    // reading the thread after one of them blocked the other.
+    if (await isBlockedBetween(userId, conversation.counterpartIds)) {
+      return NextResponse.json(
+        { error: BLOCKED_CONVERSATION_ERROR },
+        { status: 403 },
+      );
     }
 
     const messages = await prisma.message.findMany({
@@ -114,17 +156,19 @@ if ((!text || text.trim() === "") && !routeId) {
 
   try {
     // Check if user is participant of conversation
-    const conversation = await prisma.conversation.findFirst({
-      where: {
-        id: conversationId,
-        users: {
-          some: { id: userId },
-        },
-      },
-    });
+    const conversation = await loadConversationForUser(conversationId, userId);
 
     if (!conversation) {
       return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    // Blocks are two-way: the person who was blocked must not be able to keep
+    // messaging, and the blocker must not be able to message them either.
+    if (await isBlockedBetween(userId, conversation.counterpartIds)) {
+      return NextResponse.json(
+        { error: BLOCKED_CONVERSATION_ERROR },
+        { status: 403 },
+      );
     }
 
     // A shared route must belong to the sender — otherwise a user could attach
@@ -193,27 +237,19 @@ if ((!text || text.trim() === "") && !routeId) {
       message,
     });
 
-    // Also trigger update on user sidebars for conversation lists
-    // Fetch users in conversation to trigger sidebar updates
-    const users = await prisma.conversation.findUnique({
-      where: { id: conversationId },
-      select: {
-        users: {
-          select: { id: true },
-        },
-      },
-    });
+    // Also trigger update on user sidebars for conversation lists. The
+    // participant ids were already loaded for the membership and block checks,
+    // so there is no need to query the conversation a second time here.
+    const sidebarUserIds = [userId, ...conversation.counterpartIds];
 
-    if (users) {
-      await Promise.all(
-        users.users.map((u) =>
-          triggerPusher(`private-user-${u.id}`, "conversation-updated", {
-            conversationId,
-            lastMessage: message,
-          })
-        )
-      );
-    }
+    await Promise.all(
+      sidebarUserIds.map((id) =>
+        triggerPusher(`private-user-${id}`, "conversation-updated", {
+          conversationId,
+          lastMessage: message,
+        })
+      )
+    );
 
     return NextResponse.json({ success: true, message });
   } catch (error) {

--- a/src/lib/__tests__/blocking.test.ts
+++ b/src/lib/__tests__/blocking.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  blockPairWhere,
+  findBlockBetween,
+  getBlockedUserIds,
+  isBlockedBetween,
+} from "@/lib/blocking";
+import prisma from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    block: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("blockPairWhere", () => {
+  it("matches a block in both directions", () => {
+    expect(blockPairWhere("user-1", "user-2")).toEqual({
+      OR: [
+        { blockerId: "user-1", blockedId: { in: ["user-2"] } },
+        { blockerId: { in: ["user-2"] }, blockedId: "user-1" },
+      ],
+    });
+  });
+
+  it("accepts a list of counterparts", () => {
+    expect(
+      blockPairWhere("user-1", ["user-2", "user-3"]),
+    ).toEqual({
+      OR: [
+        {
+          blockerId: "user-1",
+          blockedId: { in: ["user-2", "user-3"] },
+        },
+        {
+          blockerId: { in: ["user-2", "user-3"] },
+          blockedId: "user-1",
+        },
+      ],
+    });
+  });
+
+  it("de-duplicates and drops blank ids", () => {
+    expect(
+      blockPairWhere("user-1", [
+        "user-2",
+        "user-2",
+        "",
+        "   ",
+      ]),
+    ).toEqual({
+      OR: [
+        { blockerId: "user-1", blockedId: { in: ["user-2"] } },
+        { blockerId: { in: ["user-2"] }, blockedId: "user-1" },
+      ],
+    });
+  });
+});
+
+describe("findBlockBetween", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null without querying when there are no counterparts", async () => {
+    await expect(
+      findBlockBetween("user-1", []),
+    ).resolves.toBeNull();
+
+    expect(prisma.block.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("queries both directions in a single lookup", async () => {
+    vi.mocked(prisma.block.findFirst).mockResolvedValue(
+      null as never,
+    );
+
+    await findBlockBetween("user-1", ["user-2"]);
+
+    expect(prisma.block.findFirst).toHaveBeenCalledTimes(1);
+    expect(prisma.block.findFirst).toHaveBeenCalledWith({
+      where: blockPairWhere("user-1", ["user-2"]),
+      select: { id: true },
+    });
+  });
+});
+
+describe("isBlockedBetween", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is true when the caller blocked the counterpart", async () => {
+    vi.mocked(prisma.block.findFirst).mockResolvedValue({
+      id: "block-1",
+    } as never);
+
+    await expect(
+      isBlockedBetween("user-1", "user-2"),
+    ).resolves.toBe(true);
+  });
+
+  it("is true when the counterpart blocked the caller", async () => {
+    // The direction is decided by the query, so a hit means blocked either way.
+    vi.mocked(prisma.block.findFirst).mockResolvedValue({
+      id: "block-2",
+    } as never);
+
+    await expect(
+      isBlockedBetween("user-2", "user-1"),
+    ).resolves.toBe(true);
+  });
+
+  it("is false when the pair is clear", async () => {
+    vi.mocked(prisma.block.findFirst).mockResolvedValue(
+      null as never,
+    );
+
+    await expect(
+      isBlockedBetween("user-1", "user-2"),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("getBlockedUserIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("collects counterparts from both block directions", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue([
+      { blockerId: "user-1", blockedId: "user-2" },
+      { blockerId: "user-3", blockedId: "user-1" },
+    ] as never);
+
+    await expect(
+      getBlockedUserIds("user-1"),
+    ).resolves.toEqual(["user-2", "user-3"]);
+  });
+
+  it("de-duplicates a mutual block", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue([
+      { blockerId: "user-1", blockedId: "user-2" },
+      { blockerId: "user-2", blockedId: "user-1" },
+    ] as never);
+
+    await expect(
+      getBlockedUserIds("user-1"),
+    ).resolves.toEqual(["user-2"]);
+  });
+
+  it("returns an empty list when nothing is blocked", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue(
+      [] as never,
+    );
+
+    await expect(
+      getBlockedUserIds("user-1"),
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/lib/blocking.ts
+++ b/src/lib/blocking.ts
@@ -1,0 +1,106 @@
+import prisma from "@/lib/prisma";
+
+/**
+ * Blocking is deliberately symmetric on this platform: once either side of a
+ * pair has created a `Block` row, neither of them may reach the other. Only
+ * checking `{ blockerId: me }` would let the person who was blocked keep
+ * initiating contact, which is exactly the case a block is meant to stop.
+ *
+ * Everything in here works on a *set* of counterpart ids so a caller with a
+ * whole conversation in hand still only pays for a single query.
+ */
+
+export interface BlockPairWhere {
+  OR: Array<{
+    blockerId: string | { in: string[] };
+    blockedId: string | { in: string[] };
+  }>;
+}
+
+function toIdList(
+  otherUserIds: string | readonly string[],
+): string[] {
+  const list =
+    typeof otherUserIds === "string"
+      ? [otherUserIds]
+      : Array.from(otherUserIds);
+
+  // De-duplicate and drop empties so a stray "" can never widen the query.
+  return Array.from(
+    new Set(list.filter((id) => Boolean(id?.trim()))),
+  );
+}
+
+/**
+ * Prisma `where` fragment matching a block in *either* direction between
+ * `userId` and any of `otherUserIds`.
+ */
+export function blockPairWhere(
+  userId: string,
+  otherUserIds: string | readonly string[],
+): BlockPairWhere {
+  const ids = toIdList(otherUserIds);
+
+  return {
+    OR: [
+      { blockerId: userId, blockedId: { in: ids } },
+      { blockerId: { in: ids }, blockedId: userId },
+    ],
+  };
+}
+
+/**
+ * Returns the id of the first block found between `userId` and any of
+ * `otherUserIds`, or `null` when the pair is clear.
+ */
+export async function findBlockBetween(
+  userId: string,
+  otherUserIds: string | readonly string[],
+): Promise<{ id: string } | null> {
+  const ids = toIdList(otherUserIds);
+
+  if (ids.length === 0) {
+    return null;
+  }
+
+  return prisma.block.findFirst({
+    where: blockPairWhere(userId, ids),
+    select: { id: true },
+  });
+}
+
+/**
+ * Convenience wrapper around {@link findBlockBetween} for the common
+ * "may these two interact?" check.
+ */
+export async function isBlockedBetween(
+  userId: string,
+  otherUserIds: string | readonly string[],
+): Promise<boolean> {
+  return Boolean(await findBlockBetween(userId, otherUserIds));
+}
+
+/**
+ * Every user id that `userId` may not interact with — the people they blocked
+ * plus the people who blocked them. Useful for filtering list endpoints, where
+ * a per-row check would mean N queries.
+ */
+export async function getBlockedUserIds(
+  userId: string,
+): Promise<string[]> {
+  const blocks = await prisma.block.findMany({
+    where: {
+      OR: [{ blockerId: userId }, { blockedId: userId }],
+    },
+    select: { blockerId: true, blockedId: true },
+  });
+
+  const counterparts = blocks.map(
+    (block: { blockerId: string; blockedId: string }) =>
+      block.blockerId === userId
+        ? block.blockedId
+        : block.blockerId,
+  );
+
+  return Array.from(new Set(counterparts));
+}


### PR DESCRIPTION
Closes #348

## Problem

Blocking somebody did not stop them from messaging you. `Block` was checked in `/api/matches` and in the `send` branch of `POST /api/connections`, but the messaging layer never looked at it, so an already-open conversation kept working in both directions after a block.

## What changed

**`src/lib/blocking.ts` (new)** — one place for the two-way block rule:

| helper | use |
| --- | --- |
| `blockPairWhere(userId, others)` | `where` fragment matching a block in either direction |
| `findBlockBetween(userId, others)` | single query, returns the block or `null` |
| `isBlockedBetween(userId, others)` | boolean convenience wrapper |
| `getBlockedUserIds(userId)` | every counterpart, both directions, for filtering list endpoints |

All of them take a *set* of counterparts, so a caller holding a whole conversation still pays for exactly one query. Ids are de-duplicated and blanks are dropped so a stray `""` can never widen the `in` clause.

**`/api/messages`** — `GET` and `POST` now go through a small `loadConversationForUser` helper that returns the conversation together with the other participants' ids, then return `403` if a block exists. `GET` refuses to serve history, `POST` writes nothing and fires no Pusher event.

**`/api/conversations`** — resolves the block set once and adds `users: { none: { id: { in: blocked } } }`, so blocked threads disappear from the sidebar. The filter is only added when the user has blocks, so the common query is unchanged.

**`/api/connections`** — the inline duplicate of the block query is replaced by `isBlockedBetween`. The `accept` branch also re-checks now: a request sent before the block could previously be accepted and would create a conversation neither side could use.

**`POST /api/messages` side benefit** — the participant ids are already loaded for the membership and block checks, so the extra `conversation.findUnique` that ran before the sidebar fan-out is gone. One fewer query per message sent.

## Behaviour

| Case | Before | After |
| --- | --- | --- |
| Blocked user posts to an existing conversation | `200`, message delivered over Pusher | `403`, nothing written |
| Blocked user reads history | full history | `403` |
| Blocked thread in sidebar | listed | hidden |
| Accepting a request created before a block | conversation created | `403` |

## Tests

`npx vitest run src/lib/__tests__/blocking.test.ts src/app/api/messages src/app/api/conversations src/app/api/connections` → 30 passed.

- `src/lib/__tests__/blocking.test.ts` (new, 11 cases) — both directions, de-duplication, no-query short circuit on an empty counterpart list.
- `src/app/api/conversations/__tests__/route.test.ts` (new, 5 cases) — filter present/absent, payload shape, empty conversation.
- `src/app/api/messages/__tests__/route.test.ts` — added the `403` paths and a check that the conversation is not re-queried for the fan-out.
- `src/app/api/connections/__tests__/route.test.ts` — added the `block` model to the Prisma mock, which also fixes the pre-existing failure of `sends connection request` (that test was red on `main` because the route calls `prisma.block.findFirst` and the mock did not define it).

`npm run lint` is clean. The repo-wide suite goes from 13 failures to 12; the remaining ones are the admin-ticket `PATCH` export failures already tracked in #318 / #345 / #346 and are untouched by this branch.

## Notes for review

- Fail-closed was chosen deliberately: if the block lookup throws, the surrounding `try/catch` returns `500` rather than delivering the message.
- No schema change. `Block` already has the `@@unique([blockerId, blockedId])` and both single-column indexes this needs.
