### PR TITLE
feat(safety): add unblock and blocked-user listing to /api/user/block

### DIFF
--- a/src/app/api/user/__tests__/moderation.test.ts
+++ b/src/app/api/user/__tests__/moderation.test.ts
@@ -15,9 +15,13 @@ vi.mock("@/lib/prisma", () => ({
       findUnique: vi.fn(),
       create: vi.fn(),
     },
+    connectionRequest: {
+      deleteMany: vi.fn(),
+    },
     report: {
       create: vi.fn(),
     },
+    $transaction: vi.fn((operations) => Promise.all(operations)),
   },
 }));
 

--- a/src/app/api/user/block/__tests__/route.test.ts
+++ b/src/app/api/user/block/__tests__/route.test.ts
@@ -1,0 +1,303 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import { encodeCursor } from "@/lib/pagination";
+import prisma from "@/lib/prisma";
+import { DELETE, GET, POST } from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    block: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    connectionRequest: {
+      deleteMany: vi.fn(),
+    },
+    $transaction: vi.fn((operations) => Promise.all(operations)),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+function jsonRequest(body: unknown) {
+  return {
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type"
+          ? "application/json"
+          : null,
+    },
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+function listRequest(query = "") {
+  return new NextRequest(
+    `http://localhost/api/user/block${query}`,
+  );
+}
+
+describe("GET /api/user/block", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await GET(listRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns the caller's blocks newest first", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue([
+      {
+        id: "block-2",
+        createdAt: new Date("2026-08-02T00:00:00.000Z"),
+        blocked: { id: "user-3", name: "Ravi" },
+      },
+      {
+        id: "block-1",
+        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+        blocked: { id: "user-2", name: "Nadia" },
+      },
+    ] as never);
+
+    const response = await GET(listRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.items).toHaveLength(2);
+    expect(body.blockedUsers[0]).toEqual({
+      id: "user-3",
+      name: "Ravi",
+      blockedAt: "2026-08-02T00:00:00.000Z",
+    });
+    expect(prisma.block.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { blockerId: "user-1" },
+        orderBy: [
+          { createdAt: "desc" },
+          { id: "desc" },
+        ],
+      }),
+    );
+  });
+
+  it("never selects credential columns of the blocked user", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue(
+      [] as never,
+    );
+
+    await GET(listRequest());
+
+    const call = vi.mocked(prisma.block.findMany).mock
+      .calls[0][0] as {
+      select: { blocked: { select: Record<string, boolean> } };
+    };
+
+    expect(call.select.blocked.select).toEqual({
+      id: true,
+      name: true,
+      image: true,
+      location: true,
+    });
+  });
+
+  it("reports hasMore and a cursor when the page is full", async () => {
+    vi.mocked(prisma.block.findMany).mockResolvedValue([
+      {
+        id: "block-3",
+        createdAt: new Date("2026-08-03T00:00:00.000Z"),
+        blocked: { id: "user-4" },
+      },
+      {
+        id: "block-2",
+        createdAt: new Date("2026-08-02T00:00:00.000Z"),
+        blocked: { id: "user-3" },
+      },
+      {
+        id: "block-1",
+        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+        blocked: { id: "user-2" },
+      },
+    ] as never);
+
+    const response = await GET(listRequest("?limit=2"));
+    const body = await response.json();
+
+    expect(body.items).toHaveLength(2);
+    expect(body.pagination.hasMore).toBe(true);
+    expect(body.pagination.nextCursor).toBe(
+      encodeCursor({
+        id: "block-2",
+        timestamp: "2026-08-02T00:00:00.000Z",
+      }),
+    );
+  });
+
+  it("rejects a malformed limit with 400", async () => {
+    const response = await GET(listRequest("?limit=abc"));
+
+    expect(response.status).toBe(400);
+    expect(prisma.block.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/user/block", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+  });
+
+  it("refuses to block a soft-deleted account", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-2",
+      isDeleted: true,
+    } as never);
+
+    const response = await POST(
+      jsonRequest({ blockedId: "user-2" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("clears a pending connection request alongside the block", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-2",
+      isDeleted: false,
+    } as never);
+    vi.mocked(prisma.block.findUnique).mockResolvedValue(
+      null as never,
+    );
+
+    const response = await POST(
+      jsonRequest({ blockedId: "user-2" }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(
+      prisma.connectionRequest.deleteMany,
+    ).toHaveBeenCalledWith({
+      where: {
+        status: "PENDING",
+        OR: [
+          { senderId: "user-1", receiverId: "user-2" },
+          { senderId: "user-2", receiverId: "user-1" },
+        ],
+      },
+    });
+  });
+
+  it("only selects the columns needed to validate the target", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-2",
+      isDeleted: false,
+    } as never);
+    vi.mocked(prisma.block.findUnique).mockResolvedValue(
+      null as never,
+    );
+
+    await POST(jsonRequest({ blockedId: "user-2" }));
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user-2" },
+      select: { id: true, isDeleted: true },
+    });
+  });
+
+  it("is idempotent when the block already exists", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-2",
+      isDeleted: false,
+    } as never);
+    vi.mocked(prisma.block.findUnique).mockResolvedValue({
+      id: "block-1",
+    } as never);
+
+    const response = await POST(
+      jsonRequest({ blockedId: "user-2" }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toBe("User is already blocked");
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/user/block", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await DELETE(
+      jsonRequest({ blockedId: "user-2" }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when blockedId is missing", async () => {
+    const response = await DELETE(jsonRequest({}));
+
+    expect(response.status).toBe(400);
+    expect(prisma.block.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("removes only the caller's own block row", async () => {
+    vi.mocked(prisma.block.deleteMany).mockResolvedValue({
+      count: 1,
+    } as never);
+
+    const response = await DELETE(
+      jsonRequest({ blockedId: "user-2" }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(prisma.block.deleteMany).toHaveBeenCalledWith({
+      where: {
+        blockerId: "user-1",
+        blockedId: "user-2",
+      },
+    });
+  });
+
+  it("returns 404 when the caller never blocked that user", async () => {
+    vi.mocked(prisma.block.deleteMany).mockResolvedValue({
+      count: 0,
+    } as never);
+
+    const response = await DELETE(
+      jsonRequest({ blockedId: "user-9" }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/user/block/route.ts
+++ b/src/app/api/user/block/route.ts
@@ -2,11 +2,112 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { z } from "zod";
+import {
+  buildTimestampCursorWhere,
+  createPaginatedResponse,
+  PaginationError,
+  parsePaginationParams,
+} from "@/lib/pagination";
 import { withValidation } from "@/lib/withValidation";
 
 const BlockSchema = z.object({
   blockedId: z.string().min(1, "Blocked user ID required"),
 });
+
+const UnblockSchema = z.object({
+  blockedId: z.string().min(1, "Blocked user ID required"),
+});
+
+/**
+ * The columns a caller is allowed to see about somebody they blocked. Selecting
+ * the whole `User` row here would expose `passwordHash`, `otp` and
+ * `resetToken`.
+ */
+const BLOCKED_USER_SELECT = {
+  id: true,
+  name: true,
+  image: true,
+  location: true,
+} as const;
+
+/**
+ * GET /api/user/block — the people the caller has blocked, newest first.
+ *
+ * Paginated with the shared cursor helpers so a long block list behaves the
+ * same way as /api/routes and /api/tickets.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const { limit, cursor } = parsePaginationParams(
+      request.nextUrl.searchParams,
+    );
+    const cursorWhere = buildTimestampCursorWhere(
+      "createdAt",
+      cursor,
+    );
+
+    const blocks = await prisma.block.findMany({
+      where: {
+        blockerId: session.user.id,
+        ...(cursorWhere ?? {}),
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        blocked: {
+          select: BLOCKED_USER_SELECT,
+        },
+      },
+      orderBy: [
+        { createdAt: "desc" },
+        { id: "desc" },
+      ],
+      take: limit + 1,
+    });
+
+    const result = createPaginatedResponse(
+      blocks,
+      limit,
+      "createdAt",
+    );
+
+    return NextResponse.json({
+      ...result,
+      // Flattened alias so the settings screen can render the list directly.
+      blockedUsers: result.items.map(
+        (block: {
+          createdAt: Date | string;
+          blocked: { id: string } | null;
+        }) => ({
+          ...block.blocked,
+          blockedAt: block.createdAt,
+        }),
+      ),
+    });
+  } catch (error) {
+    if (error instanceof PaginationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 }
+      );
+    }
+
+    console.error("Error listing blocked users:", error);
+    return NextResponse.json(
+      { error: "Failed to list blocked users" },
+      { status: 500 }
+    );
+  }
+}
 
 export const POST = withValidation(BlockSchema, async (request, validatedData) => {
   try {
@@ -28,12 +129,15 @@ export const POST = withValidation(BlockSchema, async (request, validatedData) =
       );
     }
 
-    // Check if the target user exists
+    // Check if the target user exists. Only the two columns needed for the
+    // decision are selected — this used to pull the entire user row,
+    // credentials included.
     const targetUser = await prisma.user.findUnique({
       where: { id: blockedId },
+      select: { id: true, isDeleted: true },
     });
 
-    if (!targetUser) {
+    if (!targetUser || targetUser.isDeleted) {
       return NextResponse.json(
         { error: "User to block not found" },
         { status: 404 }
@@ -54,18 +158,79 @@ export const POST = withValidation(BlockSchema, async (request, validatedData) =
       return NextResponse.json({ success: true, message: "User is already blocked" });
     }
 
-    await prisma.block.create({
-      data: {
-        blockerId: session.user.id,
-        blockedId,
-      },
-    });
+    // Creating the block and clearing a pending connection request go together:
+    // leaving the request behind would keep the blocked user sitting in the
+    // caller's "incoming" list with no way to act on it.
+    await prisma.$transaction([
+      prisma.block.create({
+        data: {
+          blockerId: session.user.id,
+          blockedId,
+        },
+      }),
+      prisma.connectionRequest.deleteMany({
+        where: {
+          status: "PENDING",
+          OR: [
+            { senderId: session.user.id, receiverId: blockedId },
+            { senderId: blockedId, receiverId: session.user.id },
+          ],
+        },
+      }),
+    ]);
 
     return NextResponse.json({ success: true, message: "User blocked successfully" }, { status: 201 });
   } catch (error) {
     console.error("Error blocking user:", error);
     return NextResponse.json(
       { error: "Failed to block user" },
+      { status: 500 }
+    );
+  }
+});
+
+/**
+ * DELETE /api/user/block — remove a block the caller created.
+ *
+ * The body carries the target id, matching the existing DELETE
+ * /api/user/account convention. Only the caller's own block row is ever
+ * touched, so this cannot be used to lift somebody else's block.
+ */
+export const DELETE = withValidation(UnblockSchema, async (request, validatedData) => {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const { blockedId } = validatedData;
+
+    const deleted = await prisma.block.deleteMany({
+      where: {
+        blockerId: session.user.id,
+        blockedId,
+      },
+    });
+
+    if (deleted.count === 0) {
+      return NextResponse.json(
+        { error: "You have not blocked this user" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "User unblocked successfully",
+    });
+  } catch (error) {
+    console.error("Error unblocking user:", error);
+    return NextResponse.json(
+      { error: "Failed to unblock user" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
Closes #349

## Problem

`/api/user/block` exported `POST` and nothing else. A block could not be undone through the API, and there was no way to find out who you had blocked — so no settings screen was possible either.

## What changed

### `GET /api/user/block` (new)

Returns the caller's blocks, newest first, using the existing cursor helpers from `src/lib/pagination.ts` — same shape as `/api/routes`:

```json
{
  "items": [{ "id": "block-2", "createdAt": "...", "blocked": { "id": "user-3", "name": "Ravi", "image": null, "location": "Goa" } }],
  "pagination": { "limit": 20, "nextCursor": "...", "hasMore": true },
  "blockedUsers": [{ "id": "user-3", "name": "Ravi", "image": null, "location": "Goa", "blockedAt": "..." }]
}
```

`blockedUsers` is a flattened alias so the UI can render the list without reaching through `blocked`. The select list is pinned to `id`, `name`, `image`, `location` and there is a test asserting exactly that, so a future edit cannot quietly widen it.

### `DELETE /api/user/block` (new)

Takes `{ "blockedId": "..." }`. Uses `deleteMany` scoped to `blockerId = session.user.id`, so a caller can only ever remove a block they created — there is no id in the request that could point at somebody else's row. Returns `404` when no such block exists.

The body-carrying DELETE follows the existing `DELETE /api/user/account` convention in this repo rather than inventing a query-string style.

### `POST` hardening

- **Stopped over-selecting.** The existence check was `prisma.user.findUnique({ where: { id: blockedId } })` with no `select`, which loads `passwordHash`, `otp`, `resetToken` and `resetTokenExpires` into memory just to find out whether a row exists. Now `select: { id: true, isDeleted: true }`.
- **Soft-deleted accounts** are treated as not found instead of blockable.
- **Pending connection requests are cleared** in the same `$transaction` as the block. Previously blocking somebody left their request sitting in your "incoming" list, and after #348 it could not be actioned either — a dead entry with no way to clear it.

## Tests

`npx vitest run src/app/api/user` → 26 passed.

`src/app/api/user/block/__tests__/route.test.ts` is new (13 cases):

- `GET` — 401, ordering and `where` clause, the credential-column assertion, `hasMore` + `nextCursor` on a full page, `400` on a malformed `limit`.
- `POST` — soft-deleted target, the transaction clearing the pending request, the narrowed `select`, idempotent re-block.
- `DELETE` — 401, missing `blockedId`, scoping to the caller's own row, `404` when nothing was blocked.

`src/app/api/user/__tests__/moderation.test.ts` needed `$transaction` and `connectionRequest.deleteMany` added to its Prisma mock; its existing assertions are unchanged and still pass.

`npm run lint` is clean. No new `tsc` errors (the pre-existing admin-ticket `PATCH` ones from #318 are untouched).

## Notes for review

- No schema change. `@@unique([blockerId, blockedId])` and both single-column indexes already exist on `Block`.
- `deleteMany` rather than `delete` is deliberate: `delete` throws `P2025` when the row is absent, which would mean catching a Prisma error code to produce the `404`. `deleteMany` gives a count and keeps the handler readable.
- This branch does not touch `/api/messages` or `/api/conversations`, so it is independent of #348.
