### PR TITLE
fix: restore missing admin ticket PATCH handler (verify/reject + audit trail)

### DIFF
--- a/src/app/api/admin/tickets/[id]/__tests__/cache-invalidation.test.ts
+++ b/src/app/api/admin/tickets/[id]/__tests__/cache-invalidation.test.ts
@@ -22,10 +22,7 @@ vi.mock("@/lib/prisma", () => ({
     user: {
       findUnique: vi.fn(),
     },
-    ticket: {
-      findUnique: vi.fn(),
-      update: vi.fn(),
-    },
+    $transaction: vi.fn(),
   },
 }));
 
@@ -39,6 +36,7 @@ vi.mock("@/lib/notifications", () => ({
 
 const existingTicket = {
   id: "ticket-1",
+  userId: "traveller-1",
   destination: "Goa",
   departureDate: new Date(
     "2026-08-15T00:00:00.000Z",
@@ -46,15 +44,27 @@ const existingTicket = {
   status: "PENDING",
 };
 
-const updatedTicket = {
-  ...existingTicket,
-  status: "VERIFIED",
-  user: {
-    id: "traveller-1",
-    name: "Traveller",
-    email: "traveller@example.com",
-  },
-};
+function transactionMock(status: string) {
+  return {
+    ticket: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue(existingTicket),
+      update: vi.fn().mockResolvedValue({
+        ...existingTicket,
+        status,
+        user: {
+          id: "traveller-1",
+          name: "Traveller",
+          email: "traveller@example.com",
+        },
+      }),
+    },
+    ticketAuditLog: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -67,28 +77,18 @@ beforeEach(() => {
   ).mockResolvedValue({
     role: "ADMIN",
   } as never);
-  vi.mocked(
-    prisma.ticket.findUnique,
-  ).mockResolvedValue(
-    existingTicket as never,
-  );
-  vi.mocked(
-    prisma.ticket.update,
-  ).mockResolvedValue(
-    updatedTicket as never,
-  );
 });
 
 describe("admin ticket cache invalidation", () => {
   it.each(["VERIFIED", "REJECTED"])(
     "invalidates matching windows when status becomes %s",
     async (status) => {
+      const tx = transactionMock(status);
       vi.mocked(
-        prisma.ticket.update,
-      ).mockResolvedValue({
-        ...updatedTicket,
-        status,
-      } as never);
+        prisma.$transaction,
+      ).mockImplementation(
+        async (callback: any) => callback(tx),
+      );
 
       const response = await PATCH(
         new NextRequest(
@@ -98,7 +98,10 @@ describe("admin ticket cache invalidation", () => {
             headers: {
               "content-type": "application/json",
             },
-            body: JSON.stringify({ status }),
+            body: JSON.stringify({
+              status,
+              reason: "Reviewed by admin",
+            }),
           },
         ),
         {
@@ -128,9 +131,15 @@ describe("admin ticket cache invalidation", () => {
   );
 
   it("does not fail verification when invalidation fails safely", async () => {
+    const tx = transactionMock("VERIFIED");
+    vi.mocked(
+      prisma.$transaction,
+    ).mockImplementation(
+      async (callback: any) => callback(tx),
+    );
     vi.mocked(
       invalidateMatchCachesForTicket,
-    ).mockResolvedValue(undefined);
+    ).mockRejectedValue(new Error("cache down"));
 
     const response = await PATCH(
       new NextRequest(

--- a/src/app/api/admin/tickets/[id]/route.ts
+++ b/src/app/api/admin/tickets/[id]/route.ts
@@ -10,6 +10,8 @@ import {
   apiJson,
 } from "@/lib/api-response";
 import { auth } from "@/lib/auth";
+import { invalidateMatchCachesForTicket } from "@/lib/match-cache";
+import { createNotification } from "@/lib/notifications";
 import {
   buildTimestampCursorWhere,
   createPaginatedResponse,
@@ -18,6 +20,10 @@ import {
 } from "@/lib/pagination";
 import prisma from "@/lib/prisma";
 import { getRequestId } from "@/lib/request-id";
+import {
+  NotificationType,
+  TicketStatus,
+} from "@prisma/client";
 
 interface RouteContext {
   params: {
@@ -150,6 +156,256 @@ export async function GET(
       requestId,
       API_ERROR_CODES.INTERNAL_ERROR,
       "Unable to retrieve ticket history",
+      500,
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: RouteContext,
+) {
+  const requestId = getRequestId(request);
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return apiError(
+      requestId,
+      API_ERROR_CODES.UNAUTHORIZED,
+      "Authentication is required",
+      401,
+    );
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: {
+        id: session.user.id,
+      },
+      select: {
+        role: true,
+      },
+    });
+
+    if (user?.role !== "ADMIN") {
+      return apiError(
+        requestId,
+        API_ERROR_CODES.FORBIDDEN,
+        "Administrator access is required",
+        403,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return apiError(
+        requestId,
+        API_ERROR_CODES.VALIDATION_ERROR,
+        "The request data is invalid",
+        400,
+      );
+    }
+
+    const status = (body as { status?: unknown })
+      ?.status;
+    const reasonRaw = (
+      body as { reason?: unknown }
+    )?.reason;
+    const reason =
+      typeof reasonRaw === "string"
+        ? reasonRaw.trim()
+        : "";
+
+    if (
+      status !== TicketStatus.VERIFIED &&
+      status !== TicketStatus.REJECTED
+    ) {
+      return apiError(
+        requestId,
+        API_ERROR_CODES.VALIDATION_ERROR,
+        "The request data is invalid",
+        400,
+        {
+          status: [
+            "Status must be VERIFIED or REJECTED",
+          ],
+        },
+      );
+    }
+
+    // A rejection must be justified — the reason is stored on the audit row.
+    if (
+      status === TicketStatus.REJECTED &&
+      !reason
+    ) {
+      return apiError(
+        requestId,
+        API_ERROR_CODES.VALIDATION_ERROR,
+        "A reason is required to reject a ticket",
+        400,
+        {
+          reason: [
+            "A reason is required to reject a ticket",
+          ],
+        },
+      );
+    }
+
+    const adminId = session.user.id;
+
+    // Update the ticket and write its immutable audit row in one transaction
+    // so the decision and its audit trail can never diverge. Unchanged
+    // decisions are a no-op (no update, no duplicate audit row).
+    const result = await prisma.$transaction(
+      async (tx) => {
+        const existing =
+          await tx.ticket.findUnique({
+            where: { id: params.id },
+            select: {
+              id: true,
+              userId: true,
+              destination: true,
+              departureDate: true,
+              status: true,
+            },
+          });
+
+        if (!existing) {
+          return { notFound: true as const };
+        }
+
+        if (existing.status === status) {
+          const ticket =
+            await tx.ticket.findUnique({
+              where: { id: params.id },
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    email: true,
+                  },
+                },
+              },
+            });
+          return {
+            changed: false as const,
+            ticket,
+          };
+        }
+
+        const updated = await tx.ticket.update({
+          where: { id: params.id },
+          data: { status },
+          include: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+              },
+            },
+          },
+        });
+
+        await tx.ticketAuditLog.create({
+          data: {
+            ticketId: params.id,
+            adminId,
+            previousStatus: existing.status,
+            newStatus: status,
+            reason: reason || null,
+            requestId,
+          },
+        });
+
+        return {
+          changed: true as const,
+          ticket: updated,
+          previous: existing,
+        };
+      },
+    );
+
+    if ("notFound" in result) {
+      return apiError(
+        requestId,
+        API_ERROR_CODES.NOT_FOUND,
+        "Ticket not found",
+        404,
+      );
+    }
+
+    // Side effects run only after the transaction commits, and only when the
+    // decision actually changed.
+    if (result.changed) {
+      // Verification/rejection changes which tickets are matchable, so the
+      // cached match windows must be invalidated. Never let a cache failure
+      // fail the committed status update.
+      try {
+        await invalidateMatchCachesForTicket(
+          {
+            destination:
+              result.previous.destination,
+            departureDate:
+              result.previous.departureDate,
+          },
+          {
+            destination:
+              result.previous.destination,
+            departureDate:
+              result.previous.departureDate,
+          },
+        );
+      } catch (cacheError) {
+        logApiError(
+          requestId,
+          "Match cache invalidation failed after ticket status change",
+          cacheError,
+        );
+      }
+
+      const isVerified =
+        status === TicketStatus.VERIFIED;
+
+      await createNotification({
+        userId: result.ticket!.user.id,
+        type: isVerified
+          ? NotificationType.TICKET_VERIFIED
+          : NotificationType.TICKET_REJECTED,
+        title: isVerified
+          ? "Ticket verified"
+          : "Ticket rejected",
+        content: isVerified
+          ? `Your ticket to ${result.ticket!.destination} has been verified.`
+          : `Your ticket to ${result.ticket!.destination} was rejected. ${reason}`,
+        link: "/dashboard",
+      });
+    }
+
+    return apiJson(
+      {
+        ticket: result.ticket,
+        changed: result.changed,
+      },
+      requestId,
+      {
+        status: 200,
+      },
+    );
+  } catch (error) {
+    logApiError(
+      requestId,
+      "Ticket status update failed",
+      error,
+    );
+
+    return apiError(
+      requestId,
+      API_ERROR_CODES.INTERNAL_ERROR,
+      "Unable to update ticket status",
       500,
     );
   }


### PR DESCRIPTION
Closes #368

### Problem
`src/app/api/admin/tickets/[id]/route.ts` had become a byte-for-byte copy of the history route — it exported only `GET`, with **no `PATCH`**. So admins could not verify/reject a ticket (`PATCH` → 405), and since `GET /api/matches` only matches `VERIFIED` tickets, the whole matching flow stayed empty. The `[id]/__tests__/route.test.ts` and `route-exports.test.ts` suites (which import `PATCH`) were failing.

### Fix
Restored `PATCH` to the current authoritative spec in `route.test.ts` ("feat: add immutable ticket decision audit trail"):
- Admin-gated (`auth()` + `role === ADMIN`).
- Validates `status ∈ {VERIFIED, REJECTED}`; **rejection requires a `reason`** (400 otherwise, before any DB work).
- Updates the ticket **and** writes one `TicketAuditLog` row **atomically** in a `prisma.$transaction` (`previousStatus`, `newStatus`, `reason`, `adminId`, `requestId`).
- **Idempotent**: an unchanged decision is a no-op — no update, no duplicate audit row, no notification, returns `{ changed: false }`.
- Match-cache invalidation (best-effort — a cache failure never fails the committed update) and the traveller notification run **only after the transaction commits**, so a rollback sends nothing.

### Note on the older test
`cache-invalidation.test.ts` predates the audit-trail feature and contradicted the current spec (it mocked prisma without `$transaction` and expected a reason-less rejection to succeed). I realigned it to the transaction architecture, preserving its cache-invalidation + notification assertions.

### Testing
- `npx tsc --noEmit` clean on the route.
- All 4 admin-ticket test files pass (12/12): `route.test.ts`, `cache-invalidation.test.ts`, `route-exports.test.ts`, `history/route.test.ts`.

> Heads-up: the base branch is currently failing to build (see #366 — duplicate `const rateLimit` in the auth routes), so repo-wide CI wont be green until that lands; this change is isolated to the admin-ticket route and its tests.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._