### PR TITLE
fix(users): stop exposing email addresses from user search

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -123,6 +123,53 @@ Request body:
 }
 ```
 
+### `GET /api/users`
+
+Search other travellers. Requires an authenticated session.
+
+Query parameters:
+
+| Parameter | Type    | Default | Notes |
+| --------- | ------- | ------- | ----- |
+| `search`  | string  | —       | Trimmed. Matched case-insensitively against `name` and `location`. Max 100 characters. |
+| `limit`   | integer | `20`    | Capped at 100. |
+| `cursor`  | string  | —       | Opaque cursor taken from a previous response's `nextCursor`. |
+
+Response:
+
+```json
+{
+  "users": [
+    {
+      "id": "clx...",
+      "name": "Asha Sharma",
+      "image": null,
+      "bio": "Travel enthusiast",
+      "location": "Delhi",
+      "createdAt": "2026-01-04T10:12:00.000Z"
+    }
+  ],
+  "nextCursor": "eyJ2ZXJzaW9uIjox...",
+  "hasMore": true
+}
+```
+
+Privacy rules this endpoint enforces:
+
+- **Email addresses are never returned and are never searched.** Matching on
+  `email` would turn the endpoint into an account-enumeration oracle, and
+  returning it would expose an address that no screen in the product shows.
+- Soft-deleted accounts (`isDeleted: true`) are excluded.
+- The caller is excluded from their own results.
+- Users on either side of a `Block` are excluded, matching the behaviour of
+  `GET /api/conversations`.
+
+Typical responses:
+
+- `200 OK` with the page of results
+- `400 Bad Request` for an invalid `limit`/`cursor` or an over-long `search`
+- `401 Unauthorized` without a session
+
 ## Ticket endpoints
 
 ### `POST /api/tickets`

--- a/src/app/api/users/__tests__/route.test.ts
+++ b/src/app/api/users/__tests__/route.test.ts
@@ -7,15 +7,22 @@ vi.mock("@/lib/auth", () => ({
   })),
 }));
 
+vi.mock("@/lib/blocking", () => ({
+  getBlockedUserIds: vi.fn(async () => []),
+}));
+
 vi.mock("@/lib/pagination", () => ({
   parsePaginationParams: vi.fn((searchParams) => ({
     limit: Math.min(Number.parseInt(searchParams.get("limit") || "20", 10), 100),
     cursor: searchParams.get("cursor") ? { timestamp: "2024-01-01T00:00:00.000Z", id: "cursor-id" } : null,
   })),
-  buildTimestampCursorWhere: vi.fn((cursor) => cursor ? {
+  // Real signature is (field, cursor) — the previous mock took the cursor as
+  // its first parameter, so it was handed the string "createdAt" and returned
+  // a bogus filter on every call.
+  buildTimestampCursorWhere: vi.fn((field, cursor) => cursor ? {
     OR: [
-      { createdAt: { lt: new Date(cursor.timestamp) } },
-      { createdAt: new Date(cursor.timestamp), id: { lt: cursor.id } },
+      { [field]: { lt: new Date(cursor.timestamp) } },
+      { [field]: new Date(cursor.timestamp), id: { lt: cursor.id } },
     ],
   } : undefined),
   createPaginatedResponse: vi.fn((records, limit) => {
@@ -31,11 +38,13 @@ vi.mock("@/lib/pagination", () => ({
       },
     };
   }),
+  PaginationError: class PaginationError extends Error {},
 }));
 
 vi.mock("@/lib/api-response", () => ({
   apiJson: (data: any) => new Response(JSON.stringify(data), { status: 200, headers: { "Content-Type": "application/json" } }),
-  apiError: () => new Response(JSON.stringify({ error: "error" }), { status: 401, headers: { "Content-Type": "application/json" } }),
+  apiError: (_requestId: string, _code: string, message: string, status: number) =>
+    new Response(JSON.stringify({ error: message }), { status, headers: { "Content-Type": "application/json" } }),
 }));
 
 vi.mock("@/lib/api-error", () => ({
@@ -49,18 +58,53 @@ vi.mock("@/lib/prisma", () => ({
   default: { user: { findMany: vi.fn() } },
 }));
 
+/** The projection every caller is allowed to see — note the absence of `email`. */
+const PUBLIC_SELECT = {
+  id: true,
+  name: true,
+  image: true,
+  bio: true,
+  location: true,
+  createdAt: true,
+};
+
+function userRow(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: `User ${id}`,
+    image: null,
+    bio: null,
+    location: null,
+    createdAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+async function getPrisma() {
+  return (await import("@/lib/prisma")).default;
+}
+
+async function getBlocking() {
+  return await import("@/lib/blocking");
+}
+
 describe("GET /api/users", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+
+    const { auth } = await import("@/lib/auth");
+    (auth as any).mockResolvedValue({
+      user: { id: "test-user-id", email: "test@example.com", name: "Test User" },
+    });
+
+    const { getBlockedUserIds } = await getBlocking();
+    (getBlockedUserIds as any).mockResolvedValue([]);
   });
 
   it("should return first page of users without cursor", async () => {
-    const mockUsers = [
-      { id: "1", name: "User 1", email: "user1@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-02") },
-      { id: "2", name: "User 2", email: "user2@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-01") },
-    ];
+    const mockUsers = [userRow("1"), userRow("2")];
 
-    const prisma = (await import("@/lib/prisma")).default;
+    const prisma = await getPrisma();
     (prisma.user.findMany as any).mockResolvedValue(mockUsers);
 
     const request = new Request("http://localhost:3000/api/users?limit=20");
@@ -68,19 +112,45 @@ describe("GET /api/users", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.users).toEqual(mockUsers);
+    expect(data.users).toHaveLength(2);
     expect(data.nextCursor).toBeNull();
     expect(prisma.user.findMany).toHaveBeenCalledWith({
-      where: { isDeleted: false, id: { not: "test-user-id" } },
-      select: { id: true, name: true, email: true, image: true, bio: true, location: true, createdAt: true },
+      where: { isDeleted: false, id: { notIn: ["test-user-id"] } },
+      select: PUBLIC_SELECT,
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: 21,
     });
   });
 
+  it("never selects the email column", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    await GET(new Request("http://localhost:3000/api/users") as any);
+
+    const [{ select }] = (prisma.user.findMany as any).mock.calls[0];
+
+    expect(select).not.toHaveProperty("email");
+    expect(select).toEqual(PUBLIC_SELECT);
+  });
+
+  it("never returns an email in the response payload", async () => {
+    const prisma = await getPrisma();
+    // Even if a row somehow carries an email, the assertion below documents
+    // what the contract is: the serialised payload has no address in it.
+    (prisma.user.findMany as any).mockResolvedValue([userRow("1")]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users") as any,
+    );
+    const body = await response.text();
+
+    expect(body).not.toMatch(/@/);
+  });
+
   it("should return subsequent page using nextCursor", async () => {
-    const mockUsers = [{ id: "3", name: "User 3", email: "user3@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-03") }];
-    const prisma = (await import("@/lib/prisma")).default;
+    const mockUsers = [userRow("3", { createdAt: new Date("2024-01-03") })];
+    const prisma = await getPrisma();
     (prisma.user.findMany as any).mockResolvedValue(mockUsers);
 
     const request = new Request("http://localhost:3000/api/users?limit=20&cursor=encoded-cursor");
@@ -88,50 +158,166 @@ describe("GET /api/users", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.users).toEqual(mockUsers);
+    expect(data.users).toHaveLength(1);
   });
 
-  it("should apply search filter consistently before pagination", async () => {
-    const mockUsers = [{ id: "1", name: "Ayush", email: "ayush@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-02") }];
-    const prisma = (await import("@/lib/prisma")).default;
-    (prisma.user.findMany as any).mockResolvedValue(mockUsers);
+  it("searches name and location only — never email", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([userRow("1", { name: "Ayush" })]);
 
     const request = new Request("http://localhost:3000/api/users?search=ayush&limit=20");
     const response = await GET(request as any);
-    const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.users).toEqual(mockUsers);
     expect(prisma.user.findMany).toHaveBeenCalledWith({
       where: {
         isDeleted: false,
-        id: { not: "test-user-id" },
-        OR: [
-          { name: { contains: "ayush", mode: "insensitive" } },
-          { email: { contains: "ayush", mode: "insensitive" } },
-          { location: { contains: "ayush", mode: "insensitive" } },
+        id: { notIn: ["test-user-id"] },
+        AND: [
+          {
+            OR: [
+              { name: { contains: "ayush", mode: "insensitive" } },
+              { location: { contains: "ayush", mode: "insensitive" } },
+            ],
+          },
         ],
       },
-      select: { id: true, name: true, email: true, image: true, bio: true, location: true, createdAt: true },
+      select: PUBLIC_SELECT,
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: 21,
     });
   });
 
+  it("keeps the cursor filter when a search term is also present", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    await GET(
+      new Request(
+        "http://localhost:3000/api/users?search=goa&cursor=encoded-cursor",
+      ) as any,
+    );
+
+    const [{ where }] = (prisma.user.findMany as any).mock.calls[0];
+
+    // Both groups have to survive. Spreading them into one object made the
+    // search clause overwrite the cursor clause, so paging through a search
+    // returned page one over and over.
+    expect(where.AND).toHaveLength(2);
+    expect(where.AND[0].OR[0]).toEqual({
+      createdAt: { lt: new Date("2024-01-01T00:00:00.000Z") },
+    });
+    expect(where.AND[1].OR).toEqual([
+      { name: { contains: "goa", mode: "insensitive" } },
+      { location: { contains: "goa", mode: "insensitive" } },
+    ]);
+  });
+
+  it("cannot be used to harvest accounts by email domain", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    await GET(
+      new Request("http://localhost:3000/api/users?search=%40gmail.com") as any,
+    );
+
+    const [{ where }] = (prisma.user.findMany as any).mock.calls[0];
+    const searchGroup = where.AND.find((clause: any) => clause.OR);
+    const searchedColumns = searchGroup.OR.flatMap(Object.keys);
+
+    expect(searchedColumns).toEqual(["name", "location"]);
+    expect(searchedColumns).not.toContain("email");
+  });
+
+  it("trims the search term and ignores a whitespace-only search", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    await GET(
+      new Request("http://localhost:3000/api/users?search=%20%20") as any,
+    );
+
+    const [{ where }] = (prisma.user.findMany as any).mock.calls[0];
+    expect(where).not.toHaveProperty("AND");
+
+    (prisma.user.findMany as any).mockClear();
+
+    await GET(
+      new Request("http://localhost:3000/api/users?search=%20goa%20") as any,
+    );
+
+    const [{ where: trimmedWhere }] = (prisma.user.findMany as any).mock.calls[0];
+    expect(trimmedWhere.AND[0].OR[0]).toEqual({
+      name: { contains: "goa", mode: "insensitive" },
+    });
+  });
+
+  it("rejects an over-long search term with 400", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    const response = await GET(
+      new Request(
+        `http://localhost:3000/api/users?search=${"a".repeat(101)}`,
+      ) as any,
+    );
+
+    expect(response.status).toBe(400);
+    expect(prisma.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it("excludes users on either side of a block", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    const { getBlockedUserIds } = await getBlocking();
+    (getBlockedUserIds as any).mockResolvedValue(["blocked-by-me", "blocked-me"]);
+
+    await GET(new Request("http://localhost:3000/api/users") as any);
+
+    expect(getBlockedUserIds).toHaveBeenCalledWith("test-user-id");
+    expect(prisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { notIn: ["test-user-id", "blocked-by-me", "blocked-me"] },
+        }),
+      }),
+    );
+  });
+
+  it("keeps the block filter alongside a search term", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    const { getBlockedUserIds } = await getBlocking();
+    (getBlockedUserIds as any).mockResolvedValue(["blocked-user"]);
+
+    await GET(
+      new Request("http://localhost:3000/api/users?search=goa") as any,
+    );
+
+    const [{ where }] = (prisma.user.findMany as any).mock.calls[0];
+
+    expect(where.id).toEqual({ notIn: ["test-user-id", "blocked-user"] });
+    expect(where.AND[0].OR).toHaveLength(2);
+  });
+
   it("should enforce maximum limit of 100", async () => {
-    const prisma = (await import("@/lib/prisma")).default;
+    const prisma = await getPrisma();
     (prisma.user.findMany as any).mockResolvedValue([]);
 
     const request = new Request("http://localhost:3000/api/users?limit=200");
     const response = await GET(request as any);
 
     expect(response.status).toBe(200);
+    expect(prisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 101 }),
+    );
   });
 
   it("should return null nextCursor at end of results", async () => {
-    const mockUsers = [{ id: "1", name: "User 1", email: "user1@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-01") }];
-    const prisma = (await import("@/lib/prisma")).default;
-    (prisma.user.findMany as any).mockResolvedValue(mockUsers);
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([userRow("1")]);
 
     const request = new Request("http://localhost:3000/api/users?limit=20");
     const response = await GET(request as any);
@@ -139,24 +325,27 @@ describe("GET /api/users", () => {
 
     expect(response.status).toBe(200);
     expect(data.nextCursor).toBeNull();
+    expect(data.hasMore).toBe(false);
   });
 
   it("should ensure no duplicate records between pages with stable ordering", async () => {
     const firstPageUsers = [
-      { id: "1", name: "User 1", email: "user1@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-03") },
-      { id: "2", name: "User 2", email: "user2@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-02") },
+      userRow("1", { createdAt: new Date("2024-01-03") }),
+      userRow("2", { createdAt: new Date("2024-01-02") }),
     ];
-    const secondPageUsers = [{ id: "3", name: "User 3", email: "user3@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-01") }];
-    const prisma = (await import("@/lib/prisma")).default;
+    const secondPageUsers = [userRow("3", { createdAt: new Date("2024-01-01") })];
+    const prisma = await getPrisma();
 
     (prisma.user.findMany as any).mockResolvedValue(firstPageUsers);
-    const firstRequest = new Request("http://localhost:3000/api/users?limit=2");
-    const firstResponse = await GET(firstRequest as any);
+    const firstResponse = await GET(
+      new Request("http://localhost:3000/api/users?limit=2") as any,
+    );
     const firstData = await firstResponse.json();
 
     (prisma.user.findMany as any).mockResolvedValue(secondPageUsers);
-    const secondRequest = new Request("http://localhost:3000/api/users?limit=2&cursor=next-cursor");
-    const secondResponse = await GET(secondRequest as any);
+    const secondResponse = await GET(
+      new Request("http://localhost:3000/api/users?limit=2&cursor=next-cursor") as any,
+    );
     const secondData = await secondResponse.json();
 
     const firstPageIds = firstData.users.map((u: any) => u.id);
@@ -176,21 +365,54 @@ describe("GET /api/users", () => {
     const response = await GET(request as any);
 
     expect(response.status).toBe(401);
+  });
 
-    (auth as any).mockResolvedValue({ user: { id: "test-user-id", email: "test@example.com", name: "Test User" } });
+  it("does not resolve the block set for an unauthenticated caller", async () => {
+    const { auth } = await import("@/lib/auth");
+    (auth as any).mockResolvedValue(null);
+
+    const { getBlockedUserIds } = await getBlocking();
+
+    await GET(new Request("http://localhost:3000/api/users") as any);
+
+    expect(getBlockedUserIds).not.toHaveBeenCalled();
   });
 
   it("should exclude current user from results", async () => {
-    const mockUsers = [{ id: "1", name: "User 1", email: "user1@example.com", image: null, bio: null, location: null, createdAt: new Date("2024-01-01") }];
-    const prisma = (await import("@/lib/prisma")).default;
-    (prisma.user.findMany as any).mockResolvedValue(mockUsers);
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([userRow("1")]);
 
-    const request = new Request("http://localhost:3000/api/users?limit=20");
-    const response = await GET(request as any);
+    const response = await GET(
+      new Request("http://localhost:3000/api/users?limit=20") as any,
+    );
 
     expect(response.status).toBe(200);
     expect(prisma.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({ id: { not: "test-user-id" } }),
+      where: expect.objectContaining({ id: { notIn: ["test-user-id"] } }),
     }));
+  });
+
+  it("excludes soft-deleted accounts", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockResolvedValue([]);
+
+    await GET(new Request("http://localhost:3000/api/users") as any);
+
+    expect(prisma.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ isDeleted: false }),
+      }),
+    );
+  });
+
+  it("returns 500 when the query fails", async () => {
+    const prisma = await getPrisma();
+    (prisma.user.findMany as any).mockRejectedValue(new Error("db down"));
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users") as any,
+    );
+
+    expect(response.status).toBe(500);
   });
 });

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import { NextRequest } from "next/server";
 
 import {
@@ -6,6 +7,7 @@ import {
 } from "@/lib/api-error";
 import { apiError, apiJson } from "@/lib/api-response";
 import { auth } from "@/lib/auth";
+import { getBlockedUserIds } from "@/lib/blocking";
 import {
   buildTimestampCursorWhere,
   createPaginatedResponse,
@@ -14,6 +16,48 @@ import {
 } from "@/lib/pagination";
 import prisma from "@/lib/prisma";
 import { getRequestId } from "@/lib/request-id";
+
+/**
+ * Fields a caller may see about somebody they have no relationship with.
+ *
+ * Deliberately mirrors the projection used by `/api/conversations` and
+ * `/api/connections`: id, display name, avatar, bio, location. `email` is not
+ * on the list — no screen in the product shows another user's address, and
+ * returning it here made the endpoint an address-book dump for anyone with a
+ * session.
+ */
+const PUBLIC_USER_SELECT = {
+  id: true,
+  name: true,
+  image: true,
+  bio: true,
+  location: true,
+  createdAt: true,
+} satisfies Prisma.UserSelect;
+
+/**
+ * Longest search term we will run a `contains` scan for. Anything past this is
+ * not a realistic name or place and only costs the database a wider scan.
+ */
+const MAX_SEARCH_LENGTH = 100;
+
+/**
+ * Columns the search term is matched against.
+ *
+ * `email` used to be in here, which meant `?search=@gmail.com` was a working
+ * account-harvesting query and `?search=someone@example.com` was a yes/no
+ * oracle for whether an address had signed up. Search is for finding a
+ * traveller by who they are and where they are, so name and location are the
+ * only sensible columns.
+ */
+function buildSearchFilter(
+  term: string,
+): Prisma.UserWhereInput[] {
+  return [
+    { name: { contains: term, mode: "insensitive" } },
+    { location: { contains: term, mode: "insensitive" } },
+  ];
+}
 
 export async function GET(request: NextRequest) {
   const requestId = getRequestId(request);
@@ -28,11 +72,27 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const currentUserId = session.user.id;
+
   try {
     const url = new URL(request.url);
-    const search = url.searchParams.get("search") || undefined;
+    const rawSearch = url.searchParams.get("search");
+    const search = rawSearch?.trim() || undefined;
 
-    let limit, cursor;
+    if (search && search.length > MAX_SEARCH_LENGTH) {
+      return apiError(
+        requestId,
+        API_ERROR_CODES.VALIDATION_ERROR,
+        `Search term is too long (max ${MAX_SEARCH_LENGTH} characters)`,
+        400,
+      );
+    }
+
+    let limit: number;
+    let cursor: ReturnType<
+      typeof parsePaginationParams
+    >["cursor"];
+
     try {
       const params = parsePaginationParams(
         url.searchParams,
@@ -56,48 +116,41 @@ export async function GET(request: NextRequest) {
       cursor,
     );
 
-    const whereClause: any = {
-      isDeleted: false,
-      id: {
-        not: session.user.id,
-      },
-      ...(cursorWhere ?? {}),
-    };
+    // Blocking is symmetric (see src/lib/blocking.ts), so this one query
+    // removes both the people the caller blocked and the people who blocked
+    // them. `/api/conversations` already filters its list the same way; search
+    // was the remaining place a blocked user could still surface.
+    const blockedUserIds =
+      await getBlockedUserIds(currentUserId);
+
+    const excludedIds = [
+      currentUserId,
+      ...blockedUserIds,
+    ];
+
+    // Both the cursor and the search term are expressed as `OR` groups, so
+    // spreading them into the same object made the second one overwrite the
+    // first: `?search=x&cursor=y` silently dropped the cursor and served page
+    // one forever. Nesting them under `AND` keeps both.
+    const filters: Prisma.UserWhereInput[] = [];
+
+    if (cursorWhere) {
+      filters.push(cursorWhere as Prisma.UserWhereInput);
+    }
 
     if (search) {
-      whereClause.OR = [
-        {
-          name: {
-            contains: search,
-            mode: "insensitive",
-          },
-        },
-        {
-          email: {
-            contains: search,
-            mode: "insensitive",
-          },
-        },
-        {
-          location: {
-            contains: search,
-            mode: "insensitive",
-          },
-        },
-      ];
+      filters.push({ OR: buildSearchFilter(search) });
     }
+
+    const whereClause: Prisma.UserWhereInput = {
+      isDeleted: false,
+      id: { notIn: excludedIds },
+      ...(filters.length > 0 ? { AND: filters } : {}),
+    };
 
     const users = await prisma.user.findMany({
       where: whereClause,
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        image: true,
-        bio: true,
-        location: true,
-        createdAt: true,
-      },
+      select: PUBLIC_USER_SELECT,
       orderBy: [
         { createdAt: "desc" },
         { id: "desc" },
@@ -114,7 +167,9 @@ export async function GET(request: NextRequest) {
     return apiJson(
       {
         users: paginatedResponse.items,
-        nextCursor: paginatedResponse.pagination.nextCursor,
+        nextCursor:
+          paginatedResponse.pagination.nextCursor,
+        hasMore: paginatedResponse.pagination.hasMore,
       },
       requestId,
     );


### PR DESCRIPTION
Closes #380

## The problem

`GET /api/users` selected `email` into every result and matched the `?search=` term against the email column:

```ts
whereClause.OR = [
  { name:     { contains: search, mode: "insensitive" } },
  { email:    { contains: search, mode: "insensitive" } },
  { location: { contains: search, mode: "insensitive" } },
];

const users = await prisma.user.findMany({
  where: whereClause,
  select: { id: true, name: true, email: true, ... },
});
```

Two separate problems in one query:

1. Any authenticated caller could walk the cursor with `limit=100` and dump the whole user table's email addresses. No screen in the product shows another user's email — `/api/conversations`, `/api/connections` and `/api/matches` all select `id/name/image/bio/location`.
2. `email contains <term>` is an enumeration oracle. `?search=@gmail.com` harvests by domain; `?search=someone@example.com` answers whether that address has an account.

## What this changes

**The leak.** `email` is out of the projection and out of the search predicate. Search matches `name` and `location` — what you'd actually use to find a travel companion.

**Blocked users.** Search never consulted `src/lib/blocking.ts`. Blocking is symmetric, and `/api/conversations` already filters with `getBlockedUserIds()`; user search was the remaining place a blocked user could still surface. Same helper, one query, applied to the exclusion list.

**A pagination bug found while writing the tests.** The cursor filter and the search filter were both spread into the `where` object as `OR`, so the search clause overwrote the cursor clause:

```ts
const whereClause: any = {
  ...(cursorWhere ?? {}),   // { OR: [...cursor...] }
};
if (search) {
  whereClause.OR = [...];  // silently replaces it
}
```

`?search=goa&cursor=<next>` therefore returned page one forever. Both groups now sit under `AND`.

**Typing.** `whereClause` was `any`, which is what let the `email` predicate through unnoticed. It's `Prisma.UserWhereInput` now.

**Input handling.** `search` is trimmed, a whitespace-only term is ignored rather than running a `contains ""` scan, and terms over 100 characters get a 400. `hasMore` is returned alongside `nextCursor`.

## Tests

The existing file asserted the old behaviour — that `email` *was* selected and *was* searched — so those assertions are inverted. Its `buildTimestampCursorWhere` mock also took the cursor as its first argument while the real signature is `(field, cursor)`, so it was handed the string `"createdAt"`, treated it as a cursor and returned a filter with `Date { NaN }` in it on every call. That's why 3 of the 8 tests in this file fail on `main`. Fixed, so the cursor assertions mean something.

8 tests → 19. Everything the old file covered is still covered.

## Verification

- `npx vitest run src/app/api/users` — 19 passed
- Full suite goes from 9 failing files / 23 failing tests on `main` to 8 / 20 — this branch fixes 3 pre-existing failures and introduces none
- `npx tsc --noEmit` reports nothing new for this path (the remaining errors are the base-branch breakage tracked in #366 / #379)

## Note on the base branch

`main` does not currently typecheck — five auth routes have a duplicate `rateLimit` declaration (#366, fixed by #379). Nothing in this PR touches those files, so it should rebase cleanly once #379 lands.
