### PR TITLE
fix: GET /api/matches sends a self-notification on every filter change

### DIFF
--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -8,7 +8,6 @@ import {
 } from "@/lib/match-cache";
 
 import redis from "@/lib/redis";
-import { createNotification } from "@/lib/notifications";
 import {
   API_ERROR_CODES,
   logApiError,
@@ -393,18 +392,6 @@ export async function GET(req: NextRequest) {
       cacheKey,
       scoredMatches,
     );
-
-    if (scoredMatches.length > 0) {
-      await createNotification({
-        userId: session.user.id,
-        type: "MATCH_FOUND",
-        title: "New traveller match found",
-        content: `We found ${scoredMatches.length} traveller${
-          scoredMatches.length > 1 ? "s" : ""
-        } matching your destination and travel date.`,
-        link: "/dashboard",
-      });
-    }
 
     const total = scoredMatches.length;
     const skip = (page - 1) * limit;


### PR DESCRIPTION
Closes #369

### Problem
`GET /api/matches` created a `MATCH_FOUND` notification whenever `scoredMatches.length > 0`. Because each distinct filter combination is a separate cache key (a fresh cache miss), a user adjusting filters received a "New traveller match found" notification for every one of their own searches.

### Fix
Removed the `createNotification` call from the search path (and its now-unused import). Match notifications should be driven by ticket creation/verification, not by the searchers own GET.

### Testing
- `npx tsc --noEmit` clean on the changed route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._