### PR TITLE
fix(meetup-plans): drop debug logging and validate the create payload

### DIFF
--- a/src/app/api/meetup-plans/__tests__/route.test.ts
+++ b/src/app/api/meetup-plans/__tests__/route.test.ts
@@ -1,0 +1,294 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { GET, POST } from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    meetupPlan: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    conversation: {
+      findFirst: vi.fn(),
+    },
+    route: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+function listRequest(query = "") {
+  return new NextRequest(
+    `http://localhost/api/meetup-plans${query}`,
+  );
+}
+
+function jsonRequest(body: unknown) {
+  return {
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type"
+          ? "application/json"
+          : null,
+    },
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+const VALID_BODY = {
+  conversationId: "conv-1",
+  title: "Coffee before the bus",
+  locationName: "Anjuna beach shack",
+  meetupTime: "2026-09-01T09:00:00.000Z",
+};
+
+describe("GET /api/meetup-plans", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await GET(listRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns the caller's plans as a list when no conversationId is given", async () => {
+    vi.mocked(prisma.meetupPlan.findMany).mockResolvedValue([
+      { id: "plan-1" },
+    ] as never);
+
+    const response = await GET(listRequest());
+    const body = await response.json();
+
+    expect(body).toEqual([{ id: "plan-1" }]);
+    expect(prisma.meetupPlan.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          conversation: {
+            users: { some: { id: "user-1" } },
+          },
+        },
+      }),
+    );
+  });
+
+  it("scopes a single-conversation read to the caller's membership", async () => {
+    vi.mocked(prisma.meetupPlan.findFirst).mockResolvedValue({
+      id: "plan-1",
+    } as never);
+
+    const response = await GET(
+      listRequest("?conversationId=conv-1"),
+    );
+    const body = await response.json();
+
+    expect(body.id).toBe("plan-1");
+    expect(prisma.meetupPlan.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          conversationId: "conv-1",
+          conversation: {
+            users: { some: { id: "user-1" } },
+          },
+        },
+      }),
+    );
+  });
+});
+
+describe("POST /api/meetup-plans", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.conversation.findFirst).mockResolvedValue({
+      id: "conv-1",
+    } as never);
+    vi.mocked(prisma.meetupPlan.findFirst).mockResolvedValue(
+      null as never,
+    );
+    vi.mocked(prisma.meetupPlan.create).mockResolvedValue({
+      id: "plan-1",
+    } as never);
+  });
+
+  it("returns 400 instead of crashing on an unparseable meetupTime", async () => {
+    const response = await POST(
+      jsonRequest({
+        ...VALID_BODY,
+        meetupTime: "not a date",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.meetupPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when meetupTime is missing", async () => {
+    const { meetupTime, ...withoutTime } = VALID_BODY;
+
+    const response = await POST(jsonRequest(withoutTime));
+
+    expect(response.status).toBe(400);
+    expect(prisma.meetupPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a meetup dated well into the past", async () => {
+    const response = await POST(
+      jsonRequest({
+        ...VALID_BODY,
+        meetupTime: "2019-01-01T00:00:00.000Z",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.meetupPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty title", async () => {
+    const response = await POST(
+      jsonRequest({ ...VALID_BODY, title: "   " }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects out-of-range coordinates", async () => {
+    const response = await POST(
+      jsonRequest({
+        ...VALID_BODY,
+        latitude: 120,
+        longitude: 0,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.meetupPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("persists the coordinates it was given", async () => {
+    await POST(
+      jsonRequest({
+        ...VALID_BODY,
+        latitude: 15.5874,
+        longitude: 73.7405,
+      }),
+    );
+
+    expect(prisma.meetupPlan.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          latitude: 15.5874,
+          longitude: 73.7405,
+        }),
+      }),
+    );
+  });
+
+  it("falls back to 0/0 when no point has been picked yet", async () => {
+    await POST(jsonRequest(VALID_BODY));
+
+    expect(prisma.meetupPlan.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          latitude: 0,
+          longitude: 0,
+        }),
+      }),
+    );
+  });
+
+  it("returns 403 for a conversation the caller is not in", async () => {
+    vi.mocked(prisma.conversation.findFirst).mockResolvedValue(
+      null as never,
+    );
+
+    const response = await POST(jsonRequest(VALID_BODY));
+
+    expect(response.status).toBe(403);
+    expect(prisma.meetupPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the attached route belongs to somebody else", async () => {
+    vi.mocked(prisma.route.findFirst).mockResolvedValue(
+      null as never,
+    );
+
+    const response = await POST(
+      jsonRequest({ ...VALID_BODY, routeId: "route-9" }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(prisma.route.findFirst).toHaveBeenCalledWith({
+      where: { id: "route-9", userId: "user-1" },
+      select: { id: true },
+    });
+    expect(prisma.meetupPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("accepts a route the caller owns", async () => {
+    vi.mocked(prisma.route.findFirst).mockResolvedValue({
+      id: "route-1",
+    } as never);
+
+    const response = await POST(
+      jsonRequest({ ...VALID_BODY, routeId: "route-1" }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(prisma.meetupPlan.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          routeId: "route-1",
+        }),
+      }),
+    );
+  });
+
+  it("returns 409 with the existing id rather than a second plan", async () => {
+    vi.mocked(prisma.meetupPlan.findFirst).mockResolvedValue({
+      id: "plan-existing",
+    } as never);
+
+    const response = await POST(jsonRequest(VALID_BODY));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.meetupPlanId).toBe("plan-existing");
+    expect(prisma.meetupPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("creates the plan with the caller as creator", async () => {
+    const response = await POST(jsonRequest(VALID_BODY));
+
+    expect(response.status).toBe(201);
+    expect(prisma.meetupPlan.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          conversationId: "conv-1",
+          creatorId: "user-1",
+          title: "Coffee before the bus",
+          locationName: "Anjuna beach shack",
+          meetupTime: new Date(
+            "2026-09-01T09:00:00.000Z",
+          ),
+        }),
+      }),
+    );
+  });
+});

--- a/src/app/api/meetup-plans/route.ts
+++ b/src/app/api/meetup-plans/route.ts
@@ -1,102 +1,222 @@
 import { NextRequest, NextResponse } from "next/server";
-import prisma from "@/lib/prisma";
+import { z } from "zod";
+
 import { auth } from "@/lib/auth";
-console.log(prisma);
+import prisma from "@/lib/prisma";
+import { withValidation } from "@/lib/withValidation";
 
-console.log("Prisma keys:", Object.keys(prisma));
-console.log("Meetup model:", (prisma as any).meetupPlan);
+/**
+ * A plan created from the chat starts as a placeholder ("New Meetup" at the
+ * current time), so a strict "must be in the future" rule would reject the
+ * app's own request. This guards against the case that actually matters —
+ * a mistyped year landing the meetup in the distant past.
+ */
+const MAX_MEETUP_BACKDATE_MS = 24 * 60 * 60 * 1000;
 
+const MeetupPlanSchema = z.object({
+  conversationId: z
+    .string()
+    .trim()
+    .min(1, "conversationId is required"),
+  title: z
+    .string()
+    .trim()
+    .min(1, "Title is required")
+    .max(120, "Title is too long (max 120 characters)"),
+  locationName: z
+    .string()
+    .trim()
+    .min(1, "Location is required")
+    .max(200, "Location is too long (max 200 characters)"),
+  meetupTime: z
+    .string()
+    .refine(
+      (value) => !Number.isNaN(new Date(value).getTime()),
+      "meetupTime must be a valid date",
+    )
+    .refine(
+      (value) =>
+        new Date(value).getTime() >
+        Date.now() - MAX_MEETUP_BACKDATE_MS,
+      "meetupTime cannot be more than a day in the past",
+    ),
+  // Optional until the user picks a point on the map. Previously these were
+  // hardcoded to 0, so every plan was stored at Null Island.
+  latitude: z
+    .number()
+    .min(-90, "Latitude must be between -90 and 90")
+    .max(90, "Latitude must be between -90 and 90")
+    .optional(),
+  longitude: z
+    .number()
+    .min(-180, "Longitude must be between -180 and 180")
+    .max(180, "Longitude must be between -180 and 180")
+    .optional(),
+  notes: z
+    .string()
+    .max(2000, "Notes are too long (max 2000 characters)")
+    .optional(),
+  routeId: z.string().min(1).nullish(),
+});
+
+const MEETUP_PLAN_INCLUDE = {
+  checklist: true,
+} as const;
+
+/**
+ * GET /api/meetup-plans
+ *
+ * With `conversationId`: the single plan for that conversation, or `null`.
+ * Without it: every plan in the caller's conversations, as an array.
+ *
+ * The two shapes exist because both callers already depend on them — the chat
+ * panel reads a single plan, and the meetup dashboard reads a list. The
+ * list case used to return `[]` unconditionally, so the dashboard could never
+ * show a plan at all.
+ */
 export async function GET(req: NextRequest) {
-  const session = await auth();
-
-  if (!session?.user?.id) {
-    return NextResponse.json([], { status: 401 });
-  }
-
-  const conversationId =
-    req.nextUrl.searchParams.get("conversationId");
-
-  if (!conversationId) {
-    return NextResponse.json([]);
-  }
-
-  // Only return the plan if the caller is a member of its conversation,
-  // otherwise any authenticated user could read another conversation's plan
-  // by guessing the conversationId.
-  const plan = await prisma.meetupPlan.findFirst({
-    where: {
-      conversationId,
-      conversation: {
-        users: { some: { id: session.user.id } },
-      },
-    },
-    include: {
-      checklist: true,
-    },
-  });
-
-  return NextResponse.json(plan);
-}
-
-export async function POST(req: NextRequest) {
   const session = await auth();
 
   if (!session?.user?.id) {
     return NextResponse.json(
       { error: "Unauthorized" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
-  const body = await req.json();
+  const conversationId =
+    req.nextUrl.searchParams.get("conversationId");
 
-  const {
-    conversationId,
-    title,
-    locationName,
-    meetupTime,
-    notes,
-    routeId,
-  } = body;
+  try {
+    // Only return a plan if the caller is a member of its conversation,
+    // otherwise any authenticated user could read another conversation's plan
+    // by guessing the conversationId.
+    if (conversationId) {
+      const plan = await prisma.meetupPlan.findFirst({
+        where: {
+          conversationId,
+          conversation: {
+            users: { some: { id: session.user.id } },
+          },
+        },
+        include: MEETUP_PLAN_INCLUDE,
+      });
 
-  // The caller must belong to the conversation they're creating a plan in,
-  // otherwise they could attach a meetup plan to any conversation.
-  const conversation = await prisma.conversation.findFirst({
-    where: {
-      id: conversationId,
-      users: { some: { id: session.user.id } },
-    },
-    select: { id: true },
-  });
+      return NextResponse.json(plan);
+    }
 
-  if (!conversation) {
+    const plans = await prisma.meetupPlan.findMany({
+      where: {
+        conversation: {
+          users: { some: { id: session.user.id } },
+        },
+      },
+      include: MEETUP_PLAN_INCLUDE,
+      orderBy: { meetupTime: "asc" },
+    });
+
+    return NextResponse.json(plans);
+  } catch (error) {
+    console.error("Fetch meetup plans error:", error);
     return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403 }
+      { error: "Failed to load meetup plans" },
+      { status: 500 },
     );
   }
-
-  const meetup = await prisma.meetupPlan.create({
-  data: {
-    conversationId,
-
-    creatorId: session.user.id,
-
-    title,
-
-    locationName,
-
-    latitude: 0,
-
-    longitude: 0,
-
-    meetupTime: new Date(meetupTime),
-
-    notes,
-
-    routeId,
-  },
-});
-
-  return NextResponse.json(meetup);
 }
+
+export const POST = withValidation(
+  MeetupPlanSchema,
+  async (_req, data) => {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const userId = session.user.id;
+
+    try {
+      // The caller must belong to the conversation they're creating a plan in,
+      // otherwise they could attach a meetup plan to any conversation.
+      const conversation =
+        await prisma.conversation.findFirst({
+          where: {
+            id: data.conversationId,
+            users: { some: { id: userId } },
+          },
+          select: { id: true },
+        });
+
+      if (!conversation) {
+        return NextResponse.json(
+          { error: "Forbidden" },
+          { status: 403 },
+        );
+      }
+
+      // A shared route must belong to the creator, the same rule POST
+      // /api/messages applies — otherwise a member could attach (and expose)
+      // another user's route by passing its id.
+      if (data.routeId) {
+        const route = await prisma.route.findFirst({
+          where: { id: data.routeId, userId },
+          select: { id: true },
+        });
+
+        if (!route) {
+          return NextResponse.json(
+            {
+              error: "Route not found or not owned by you",
+            },
+            { status: 403 },
+          );
+        }
+      }
+
+      // GET reads the conversation's plan with findFirst, so a second plan
+      // would be silently unreachable. Say so instead of creating it.
+      const existing = await prisma.meetupPlan.findFirst({
+        where: { conversationId: data.conversationId },
+        select: { id: true },
+      });
+
+      if (existing) {
+        return NextResponse.json(
+          {
+            error:
+              "This conversation already has a meetup plan",
+            meetupPlanId: existing.id,
+          },
+          { status: 409 },
+        );
+      }
+
+      const meetup = await prisma.meetupPlan.create({
+        data: {
+          conversationId: data.conversationId,
+          creatorId: userId,
+          title: data.title,
+          locationName: data.locationName,
+          latitude: data.latitude ?? 0,
+          longitude: data.longitude ?? 0,
+          meetupTime: new Date(data.meetupTime),
+          notes: data.notes ?? null,
+          routeId: data.routeId ?? null,
+        },
+        include: MEETUP_PLAN_INCLUDE,
+      });
+
+      return NextResponse.json(meetup, { status: 201 });
+    } catch (error) {
+      console.error("Create meetup plan error:", error);
+      return NextResponse.json(
+        { error: "Failed to create meetup plan" },
+        { status: 500 },
+      );
+    }
+  },
+);

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -364,6 +364,22 @@ if (!inputText.trim() && !selectedRoute) {
       }),
     });
 
+    // A conversation holds a single plan. If one already exists (another
+    // participant created it, or this ran twice), open that one rather than
+    // showing an error.
+    if (res.status === 409) {
+      const existing = await fetch(
+        `/api/meetup-plans?conversationId=${activeConvId}`
+      );
+
+      if (existing.ok) {
+        const plan = await existing.json();
+        setMeetupPlan(plan);
+        setShowMeetup(!!plan);
+        return;
+      }
+    }
+
     if (!res.ok) {
       throw new Error("Failed to create meetup");
     }


### PR DESCRIPTION
Closes #351

## 1. Debug logging removed

```ts
console.log(prisma);
console.log("Prisma keys:", Object.keys(prisma));
console.log("Meetup model:", (prisma as any).meetupPlan);
```

These sat at module scope, so they ran on every cold start of the route and dumped the whole Prisma client into production logs. The middle one was also the only `(prisma as any)` cast in the codebase.

## 2. `POST` is validated

The handler moves onto `withValidation` + a zod schema, matching every other write route in the repo. `await req.json()` on a non-JSON body is now a `400` from the wrapper instead of an unhandled `500`.

| Field | Rule |
| --- | --- |
| `conversationId` | required, non-empty |
| `title` | required, trimmed, ≤ 120 |
| `locationName` | required, trimmed, ≤ 200 |
| `meetupTime` | must parse; rejected if more than 24h in the past |
| `latitude` / `longitude` | optional, `-90..90` / `-180..180` |
| `notes` | optional, ≤ 2000 |
| `routeId` | optional, must be owned by the caller |

`new Date("not a date")` used to reach Prisma as `Invalid Date` and come back as a raw `500`; it is a field error now.

**On the past-date rule:** a strict "must be in the future" check would reject the app's own request — `createMeetupPlan` in `ChatInterface` posts a placeholder plan at `new Date().toISOString()`, which is already a few milliseconds old by the time it is validated. The 24-hour window catches what actually goes wrong (a mistyped year) without breaking the placeholder flow. Happy to tighten it if the placeholder is reworked.

## 3. Coordinates are stored

`latitude: 0, longitude: 0` was hardcoded, so every plan was at Null Island even though the model has real `Float` columns and `/dashboard/meetup` renders them. They come from the body now, range-checked, falling back to `0/0` only while the user has not picked a point yet.

## 4. `routeId` ownership

Any conversation member could attach any `Route` id they could guess. `POST /api/messages` already guards exactly this ("a shared route must belong to the sender"); the same check now applies here and returns `403`.

## 5. One plan per conversation

`GET` reads the plan with `findFirst`, so a second plan for the same conversation would be created and then be permanently unreachable. `POST` returns `409` with the existing `meetupPlanId` instead. `ChatInterface` handles that by loading the existing plan rather than showing "Couldn't create meetup."

## 6. `GET` without `conversationId` returned `[]` unconditionally

Not in the original issue — found while testing. `/dashboard/meetup` calls `fetch("/api/meetup-plans")` with no query and reads `plans[0]`, but the route had:

```ts
if (!conversationId) {
  return NextResponse.json([]);
}
```

So that page could only ever render "No meetup plan found." It now returns the caller's plans (scoped through conversation membership), ordered by `meetupTime`, which is the shape the dashboard already expects. The `conversationId` branch still returns a single object for the chat panel — both existing callers keep working.

## Tests

`npx vitest run src/app/api/meetup-plans` → 15 passed (new file).

`GET`: 401, the list shape and its membership scoping, the single-plan scoping.
`POST`: unparseable and missing `meetupTime`, a far-past date, empty title, out-of-range coordinates, coordinates persisted, the `0/0` fallback, `403` for a non-member, `403` for somebody else's route, a route the caller owns, `409` carrying the existing id, and the created payload.

`npm run lint` is clean, no new `tsc` errors.

## Notes for review

- `POST` returns `201` now instead of `200`. `ChatInterface` only checks `res.ok`, so it is unaffected.
- No schema change.
- This branch touches `meetup-plans/route.ts` and one function in `ChatInterface.tsx`, so it does not overlap with the messaging PRs.
