### PR TITLE
fix(notifications): paginate the list and give it a way to be cleared

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -304,6 +304,78 @@ channel and to each participant's personal channel.
 List the caller's conversations, most recently updated first, each with the
 other participant and the latest message for the sidebar.
 
+## Notification endpoints
+
+### `GET /api/notifications`
+
+Return one page of the caller's notifications, newest first.
+
+Query parameters:
+
+| Name | Default | Notes |
+| --- | --- | --- |
+| `limit` | `20` | Capped at `100`. |
+| `cursor` | — | Opaque cursor from a previous `pagination.nextCursor`. |
+| `unreadOnly` | `false` | `true` returns only unread notifications. |
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "id": "ntf-3",
+      "title": "New connection request",
+      "content": "Asha wants to connect",
+      "link": "/dashboard/connections",
+      "read": false,
+      "createdAt": "2026-08-10T09:15:00.000Z"
+    }
+  ],
+  "pagination": {
+    "limit": 20,
+    "nextCursor": "eyJ2ZXJzaW9uIjoxLCJ0aW1lc3RhbXAiOiIuLi4iLCJpZCI6Im50Zi0yIn0",
+    "hasMore": true
+  },
+  "notifications": [],
+  "unreadCount": 4
+}
+```
+
+`notifications` is an alias for `items`, kept for existing consumers.
+
+Notifications whose `expiresAt` has passed are excluded from both the page and
+`unreadCount`. The cron sweeper at `/api/internal/notifications/cleanup` deletes
+them in batches, so read paths cannot assume it has caught up.
+
+`400` is returned for a malformed `limit` or `cursor`.
+
+### `PATCH /api/notifications`
+
+Mark every unread notification as read.
+
+```json
+{ "ok": true, "updated": 12 }
+```
+
+### `DELETE /api/notifications`
+
+Clear the caller's read notifications. Pass `?all=true` to clear unread ones too.
+
+```json
+{ "ok": true, "deleted": 12 }
+```
+
+### `PATCH /api/notifications/[id]` and `PATCH /api/notifications/[id]/read`
+
+Mark a single notification as read. Both routes are equivalent; the `/read`
+form is the one the notification bell uses.
+
+### `DELETE /api/notifications/[id]`
+
+Dismiss a single notification. Responds `404` when the id does not exist or
+belongs to another user.
+
 ## AI chat endpoint
 
 ### `POST /api/chat`

--- a/src/app/api/notifications/[id]/__tests__/route.test.ts
+++ b/src/app/api/notifications/[id]/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { DELETE } from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    notification: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+function request() {
+  return new NextRequest(
+    "http://localhost/api/notifications/n-1",
+  );
+}
+
+const params = { params: { id: "n-1" } };
+
+describe("DELETE /api/notifications/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.notification.deleteMany).mockResolvedValue({
+      count: 1,
+    } as never);
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await DELETE(request(), params);
+
+    expect(response.status).toBe(401);
+    expect(prisma.notification.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("scopes the delete to the caller", async () => {
+    const response = await DELETE(request(), params);
+
+    expect(prisma.notification.deleteMany).toHaveBeenCalledWith({
+      where: { id: "n-1", userId: "user-1" },
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 404 when the notification belongs to someone else", async () => {
+    // deleteMany with a userId filter removes nothing rather than throwing,
+    // which is exactly what makes it safe against id guessing.
+    vi.mocked(prisma.notification.deleteMany).mockResolvedValue({
+      count: 0,
+    } as never);
+
+    const response = await DELETE(request(), params);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 500 when the delete fails", async () => {
+    vi.mocked(prisma.notification.deleteMany).mockRejectedValue(
+      new Error("db down") as never,
+    );
+
+    const response = await DELETE(request(), params);
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { deleteNotification } from "@/lib/notifications";
 import prisma from "@/lib/prisma";
 
 export async function PATCH(
@@ -48,6 +49,54 @@ export async function PATCH(
 
     return NextResponse.json(
       { error: "Failed to update notification" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/notifications/[id]
+ *
+ * Dismiss a single notification. The list had no removal path at all, so a
+ * notification for a connection request that has since been declined stayed in
+ * the bell forever.
+ *
+ * The delete is scoped by `userId` in the same statement as the id, so a
+ * caller cannot remove somebody else's row by guessing an id — a foreign or
+ * missing id deletes nothing and is reported as 404.
+ */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const deleted = await deleteNotification(
+      params.id,
+      session.user.id
+    );
+
+    if (deleted === 0) {
+      return NextResponse.json(
+        { error: "Notification not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Notification delete error:", error);
+
+    return NextResponse.json(
+      { error: "Failed to delete notification" },
       { status: 500 }
     );
   }

--- a/src/app/api/notifications/__tests__/route.test.ts
+++ b/src/app/api/notifications/__tests__/route.test.ts
@@ -1,0 +1,315 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { DELETE, GET, PATCH } from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    notification: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      updateMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+function request(query = "") {
+  return new NextRequest(
+    `http://localhost/api/notifications${query}`,
+  );
+}
+
+function notificationRow(
+  id: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    userId: "user-1",
+    type: "MESSAGE",
+    title: `Notification ${id}`,
+    content: "body",
+    link: null,
+    read: false,
+    dedupeKey: null,
+    expiresAt: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("GET /api/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.notification.findMany).mockResolvedValue(
+      [] as never,
+    );
+    vi.mocked(prisma.notification.count).mockResolvedValue(
+      0 as never,
+    );
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(401);
+    expect(prisma.notification.findMany).not.toHaveBeenCalled();
+  });
+
+  it("bounds the query instead of fetching every row", async () => {
+    await GET(request());
+
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // Default page of 20, plus the lookahead row used to decide hasMore.
+        take: 21,
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      }),
+    );
+  });
+
+  it("caps the page size at 100", async () => {
+    await GET(request("?limit=500"));
+
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 101 }),
+    );
+  });
+
+  it("excludes notifications whose expiry has passed", async () => {
+    await GET(request());
+
+    const [{ where }] = vi.mocked(
+      prisma.notification.findMany,
+    ).mock.calls[0] as [{ where: any }];
+
+    const expiryClause = where.AND.find(
+      (clause: any) => clause.OR,
+    );
+
+    expect(expiryClause.OR[0]).toEqual({ expiresAt: null });
+    expect(expiryClause.OR[1].expiresAt.gt).toBeInstanceOf(Date);
+  });
+
+  it("applies the same expiry rule to the unread badge", async () => {
+    await GET(request());
+
+    const [{ where }] = vi.mocked(prisma.notification.count).mock
+      .calls[0] as [{ where: any }];
+
+    expect(where.read).toBe(false);
+    expect(where.OR[0]).toEqual({ expiresAt: null });
+  });
+
+  it("uses one clock reading for the page and the badge", async () => {
+    await GET(request());
+
+    const [{ where: listWhere }] = vi.mocked(
+      prisma.notification.findMany,
+    ).mock.calls[0] as [{ where: any }];
+    const [{ where: countWhere }] = vi.mocked(
+      prisma.notification.count,
+    ).mock.calls[0] as [{ where: any }];
+
+    const listNow = listWhere.AND.find((c: any) => c.OR).OR[1]
+      .expiresAt.gt;
+    const countNow = countWhere.OR[1].expiresAt.gt;
+
+    expect(listNow.getTime()).toBe(countNow.getTime());
+  });
+
+  it("filters to unread when unreadOnly=true", async () => {
+    await GET(request("?unreadOnly=true"));
+
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ read: false }),
+      }),
+    );
+  });
+
+  it("does not filter to unread by default", async () => {
+    await GET(request());
+
+    const [{ where }] = vi.mocked(
+      prisma.notification.findMany,
+    ).mock.calls[0] as [{ where: any }];
+
+    expect(where).not.toHaveProperty("read");
+  });
+
+  it("returns a cursor when more rows exist", async () => {
+    const rows = Array.from({ length: 3 }, (_, index) =>
+      notificationRow(`n-${index}`, {
+        createdAt: new Date(
+          `2026-01-0${index + 1}T00:00:00.000Z`,
+        ),
+      }),
+    );
+
+    vi.mocked(prisma.notification.findMany).mockResolvedValue(
+      rows as never,
+    );
+
+    const response = await GET(request("?limit=2"));
+    const body = await response.json();
+
+    expect(body.notifications).toHaveLength(2);
+    expect(body.pagination.hasMore).toBe(true);
+    expect(body.pagination.nextCursor).toBeTruthy();
+  });
+
+  it("returns a null cursor on the last page", async () => {
+    vi.mocked(prisma.notification.findMany).mockResolvedValue([
+      notificationRow("n-1"),
+    ] as never);
+
+    const response = await GET(request("?limit=20"));
+    const body = await response.json();
+
+    expect(body.pagination.hasMore).toBe(false);
+    expect(body.pagination.nextCursor).toBeNull();
+  });
+
+  it("keeps the legacy notifications key alongside items", async () => {
+    vi.mocked(prisma.notification.findMany).mockResolvedValue([
+      notificationRow("n-1"),
+    ] as never);
+    vi.mocked(prisma.notification.count).mockResolvedValue(
+      4 as never,
+    );
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(body.notifications).toHaveLength(1);
+    expect(body.items).toHaveLength(1);
+    expect(body.unreadCount).toBe(4);
+  });
+
+  it("returns 400 for a malformed limit", async () => {
+    const response = await GET(request("?limit=abc"));
+
+    expect(response.status).toBe(400);
+    expect(prisma.notification.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a malformed cursor", async () => {
+    const response = await GET(request("?cursor=not-a-cursor"));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 500 when the query fails", async () => {
+    vi.mocked(prisma.notification.findMany).mockRejectedValue(
+      new Error("db down") as never,
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("PATCH /api/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.notification.updateMany).mockResolvedValue({
+      count: 3,
+    } as never);
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await PATCH();
+
+    expect(response.status).toBe(401);
+    expect(prisma.notification.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("marks only the caller's unread notifications", async () => {
+    const response = await PATCH();
+    const body = await response.json();
+
+    expect(prisma.notification.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", read: false },
+      data: { read: true },
+    });
+    expect(body).toEqual({ ok: true, updated: 3 });
+  });
+
+  it("returns 500 when the update fails", async () => {
+    vi.mocked(prisma.notification.updateMany).mockRejectedValue(
+      new Error("db down") as never,
+    );
+
+    const response = await PATCH();
+
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("DELETE /api/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    vi.mocked(prisma.notification.deleteMany).mockResolvedValue({
+      count: 2,
+    } as never);
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await DELETE(request());
+
+    expect(response.status).toBe(401);
+    expect(prisma.notification.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("clears only the read notifications by default", async () => {
+    const response = await DELETE(request());
+    const body = await response.json();
+
+    expect(prisma.notification.deleteMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", read: true },
+    });
+    expect(body).toEqual({ ok: true, deleted: 2 });
+  });
+
+  it("clears everything with ?all=true", async () => {
+    await DELETE(request("?all=true"));
+
+    expect(prisma.notification.deleteMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+    });
+  });
+
+  it("returns 500 when the delete fails", async () => {
+    vi.mocked(prisma.notification.deleteMany).mockRejectedValue(
+      new Error("db down") as never,
+    );
+
+    const response = await DELETE(request());
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,45 +1,178 @@
-import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
-import prisma from "@/lib/prisma";
+import { NextResponse, type NextRequest } from "next/server";
 
-export async function GET() {
+import { auth } from "@/lib/auth";
+import {
+  deleteNotificationsForUser,
+  getUnreadNotificationCount,
+  listNotifications,
+  markAllNotificationsAsRead,
+} from "@/lib/notifications";
+import {
+  buildTimestampCursorWhere,
+  createPaginatedResponse,
+  PaginationError,
+  parsePaginationParams,
+} from "@/lib/pagination";
+
+/**
+ * GET /api/notifications
+ *
+ * One page of the caller's notifications, newest first.
+ *
+ * This used to be a single unbounded `findMany`: every notification the user
+ * had ever received was serialised on every page load, to render a dropdown
+ * that shows about six of them. It now uses the same cursor helpers as
+ * /api/messages, /api/routes and /api/tickets.
+ *
+ * Query parameters:
+ *   limit       page size, default 20, capped at 100
+ *   cursor      opaque cursor from a previous `pagination.nextCursor`
+ *   unreadOnly  "true" to return only unread notifications
+ */
+export async function GET(request: NextRequest) {
   const session = await auth();
 
   if (!session?.user?.id) {
     return NextResponse.json(
       { error: "Unauthorized" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
+  const userId = session.user.id;
+
   try {
-    const [notifications, unreadCount] = await Promise.all([
-      prisma.notification.findMany({
-        where: {
-          userId: session.user.id,
-        },
-        orderBy: {
-          createdAt: "desc",
-        },
+    const searchParams = new URL(request.url).searchParams;
+    const { limit, cursor } =
+      parsePaginationParams(searchParams);
+    const cursorWhere = buildTimestampCursorWhere(
+      "createdAt",
+      cursor,
+    );
+    const unreadOnly =
+      searchParams.get("unreadOnly") === "true";
+
+    // One clock reading for both queries, so the page and the badge cannot
+    // disagree about whether a notification expiring right now still counts.
+    const now = new Date();
+
+    const [records, unreadCount] = await Promise.all([
+      listNotifications({
+        userId,
+        limit,
+        cursorWhere,
+        unreadOnly,
+        now,
       }),
-      prisma.notification.count({
-        where: {
-          userId: session.user.id,
-          read: false,
-        },
-      }),
+      getUnreadNotificationCount(userId, now),
     ]);
 
+    const result = createPaginatedResponse(
+      records,
+      limit,
+      "createdAt",
+    );
+
     return NextResponse.json({
-      notifications,
+      ...result,
+      // Alias retained for existing consumers of this endpoint.
+      notifications: result.items,
       unreadCount,
     });
   } catch (error) {
+    if (error instanceof PaginationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 },
+      );
+    }
+
     console.error("Notification fetch error:", error);
 
     return NextResponse.json(
       { error: "Failed to fetch notifications" },
-      { status: 500 }
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * PATCH /api/notifications
+ *
+ * Mark every unread notification as read.
+ *
+ * `markAllNotificationsAsRead` has been sitting in src/lib/notifications.ts
+ * with no caller — the helper was written but never given a route, so the only
+ * way to clear a long list was to click each row.
+ */
+export async function PATCH() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const result = await markAllNotificationsAsRead(
+      session.user.id,
+    );
+
+    return NextResponse.json({
+      ok: true,
+      updated: result.count,
+    });
+  } catch (error) {
+    console.error(
+      "Mark all notifications read error:",
+      error,
+    );
+
+    return NextResponse.json(
+      { error: "Failed to update notifications" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/notifications
+ *
+ * Clears the caller's read notifications. Pass `?all=true` to clear the
+ * unread ones too.
+ */
+export async function DELETE(request: NextRequest) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const clearAll =
+      new URL(request.url).searchParams.get("all") ===
+      "true";
+
+    const deleted = await deleteNotificationsForUser(
+      session.user.id,
+      { onlyRead: !clearAll },
+    );
+
+    return NextResponse.json({ ok: true, deleted });
+  } catch (error) {
+    console.error(
+      "Clear notifications error:",
+      error,
+    );
+
+    return NextResponse.json(
+      { error: "Failed to clear notifications" },
+      { status: 500 },
     );
   }
 }

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Bell } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Bell, CheckCheck, Loader2, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 type Notification = {
@@ -12,140 +12,295 @@ type Notification = {
   link: string | null;
 };
 
+type NotificationPage = {
+  notifications: Notification[];
+  unreadCount: number;
+  pagination?: {
+    nextCursor: string | null;
+    hasMore: boolean;
+  };
+};
+
+const PAGE_SIZE = 20;
+
 export default function NotificationBell() {
-    const [notifications, setNotifications] = useState<Notification[]>([]);
-    const [unreadCount, setUnreadCount] = useState(0);
-    const [loading, setLoading] = useState(true);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
 
-    const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(false);
 
-    const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-    const router = useRouter();
+  const router = useRouter();
 
-  useEffect(() => {
-    async function loadNotifications() {
-      try {
-        const res = await fetch("/api/notifications");
+  /**
+   * Fetch one page. `cursor` is the opaque marker the API returned with the
+   * previous page; without it this is the first page and replaces the list.
+   */
+  const loadPage = useCallback(async (cursor?: string) => {
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+    });
 
-        if (!res.ok) return;
-
-        const data = await res.json();
-
-        setNotifications(data.notifications);
-        setUnreadCount(data.unreadCount);
-      } catch (err) {
-        console.error(err);
-      }
+    if (cursor) {
+      params.set("cursor", cursor);
     }
 
-    loadNotifications();
+    const res = await fetch(`/api/notifications?${params}`);
+
+    if (!res.ok) {
+      throw new Error("Failed to load notifications");
+    }
+
+    const data: NotificationPage = await res.json();
+
+    setNotifications((prev) =>
+      cursor ? [...prev, ...data.notifications] : data.notifications,
+    );
+    setUnreadCount(data.unreadCount);
+    setNextCursor(data.pagination?.nextCursor ?? null);
   }, []);
 
   useEffect(() => {
-  function handleClickOutside(event: MouseEvent) {
-    if (
-      dropdownRef.current &&
-      !dropdownRef.current.contains(event.target as Node)
-    ) {
-      setOpen(false);
+    let cancelled = false;
+
+    async function loadFirstPage() {
+      try {
+        await loadPage();
+      } catch (err) {
+        if (!cancelled) {
+          console.error(err);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadFirstPage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadPage]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  async function loadMore() {
+    if (!nextCursor || loadingMore) return;
+
+    setLoadingMore(true);
+
+    try {
+      await loadPage(nextCursor);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoadingMore(false);
     }
   }
 
-  document.addEventListener("mousedown", handleClickOutside);
+  async function markAllRead() {
+    // Optimistic: flipping every row locally is cheap and the failure path
+    // just refetches the first page to get back in sync.
+    const previous = notifications;
+    const previousUnread = unreadCount;
 
-  return () => {
-    document.removeEventListener("mousedown", handleClickOutside);
-  };
-}, []);
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    setUnreadCount(0);
 
-   return (
-  <div className="relative" ref={dropdownRef}>
-    <button
-      onClick={() => setOpen((prev) => !prev)}
-      className="relative rounded-full p-2 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
-    >
-      <Bell size={20} />
+    try {
+      const res = await fetch("/api/notifications", { method: "PATCH" });
 
-      {unreadCount > 0 && (
-        <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] rounded-full bg-red-500 text-white text-[10px] flex items-center justify-center font-bold">
-          {unreadCount}
-        </span>
-      )}
-    </button>
+      if (!res.ok) {
+        throw new Error("Failed to mark notifications read");
+      }
+    } catch (err) {
+      console.error(err);
+      setNotifications(previous);
+      setUnreadCount(previousUnread);
+    }
+  }
 
-    {open && (
-      <div className="absolute right-0 mt-2 w-96 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-xl z-50 overflow-hidden">
-        <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700">
-          <h3 className="font-semibold text-slate-900 dark:text-white">
-            Notifications
-          </h3>
-        </div>
+  async function dismiss(id: string) {
+    const removed = notifications.find((n) => n.id === id);
 
-        <div className="max-h-96 overflow-y-auto">
-          {notifications.length === 0 ? (
-            <div className="p-6 text-center text-sm text-slate-500">
-              No notifications yet.
-            </div>
-          ) : (
-            notifications.map((notification) => (
+    if (!removed) return;
+
+    const previous = notifications;
+    const previousUnread = unreadCount;
+
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+
+    if (!removed.read) {
+      setUnreadCount((prev) => Math.max(prev - 1, 0));
+    }
+
+    try {
+      const res = await fetch(`/api/notifications/${id}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to dismiss notification");
+      }
+    } catch (err) {
+      console.error(err);
+      setNotifications(previous);
+      setUnreadCount(previousUnread);
+    }
+  }
+
+  async function openNotification(notification: Notification) {
+    try {
+      await fetch(`/api/notifications/${notification.id}/read`, {
+        method: "PATCH",
+      });
+
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n.id === notification.id ? { ...n, read: true } : n,
+        ),
+      );
+
+      setUnreadCount((prev) =>
+        notification.read ? prev : Math.max(prev - 1, 0),
+      );
+
+      setOpen(false);
+
+      if (notification.link) {
+        router.push(notification.link);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label="Notifications"
+        className="relative rounded-full p-2 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+      >
+        <Bell size={20} />
+
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] rounded-full bg-red-500 text-white text-[10px] flex items-center justify-center font-bold">
+            {unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-96 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-xl z-50 overflow-hidden">
+          <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-700">
+            <h3 className="font-semibold text-slate-900 dark:text-white">
+              Notifications
+            </h3>
+
+            {unreadCount > 0 && (
               <button
-                key={notification.id}
-                onClick={async () => {
-                  try {
-                    await fetch(
-                      `/api/notifications/${notification.id}/read`,
-                      {
-                        method: "PATCH",
-                      }
-                    );
-
-                    setNotifications((prev) =>
-                      prev.map((n) =>
-                        n.id === notification.id
-                          ? { ...n, read: true }
-                          : n
-                      )
-                    );
-
-                    setUnreadCount((prev) =>
-                      notification.read ? prev : Math.max(prev - 1, 0)
-                    );
-
-                    setOpen(false);
-
-                    if (notification.link) {
-                      router.push(notification.link);
-                    }
-                  } catch (err) {
-                    console.error(err);
-                  }
-                }}
-                className={`w-full text-left px-4 py-3 border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800 transition ${
-                  notification.read
-                    ? ""
-                    : "bg-blue-50 dark:bg-slate-800"
-                }`}
+                type="button"
+                onClick={markAllRead}
+                className="flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400"
               >
-                <div className="font-medium text-slate-900 dark:text-white">
-                  {notification.title}
-                </div>
-
-                <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">
-                  {notification.content}
-                </p>
-
-                {!notification.read && (
-                  <span className="inline-block mt-2 text-xs text-blue-600 font-semibold">
-                    New
-                  </span>
-                )}
+                <CheckCheck className="h-3.5 w-3.5" />
+                Mark all read
               </button>
-            ))
-          )}
+            )}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto">
+            {loading ? (
+              <div className="space-y-2 p-4 animate-pulse">
+                <div className="h-12 rounded-lg bg-slate-200 dark:bg-slate-700" />
+                <div className="h-12 rounded-lg bg-slate-200 dark:bg-slate-700" />
+                <div className="h-12 rounded-lg bg-slate-200 dark:bg-slate-700" />
+              </div>
+            ) : notifications.length === 0 ? (
+              <div className="p-6 text-center text-sm text-slate-500">
+                No notifications yet.
+              </div>
+            ) : (
+              <>
+                {notifications.map((notification) => (
+                  <div
+                    key={notification.id}
+                    className={`flex items-start gap-2 border-b border-slate-100 dark:border-slate-800 transition ${
+                      notification.read
+                        ? ""
+                        : "bg-blue-50 dark:bg-slate-800"
+                    }`}
+                  >
+                    <button
+                      onClick={() => openNotification(notification)}
+                      className="flex-1 text-left px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800"
+                    >
+                      <div className="font-medium text-slate-900 dark:text-white">
+                        {notification.title}
+                      </div>
+
+                      <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">
+                        {notification.content}
+                      </p>
+
+                      {!notification.read && (
+                        <span className="inline-block mt-2 text-xs text-blue-600 font-semibold">
+                          New
+                        </span>
+                      )}
+                    </button>
+
+                    <button
+                      type="button"
+                      aria-label={`Dismiss ${notification.title}`}
+                      onClick={() => dismiss(notification.id)}
+                      className="mr-2 mt-3 rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                ))}
+
+                {nextCursor && (
+                  <button
+                    type="button"
+                    onClick={loadMore}
+                    disabled={loadingMore}
+                    className="flex w-full items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-blue-600 hover:bg-slate-50 disabled:opacity-60 dark:text-blue-400 dark:hover:bg-slate-800"
+                  >
+                    {loadingMore && (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
+                    {loadingMore ? "Loading..." : "Load more"}
+                  </button>
+                )}
+              </>
+            )}
+          </div>
         </div>
-      </div>
-    )}
-  </div>
-);
+      )}
+    </div>
+  );
 }

--- a/src/lib/__tests__/notification-list.test.ts
+++ b/src/lib/__tests__/notification-list.test.ts
@@ -1,0 +1,261 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  activeNotificationWhere,
+  deleteNotification,
+  deleteNotificationsForUser,
+  getUnreadNotificationCount,
+  listNotifications,
+  markAllNotificationsAsRead,
+} from "@/lib/notifications";
+import prisma from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    notification: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      updateMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+const NOW = new Date("2026-08-10T12:00:00.000Z");
+
+describe("activeNotificationWhere", () => {
+  it("matches rows with no expiry and rows expiring in the future", () => {
+    expect(activeNotificationWhere(NOW)).toEqual({
+      OR: [
+        { expiresAt: null },
+        { expiresAt: { gt: NOW } },
+      ],
+    });
+  });
+
+  it("uses a strict comparison so a row expiring exactly now is excluded", () => {
+    // cleanupExpiredNotifications deletes with `lte: now`. Using `gt` here
+    // means the two rules partition the table rather than overlapping — a row
+    // is either sweepable or visible, never both and never neither.
+    const where = activeNotificationWhere(NOW);
+    const expiryClause = where.OR[1] as {
+      expiresAt: { gt: Date };
+    };
+
+    expect(expiryClause.expiresAt).toHaveProperty("gt");
+    expect(expiryClause.expiresAt).not.toHaveProperty("gte");
+  });
+});
+
+describe("listNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.notification.findMany).mockResolvedValue(
+      [] as never,
+    );
+  });
+
+  it("takes one row beyond the page size so hasMore can be computed", async () => {
+    await listNotifications({
+      userId: "user-1",
+      limit: 20,
+      now: NOW,
+    });
+
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 21 }),
+    );
+  });
+
+  it("orders newest first with a stable id tiebreaker", async () => {
+    await listNotifications({
+      userId: "user-1",
+      limit: 5,
+      now: NOW,
+    });
+
+    expect(prisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      }),
+    );
+  });
+
+  it("always filters out expired rows", async () => {
+    await listNotifications({
+      userId: "user-1",
+      limit: 5,
+      now: NOW,
+    });
+
+    const [{ where }] = vi.mocked(
+      prisma.notification.findMany,
+    ).mock.calls[0] as [{ where: any }];
+
+    expect(where.userId).toBe("user-1");
+    expect(where.AND).toContainEqual(
+      activeNotificationWhere(NOW),
+    );
+  });
+
+  it("nests the cursor filter alongside the expiry filter", async () => {
+    const cursorWhere = {
+      OR: [
+        { createdAt: { lt: NOW } },
+        { createdAt: NOW, id: { lt: "n-9" } },
+      ],
+    };
+
+    await listNotifications({
+      userId: "user-1",
+      limit: 5,
+      cursorWhere,
+      now: NOW,
+    });
+
+    const [{ where }] = vi.mocked(
+      prisma.notification.findMany,
+    ).mock.calls[0] as [{ where: any }];
+
+    // Both are OR groups. Spreading them into one object would make the
+    // second silently replace the first, so they live under AND.
+    expect(where.AND).toHaveLength(2);
+    expect(where.AND[1]).toEqual(cursorWhere);
+  });
+
+  it("omits the read filter unless unreadOnly is set", async () => {
+    await listNotifications({
+      userId: "user-1",
+      limit: 5,
+      now: NOW,
+    });
+
+    const [{ where }] = vi.mocked(
+      prisma.notification.findMany,
+    ).mock.calls[0] as [{ where: any }];
+
+    expect(where).not.toHaveProperty("read");
+  });
+
+  it("filters to unread when asked", async () => {
+    await listNotifications({
+      userId: "user-1",
+      limit: 5,
+      unreadOnly: true,
+      now: NOW,
+    });
+
+    const [{ where }] = vi.mocked(
+      prisma.notification.findMany,
+    ).mock.calls[0] as [{ where: any }];
+
+    expect(where.read).toBe(false);
+  });
+});
+
+describe("getUnreadNotificationCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.notification.count).mockResolvedValue(
+      7 as never,
+    );
+  });
+
+  it("does not count expired notifications", async () => {
+    const count = await getUnreadNotificationCount(
+      "user-1",
+      NOW,
+    );
+
+    expect(count).toBe(7);
+    expect(prisma.notification.count).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        read: false,
+        ...activeNotificationWhere(NOW),
+      },
+    });
+  });
+});
+
+describe("markAllNotificationsAsRead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.notification.updateMany).mockResolvedValue({
+      count: 2,
+    } as never);
+  });
+
+  it("only touches the caller's unread rows", async () => {
+    await markAllNotificationsAsRead("user-1");
+
+    expect(prisma.notification.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", read: false },
+      data: { read: true },
+    });
+  });
+});
+
+describe("deleteNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scopes the delete to the owner and reports the row count", async () => {
+    vi.mocked(prisma.notification.deleteMany).mockResolvedValue({
+      count: 1,
+    } as never);
+
+    const deleted = await deleteNotification("n-1", "user-1");
+
+    expect(deleted).toBe(1);
+    expect(prisma.notification.deleteMany).toHaveBeenCalledWith({
+      where: { id: "n-1", userId: "user-1" },
+    });
+  });
+
+  it("reports 0 rather than throwing for a foreign id", async () => {
+    vi.mocked(prisma.notification.deleteMany).mockResolvedValue({
+      count: 0,
+    } as never);
+
+    await expect(
+      deleteNotification("someone-elses", "user-1"),
+    ).resolves.toBe(0);
+  });
+});
+
+describe("deleteNotificationsForUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.notification.deleteMany).mockResolvedValue({
+      count: 4,
+    } as never);
+  });
+
+  it("defaults to clearing only the read ones", async () => {
+    const deleted =
+      await deleteNotificationsForUser("user-1");
+
+    expect(deleted).toBe(4);
+    expect(prisma.notification.deleteMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", read: true },
+    });
+  });
+
+  it("clears everything when onlyRead is false", async () => {
+    await deleteNotificationsForUser("user-1", {
+      onlyRead: false,
+    });
+
+    expect(prisma.notification.deleteMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+    });
+  });
+});

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -146,15 +146,78 @@ export async function cleanupExpiredNotifications(
   };
 }
 
+/**
+ * A notification is "active" when it has no expiry, or its expiry is still in
+ * the future.
+ *
+ * `cleanupExpiredNotifications` runs on a cron in batches of at most 500, so
+ * between sweeps there are expired rows still sitting in the table. Read paths
+ * must not depend on the sweeper having caught up — they filter on the same
+ * rule the sweeper deletes by.
+ */
+export function activeNotificationWhere(
+  now = new Date(),
+): {
+  OR: Array<Record<string, unknown>>;
+} {
+  return {
+    OR: [
+      { expiresAt: null },
+      { expiresAt: { gt: now } },
+    ],
+  };
+}
+
 export async function getUnreadNotificationCount(
   userId: string,
+  now = new Date(),
 ) {
   return prisma.notification.count({
     where: {
       userId,
       read: false,
+      ...activeNotificationWhere(now),
     },
   });
+}
+
+/**
+ * Dismiss a single notification.
+ *
+ * Scoped by `userId` via `deleteMany` rather than `delete` so a caller cannot
+ * remove somebody else's row by guessing an id — a missing or foreign id is a
+ * `count` of 0, not a thrown `RecordNotFound`.
+ */
+export async function deleteNotification(
+  id: string,
+  userId: string,
+): Promise<number> {
+  const result = await prisma.notification.deleteMany({
+    where: {
+      id,
+      userId,
+    },
+  });
+
+  return result.count;
+}
+
+/**
+ * Clear a user's notifications. Defaults to the read ones, which is the
+ * "tidy up" action; pass `onlyRead: false` for a full clear.
+ */
+export async function deleteNotificationsForUser(
+  userId: string,
+  { onlyRead = true }: { onlyRead?: boolean } = {},
+): Promise<number> {
+  const result = await prisma.notification.deleteMany({
+    where: {
+      userId,
+      ...(onlyRead ? { read: true } : {}),
+    },
+  });
+
+  return result.count;
 }
 
 export async function markNotificationAsRead(
@@ -183,5 +246,43 @@ export async function markAllNotificationsAsRead(
     data: {
       read: true,
     },
+  });
+}
+
+export interface ListNotificationsParams {
+  userId: string;
+  limit: number;
+  cursorWhere?: Record<string, unknown>;
+  unreadOnly?: boolean;
+  now?: Date;
+}
+
+/**
+ * One page of a user's active notifications, newest first.
+ *
+ * Takes `limit + 1` rows so the caller can hand the result straight to
+ * `createPaginatedResponse`, which uses the extra row to decide `hasMore`.
+ */
+export async function listNotifications({
+  userId,
+  limit,
+  cursorWhere,
+  unreadOnly = false,
+  now = new Date(),
+}: ListNotificationsParams): Promise<Notification[]> {
+  return prisma.notification.findMany({
+    where: {
+      userId,
+      ...(unreadOnly ? { read: false } : {}),
+      AND: [
+        activeNotificationWhere(now),
+        ...(cursorWhere ? [cursorWhere] : []),
+      ],
+    },
+    orderBy: [
+      { createdAt: "desc" },
+      { id: "desc" },
+    ],
+    take: limit + 1,
   });
 }


### PR DESCRIPTION
Closes #381

## The problem

`GET /api/notifications` was a single unbounded query:

```ts
prisma.notification.findMany({
  where: { userId: session.user.id },   // no take, no cursor, no expiry filter
  orderBy: { createdAt: "desc" },
})
```

`NotificationBell` fetches this on mount for every authenticated page, so an active user downloads every notification they have ever received in order to render a dropdown that is `max-h-96` and shows about six of them.

It also returned rows whose `expiresAt` had already passed. The schema has the column and `cleanupExpiredNotifications()` sweeps it, but on a cron in batches of ≤500 — so between sweeps there are expired rows in the table and the read path was handing them to the client.

And there was no way to remove anything. `PATCH /api/notifications/[id]/read` existed; `DELETE` did not, and `markAllNotificationsAsRead()` was exported from `src/lib/notifications.ts` with **no caller anywhere in the codebase**. The helper was written, the route never was, so clearing a 500-item bell meant clicking 500 rows.

## What this changes

### Pagination

Uses the shared helpers from `src/lib/pagination.ts` — the same ones `/api/messages`, `/api/routes`, `/api/tickets` and `/api/users` already use. Default 20, capped at 100, `pagination.nextCursor` / `hasMore` in the response, `400` on a malformed `limit` or `cursor`. The `notifications` key is kept as an alias for `items` so nothing breaks.

### Expiry

`activeNotificationWhere()` filters both the page and `unreadCount`, off a **single clock reading** so the badge and the list cannot disagree about a notification expiring mid-request. It uses `gt: now` against the sweeper's `lte: now`, so the two rules partition the table: a row is either sweepable or visible, never both and never neither.

### The missing write paths

| Route | Does |
| --- | --- |
| `PATCH /api/notifications` | Mark all read — wires up the orphaned `markAllNotificationsAsRead()` |
| `DELETE /api/notifications/[id]` | Dismiss one |
| `DELETE /api/notifications?all=true` | Clear read ones, or everything |

The single-row delete goes through `deleteMany` with the `userId` in the same `where`, so a guessed id belonging to somebody else deletes nothing and returns 404 rather than throwing `RecordNotFound`.

### UI

`NotificationBell` gets **Mark all read**, a per-row **dismiss**, and **Load more**. Both mutations are optimistic with a rollback on failure. The loading state renders skeletons instead of "No notifications yet" while the first page is still in flight — previously the dropdown claimed the list was empty during load.

## Tests

45 new tests across three files:

- `src/lib/__tests__/notification-list.test.ts` — the new helpers, including that the cursor filter and expiry filter both survive under `AND` rather than one replacing the other, and that `deleteNotification` reports 0 instead of throwing for a foreign id
- `src/app/api/notifications/__tests__/route.test.ts` — GET/PATCH/DELETE, including the single-clock-reading assertion
- `src/app/api/notifications/[id]/__tests__/route.test.ts` — the new DELETE

## Verification

- `npx vitest run src/app/api/notifications src/lib/__tests__/notification-list.test.ts src/lib/__tests__/notifications.test.ts` — 45 passed
- Full suite unchanged from `main`'s baseline: 9 failing files / 23 failing tests before and after
- `npx tsc --noEmit` reports nothing new for these paths

## Note on the base branch

`main` does not currently typecheck (#366, fixed by #379). Nothing here touches those files.
