### PR TITLE
fix: remove allowDangerousEmailAccountLinking (pre-registration account linking)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,7 +30,6 @@ export const { auth, signIn, signOut, handlers } = NextAuth({
     GoogleProvider({
   clientId: process.env.GOOGLE_CLIENT_ID!,
   clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-  allowDangerousEmailAccountLinking: true,
 }),
     AppleProvider({
       clientId: process.env.APPLE_CLIENT_ID!,


### PR DESCRIPTION
Closes #370

### Problem
`src/lib/auth.ts` set `allowDangerousEmailAccountLinking: true` on the Google provider. An attacker could `POST /api/auth/signup` with a victims email **before** the victim first uses Google sign-in, creating a credentials user row with the attackers password. When the victim later signs in with Google for that email, the flag links the Google identity to the attacker-created row instead of refusing — the account then carries the attackers credentials alongside the victims OAuth login.

### Fix
Remove the flag (defaults to `false`), so NextAuth will not auto-link a provider to an existing account by (unverified) email.

### Testing
- `npx tsc --noEmit` clean on the changed file.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._