### PR TITLE
fix: base branch fails to build — duplicate rateLimit declaration in 5 auth routes

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,7 +4,6 @@ import {
   rateLimitExceededResponse,
 } from "@/lib/rate-limit";
 import { enforceRateLimit } from "@/lib/rate-limit-rules";
-import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config";
 import type { NextRequest } from "next/server";
 
 export const GET = handlers.GET;
@@ -35,12 +34,6 @@ export async function POST(request: NextRequest): Promise<Response> {
 
   const email = await getCredentialsEmail(request);
   const rateLimit = await enforceRateLimit(request, "authSignin", email);
-  const rateLimit = await checkRateLimit({
-    namespace: "auth:signin",
-    identifier: getRateLimitIdentifier(request, email),
-    limit: RATE_LIMIT_CONFIG.auth.signin.limit,
-    windowSeconds: RATE_LIMIT_CONFIG.auth.signin.windowSeconds,
-  });
 
   if (!rateLimit.allowed) {
     return rateLimitExceededResponse(rateLimit);

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -9,7 +9,6 @@ import {
   rateLimitExceededResponse,
 } from "@/lib/rate-limit";
 import { enforceRateLimit } from "@/lib/rate-limit-rules";
-import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config";
 
 const forgotPasswordSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -20,12 +19,6 @@ export const POST = withValidation(forgotPasswordSchema, async (req, data) => {
     const { email } = data;
 
     const rateLimit = await enforceRateLimit(req, "authForgotPassword", email);
-    const rateLimit = await checkRateLimit({
-      namespace: "auth:forgot-password",
-      identifier: getRateLimitIdentifier(req, email),
-      limit: RATE_LIMIT_CONFIG.auth.forgotPassword.limit,
-      windowSeconds: RATE_LIMIT_CONFIG.auth.forgotPassword.windowSeconds,
-    });
 
     if (!rateLimit.allowed) {
       return rateLimitExceededResponse(rateLimit);

--- a/src/app/api/auth/resend-otp/route.ts
+++ b/src/app/api/auth/resend-otp/route.ts
@@ -9,7 +9,6 @@ import {
   rateLimitExceededResponse,
 } from "@/lib/rate-limit";
 import { enforceRateLimit } from "@/lib/rate-limit-rules";
-import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config";
 
 const resendSchema = z.object({
   email: z.string().email("Invalid email"),
@@ -20,12 +19,6 @@ export const POST = withValidation(resendSchema, async (req, data) => {
     const { email } = data;
 
     const rateLimit = await enforceRateLimit(req, "authResendOtp", email);
-    const rateLimit = await checkRateLimit({
-      namespace: "auth:resend-otp",
-      identifier: getRateLimitIdentifier(req, email),
-      limit: RATE_LIMIT_CONFIG.auth.resendOtp.limit,
-      windowSeconds: RATE_LIMIT_CONFIG.auth.resendOtp.windowSeconds,
-    });
 
     if (!rateLimit.allowed) {
       return rateLimitExceededResponse(rateLimit);

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -11,7 +11,6 @@ import {
   rateLimitExceededResponse,
 } from "@/lib/rate-limit";
 import { enforceRateLimit } from "@/lib/rate-limit-rules";
-import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config";
 
 const signupSchema = z.object({
   name: z.string().min(1, "Name required"),
@@ -28,12 +27,6 @@ export const POST = withValidation(
       const { name, email, password } = data;
 
       const rateLimit = await enforceRateLimit(_req, "authSignup", email);
-      const rateLimit = await checkRateLimit({
-        namespace: "auth:signup",
-        identifier: getRateLimitIdentifier(_req, email),
-        limit: RATE_LIMIT_CONFIG.auth.signup.limit,
-        windowSeconds: RATE_LIMIT_CONFIG.auth.signup.windowSeconds,
-      });
 
       if (!rateLimit.allowed) {
         return rateLimitExceededResponse(rateLimit);

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -8,7 +8,6 @@ import {
   rateLimitExceededResponse,
 } from "@/lib/rate-limit";
 import { enforceRateLimit } from "@/lib/rate-limit-rules";
-import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config";
 
 const verifySchema = z.object({
   email: z.string().email("Invalid email"),
@@ -20,12 +19,6 @@ export const POST = withValidation(verifySchema, async (req, data) => {
     const { email, otp } = data;
 
     const rateLimit = await enforceRateLimit(req, "authVerifyOtp", email);
-    const rateLimit = await checkRateLimit({
-      namespace: "auth:verify-otp",
-      identifier: getRateLimitIdentifier(req, email),
-      limit: RATE_LIMIT_CONFIG.auth.verifyOtp.limit,
-      windowSeconds: RATE_LIMIT_CONFIG.auth.verifyOtp.windowSeconds,
-    });
 
     if (!rateLimit.allowed) {
       return rateLimitExceededResponse(rateLimit);


### PR DESCRIPTION
Closes #366

### Problem
Five auth routes each declared `const rateLimit` twice:
```ts
const rateLimit = await enforceRateLimit(_req, "authSignup", email);   // correct helper
const rateLimit = await checkRateLimit({ ... });                        // redeclare + undefined fns
```
`checkRateLimit` and `getRateLimitIdentifier` aren’t imported in these files, so this is both `Cannot redeclare block-scoped variable rateLimit` and `Cannot find name checkRateLimit` — failing `tsc` and `next build` (the `build-and-lint` CI job), and breaking signup, OTP resend, OTP verify, password reset, and credential sign-in at runtime.

Affected files:
- `src/app/api/auth/signup/route.ts`
- `src/app/api/auth/resend-otp/route.ts`
- `src/app/api/auth/verify-otp/route.ts`
- `src/app/api/auth/forgot-password/route.ts`
- `src/app/api/auth/[...nextauth]/route.ts`

### Fix
Remove the leftover `checkRateLimit({...})` block in each (the migration to `enforceRateLimit` was the intended path — it already wraps the rule lookup, `getRateLimitIdentifier`, and `checkRateLimit`), and drop the now-unused `RATE_LIMIT_CONFIG` import.

### Testing
- `npx tsc --noEmit` is clean on all five routes.

> Note: the base branch has a second, independent build break — the admin ticket route is missing its `PATCH` export — fixed separately in #378. Both need to land for `build-and-lint` to go fully green. The remaining vitest failures are a pre-existing test-infra issue (`require("@/lib/rate-limit")` alias resolution), tracked in #318, and are not run by the current CI.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._