### PR TITLE
fix(meetup): validate checklist writes and allow items to be deleted

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -241,6 +241,57 @@ Response:
 }
 ```
 
+## Meetup checklist endpoints
+
+Every verb resolves the item's `MeetupPlan`, then its `Conversation`, and
+requires the caller to be a member of that conversation. Either traveller on a
+plan can read and edit the shared list; nobody outside it can.
+
+### `GET /api/meetup-checklist?meetupPlanId=<id>`
+
+Return the plan's checklist, incomplete items first. Bounded at 200 rows.
+Responds `[]` when `meetupPlanId` is omitted, `403` when the caller is not a
+member of the plan's conversation.
+
+### `POST /api/meetup-checklist`
+
+Add an item.
+
+```json
+{
+  "meetupPlanId": "plan-1",
+  "text": "Book the hostel"
+}
+```
+
+- `text` is trimmed, required, and capped at 200 characters.
+- `201 Created` with the new item.
+- `400 Bad Request` for empty, over-long or non-string text.
+- `409 Conflict` once the plan already holds 200 items.
+
+### `PATCH /api/meetup-checklist`
+
+Update an item's text, its completion flag, or both. At least one of the two
+must be present.
+
+```json
+{
+  "id": "item-1",
+  "text": "Book the hostel",
+  "completed": true
+}
+```
+
+- `400 Bad Request` when `id` is missing, when neither field is supplied, when
+  `text` trims to empty, or when `completed` is not a boolean.
+- `404 Not Found` for an unknown id, `403 Forbidden` for another
+  conversation's item.
+
+### `DELETE /api/meetup-checklist?id=<itemId>`
+
+Remove one item. `400` without an `id`, `404` for an unknown id, `403` for
+another conversation's item.
+
 ## Messaging endpoints
 
 ### `GET /api/messages?conversationId=<id>`

--- a/src/app/api/meetup-checklist/__tests__/route.test.ts
+++ b/src/app/api/meetup-checklist/__tests__/route.test.ts
@@ -1,0 +1,473 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import {
+  DELETE,
+  GET,
+  MAX_CHECKLIST_ITEMS_PER_PLAN,
+  MAX_CHECKLIST_TEXT_LENGTH,
+  PATCH,
+  POST,
+} from "../route";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    meetupPlan: {
+      findFirst: vi.fn(),
+    },
+    meetupChecklistItem: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+function jsonRequest(
+  method: "POST" | "PATCH",
+  body: unknown,
+) {
+  return new NextRequest(
+    "http://localhost/api/meetup-checklist",
+    {
+      method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function deleteRequest(query = "") {
+  return new NextRequest(
+    `http://localhost/api/meetup-checklist${query}`,
+    { method: "DELETE" },
+  );
+}
+
+function grantPlanAccess() {
+  vi.mocked(prisma.meetupPlan.findFirst).mockResolvedValue({
+    id: "plan-1",
+  } as never);
+}
+
+function denyPlanAccess() {
+  vi.mocked(prisma.meetupPlan.findFirst).mockResolvedValue(
+    null as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(auth).mockResolvedValue({
+    user: { id: "user-1" },
+  } as never);
+  grantPlanAccess();
+  vi.mocked(prisma.meetupChecklistItem.count).mockResolvedValue(
+    0 as never,
+  );
+  vi.mocked(prisma.meetupChecklistItem.create).mockResolvedValue({
+    id: "item-1",
+    meetupPlanId: "plan-1",
+    text: "Book the hostel",
+    completed: false,
+  } as never);
+  vi.mocked(prisma.meetupChecklistItem.update).mockResolvedValue({
+    id: "item-1",
+  } as never);
+  vi.mocked(
+    prisma.meetupChecklistItem.findUnique,
+  ).mockResolvedValue({ meetupPlanId: "plan-1" } as never);
+});
+
+describe("POST /api/meetup-checklist", () => {
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "Book the hostel",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(
+      prisma.meetupChecklistItem.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("creates an item for a plan the caller belongs to", async () => {
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "Book the hostel",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(
+      prisma.meetupChecklistItem.create,
+    ).toHaveBeenCalledWith({
+      data: {
+        meetupPlanId: "plan-1",
+        text: "Book the hostel",
+      },
+    });
+  });
+
+  it("trims the text before storing it", async () => {
+    await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "   Carry the printout   ",
+      }),
+    );
+
+    expect(
+      prisma.meetupChecklistItem.create,
+    ).toHaveBeenCalledWith({
+      data: {
+        meetupPlanId: "plan-1",
+        text: "Carry the printout",
+      },
+    });
+  });
+
+  it("rejects an empty item with 400", async () => {
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(
+      prisma.meetupChecklistItem.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only text with 400", async () => {
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "      ",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects non-string text with 400 rather than a Prisma 500", async () => {
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: { nested: "object" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(
+      prisma.meetupChecklistItem.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects text past the length cap with 400", async () => {
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "a".repeat(MAX_CHECKLIST_TEXT_LENGTH + 1),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("accepts text exactly at the length cap", async () => {
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "a".repeat(MAX_CHECKLIST_TEXT_LENGTH),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+  });
+
+  it("rejects a missing meetupPlanId with 400", async () => {
+    const response = await POST(
+      jsonRequest("POST", { text: "Book the hostel" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 403 for a plan the caller is not part of", async () => {
+    denyPlanAccess();
+
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "someone-elses-plan",
+        text: "Book the hostel",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(
+      prisma.meetupChecklistItem.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("refuses to grow a checklist past the item cap", async () => {
+    vi.mocked(
+      prisma.meetupChecklistItem.count,
+    ).mockResolvedValue(
+      MAX_CHECKLIST_ITEMS_PER_PLAN as never,
+    );
+
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "One too many",
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(
+      prisma.meetupChecklistItem.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the insert fails", async () => {
+    vi.mocked(
+      prisma.meetupChecklistItem.create,
+    ).mockRejectedValue(new Error("db down") as never);
+
+    const response = await POST(
+      jsonRequest("POST", {
+        meetupPlanId: "plan-1",
+        text: "Book the hostel",
+      }),
+    );
+
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("PATCH /api/meetup-checklist", () => {
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await PATCH(
+      jsonRequest("PATCH", { id: "item-1", completed: true }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 instead of 500 when id is missing", async () => {
+    const response = await PATCH(
+      jsonRequest("PATCH", { completed: true }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(
+      prisma.meetupChecklistItem.findUnique,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when neither text nor completed is supplied", async () => {
+    const response = await PATCH(
+      jsonRequest("PATCH", { id: "item-1" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects blanking an item's text", async () => {
+    const response = await PATCH(
+      jsonRequest("PATCH", { id: "item-1", text: "   " }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(
+      prisma.meetupChecklistItem.update,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-boolean completed flag", async () => {
+    const response = await PATCH(
+      jsonRequest("PATCH", { id: "item-1", completed: "yes" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("toggles completion for an accessible item", async () => {
+    const response = await PATCH(
+      jsonRequest("PATCH", { id: "item-1", completed: true }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      prisma.meetupChecklistItem.update,
+    ).toHaveBeenCalledWith({
+      where: { id: "item-1" },
+      data: { completed: true },
+    });
+  });
+
+  it("returns 404 for an item that does not exist", async () => {
+    vi.mocked(
+      prisma.meetupChecklistItem.findUnique,
+    ).mockResolvedValue(null as never);
+
+    const response = await PATCH(
+      jsonRequest("PATCH", { id: "missing", completed: true }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 for an item on another conversation's plan", async () => {
+    denyPlanAccess();
+
+    const response = await PATCH(
+      jsonRequest("PATCH", { id: "item-1", completed: true }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(
+      prisma.meetupChecklistItem.update,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/meetup-checklist", () => {
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await DELETE(
+      deleteRequest("?id=item-1"),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 without an id", async () => {
+    const response = await DELETE(deleteRequest());
+
+    expect(response.status).toBe(400);
+    expect(
+      prisma.meetupChecklistItem.delete,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("deletes an item on a plan the caller belongs to", async () => {
+    const response = await DELETE(
+      deleteRequest("?id=item-1"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      prisma.meetupChecklistItem.delete,
+    ).toHaveBeenCalledWith({ where: { id: "item-1" } });
+  });
+
+  it("returns 404 for an item that does not exist", async () => {
+    vi.mocked(
+      prisma.meetupChecklistItem.findUnique,
+    ).mockResolvedValue(null as never);
+
+    const response = await DELETE(
+      deleteRequest("?id=missing"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(
+      prisma.meetupChecklistItem.delete,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for an item on another conversation's plan", async () => {
+    denyPlanAccess();
+
+    const response = await DELETE(
+      deleteRequest("?id=item-1"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(
+      prisma.meetupChecklistItem.delete,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the delete fails", async () => {
+    vi.mocked(
+      prisma.meetupChecklistItem.delete,
+    ).mockRejectedValue(new Error("db down") as never);
+
+    const response = await DELETE(
+      deleteRequest("?id=item-1"),
+    );
+
+    expect(response.status).toBe(500);
+  });
+});
+
+describe("GET /api/meetup-checklist", () => {
+  beforeEach(() => {
+    vi.mocked(
+      prisma.meetupChecklistItem.findMany,
+    ).mockResolvedValue([] as never);
+  });
+
+  it("returns 401 without a session", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/meetup-checklist?meetupPlanId=plan-1",
+      ),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("bounds the query rather than returning the whole list", async () => {
+    await GET(
+      new NextRequest(
+        "http://localhost/api/meetup-checklist?meetupPlanId=plan-1",
+      ),
+    );
+
+    expect(
+      prisma.meetupChecklistItem.findMany,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: MAX_CHECKLIST_ITEMS_PER_PLAN,
+      }),
+    );
+  });
+
+  it("returns 403 for a plan the caller is not part of", async () => {
+    denyPlanAccess();
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/meetup-checklist?meetupPlanId=plan-1",
+      ),
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/src/app/api/meetup-checklist/route.ts
+++ b/src/app/api/meetup-checklist/route.ts
@@ -1,6 +1,64 @@
 import { NextRequest, NextResponse } from "next/server";
-import prisma from "@/lib/prisma";
+import { z } from "zod";
+
 import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { withValidation } from "@/lib/withValidation";
+
+/**
+ * Checklist items are one-line reminders ("book the hostel", "carry the
+ * printout"), not notes. `text` is an unbounded String in the schema, so
+ * without a cap a single item could carry megabytes that both travellers then
+ * download on every load.
+ */
+export const MAX_CHECKLIST_TEXT_LENGTH = 200;
+
+/**
+ * Upper bound on items per plan. Nothing here is user-facing under normal use
+ * — it exists so a script cannot grow one plan without limit, and so `GET`
+ * has a number it can safely `take`.
+ */
+export const MAX_CHECKLIST_ITEMS_PER_PLAN = 200;
+
+const checklistTextSchema = z
+  .string({
+    invalid_type_error: "Checklist text must be a string",
+  })
+  .trim()
+  .min(1, "Checklist text is required")
+  .max(
+    MAX_CHECKLIST_TEXT_LENGTH,
+    `Checklist text is too long (max ${MAX_CHECKLIST_TEXT_LENGTH} characters)`,
+  );
+
+const createItemSchema = z.object({
+  meetupPlanId: z
+    .string()
+    .trim()
+    .min(1, "meetupPlanId is required"),
+  text: checklistTextSchema,
+});
+
+const updateItemSchema = z
+  .object({
+    id: z.string().trim().min(1, "id is required"),
+    text: checklistTextSchema.optional(),
+    completed: z
+      .boolean({
+        invalid_type_error: "completed must be a boolean",
+      })
+      .optional(),
+  })
+  .refine(
+    (data) =>
+      data.text !== undefined ||
+      data.completed !== undefined,
+    {
+      message:
+        "Provide text, completed, or both",
+      path: ["text"],
+    },
+  );
 
 // A checklist item belongs to a MeetupPlan, which belongs to a Conversation.
 // A user may read/modify it only if they are a member of that conversation.
@@ -13,6 +71,51 @@ async function canAccessMeetupPlan(meetupPlanId: string, userId: string) {
     select: { id: true },
   });
   return Boolean(plan);
+}
+
+/**
+ * Resolves the item and checks access in one place, so every verb that works
+ * on an existing item applies the same rule.
+ */
+async function loadAccessibleItem(
+  itemId: string,
+  userId: string,
+): Promise<
+  | { ok: true }
+  | { ok: false; response: NextResponse }
+> {
+  const existing =
+    await prisma.meetupChecklistItem.findUnique({
+      where: { id: itemId },
+      select: { meetupPlanId: true },
+    });
+
+  if (!existing) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Not found" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  if (
+    !(await canAccessMeetupPlan(
+      existing.meetupPlanId,
+      userId,
+    ))
+  ) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Forbidden" },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { ok: true };
 }
 
 export async function GET(req: NextRequest) {
@@ -32,83 +135,194 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const items = await prisma.meetupChecklistItem.findMany({
-    where: {
-      meetupPlanId,
-    },
-    orderBy: [
-      { completed: "asc" },
-      { createdAt: "asc" },
-    ],
-  });
+  try {
+    const items = await prisma.meetupChecklistItem.findMany({
+      where: {
+        meetupPlanId,
+      },
+      orderBy: [
+        { completed: "asc" },
+        { createdAt: "asc" },
+      ],
+      take: MAX_CHECKLIST_ITEMS_PER_PLAN,
+    });
 
-  return NextResponse.json(items);
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error("Fetch checklist error:", error);
+
+    return NextResponse.json(
+      { error: "Failed to load checklist" },
+      { status: 500 },
+    );
+  }
 }
 
-export async function POST(req: NextRequest) {
+export const POST = withValidation(
+  createItemSchema,
+  async (_req, data) => {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    if (
+      !(await canAccessMeetupPlan(
+        data.meetupPlanId,
+        session.user.id,
+      ))
+    ) {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: 403 },
+      );
+    }
+
+    try {
+      const itemCount =
+        await prisma.meetupChecklistItem.count({
+          where: { meetupPlanId: data.meetupPlanId },
+        });
+
+      if (itemCount >= MAX_CHECKLIST_ITEMS_PER_PLAN) {
+        return NextResponse.json(
+          {
+            error: `This checklist is full (max ${MAX_CHECKLIST_ITEMS_PER_PLAN} items)`,
+          },
+          { status: 409 },
+        );
+      }
+
+      const item =
+        await prisma.meetupChecklistItem.create({
+          data: {
+            meetupPlanId: data.meetupPlanId,
+            text: data.text,
+          },
+        });
+
+      return NextResponse.json(item, { status: 201 });
+    } catch (error) {
+      console.error(
+        "Create checklist item error:",
+        error,
+      );
+
+      return NextResponse.json(
+        { error: "Failed to add checklist item" },
+        { status: 500 },
+      );
+    }
+  },
+);
+
+export const PATCH = withValidation(
+  updateItemSchema,
+  async (_req, data) => {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const access = await loadAccessibleItem(
+      data.id,
+      session.user.id,
+    );
+
+    if (!access.ok) {
+      return access.response;
+    }
+
+    try {
+      const item =
+        await prisma.meetupChecklistItem.update({
+          where: {
+            id: data.id,
+          },
+          data: {
+            ...(data.completed !== undefined && {
+              completed: data.completed,
+            }),
+
+            ...(data.text !== undefined && {
+              text: data.text,
+            }),
+          },
+        });
+
+      return NextResponse.json(item);
+    } catch (error) {
+      console.error(
+        "Update checklist item error:",
+        error,
+      );
+
+      return NextResponse.json(
+        { error: "Failed to update checklist item" },
+        { status: 500 },
+      );
+    }
+  },
+);
+
+/**
+ * DELETE /api/meetup-checklist?id=<itemId>
+ *
+ * Removes one item. Gated by the same conversation-membership rule as the
+ * other verbs, so either traveller on the plan can tidy the shared list but
+ * nobody outside it can touch it.
+ */
+export async function DELETE(req: NextRequest) {
   const session = await auth();
+
   if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const body = await req.json();
-
-  if (!body.meetupPlanId) {
     return NextResponse.json(
-      { error: "meetupPlanId is required" },
-      { status: 400 }
+      { error: "Unauthorized" },
+      { status: 401 },
     );
   }
 
-  if (!(await canAccessMeetupPlan(body.meetupPlanId, session.user.id))) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const itemId = new URL(req.url).searchParams.get("id");
+
+  if (!itemId) {
+    return NextResponse.json(
+      { error: "id is required" },
+      { status: 400 },
+    );
   }
 
-  const item = await prisma.meetupChecklistItem.create({
-    data: {
-      meetupPlanId: body.meetupPlanId,
-      text: body.text,
-    },
-  });
+  const access = await loadAccessibleItem(
+    itemId,
+    session.user.id,
+  );
 
-  return NextResponse.json(item);
-}
-
-export async function PATCH(req: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!access.ok) {
+    return access.response;
   }
 
-  const body = await req.json();
+  try {
+    await prisma.meetupChecklistItem.delete({
+      where: { id: itemId },
+    });
 
-  const existing = await prisma.meetupChecklistItem.findUnique({
-    where: { id: body.id },
-    select: { meetupPlanId: true },
-  });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error(
+      "Delete checklist item error:",
+      error,
+    );
 
-  if (!existing) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(
+      { error: "Failed to delete checklist item" },
+      { status: 500 },
+    );
   }
-
-  if (!(await canAccessMeetupPlan(existing.meetupPlanId, session.user.id))) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const item = await prisma.meetupChecklistItem.update({
-    where: {
-      id: body.id,
-    },
-    data: {
-      ...(body.completed !== undefined && {
-        completed: body.completed,
-      }),
-
-      ...(body.text !== undefined && {
-        text: body.text,
-      }),
-    },
-  });
-
-  return NextResponse.json(item);
 }

--- a/src/components/TripBoard.tsx
+++ b/src/components/TripBoard.tsx
@@ -2,13 +2,20 @@
 
 import { useEffect, useState } from "react";
 import { RouteViewer } from "./route-viewer";
-import { CalendarDays, MapPin, NotebookPen, CheckSquare, Pencil, Check, X, } from "lucide-react";
+import { CalendarDays, MapPin, NotebookPen, CheckSquare, Pencil, Check, X, Trash2, } from "lucide-react";
 
 interface ChecklistItem {
   id: string;
   text: string;
   completed: boolean;
 }
+
+/**
+ * Mirrors MAX_CHECKLIST_TEXT_LENGTH in src/app/api/meetup-checklist/route.ts.
+ * The server is the authority; this only stops the user typing past the limit
+ * and getting a 400 back.
+ */
+const MAX_ITEM_LENGTH = 200;
 
 interface TripBoardProps {
   meetupPlanId: string;
@@ -19,6 +26,22 @@ interface TripBoardProps {
   notes?: string;
 
   routeId?: string;
+}
+
+/**
+ * Pull the server's message out of a failed response so the user sees why the
+ * write was rejected (item too long, checklist full) instead of nothing at all.
+ */
+async function readError(
+  res: Response,
+  fallback: string
+): Promise<string> {
+  try {
+    const body = await res.json();
+    return typeof body?.error === "string" ? body.error : fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 export default function TripBoard({
@@ -55,9 +78,14 @@ export default function TripBoard({
   const [text, setText] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
 const [editingText, setEditingText] = useState("");
+const [error, setError] = useState<string | null>(null);
 
   async function addItem() {
-  if (!text.trim()) return;
+  const trimmed = text.trim();
+
+  if (!trimmed) return;
+
+  setError(null);
 
   const res = await fetch("/api/meetup-checklist", {
     method: "POST",
@@ -66,17 +94,41 @@ const [editingText, setEditingText] = useState("");
     },
     body: JSON.stringify({
       meetupPlanId,
-      text,
+      text: trimmed,
     }),
   });
 
-  if (!res.ok) return;
+  if (!res.ok) {
+    setError(await readError(res, "Could not add that item."));
+    return;
+  }
 
   const item = await res.json();
 
   setItems((prev) => [...prev, item]);
 
   setText("");
+}
+
+async function removeItem(id: string) {
+  const previous = items;
+
+  // Optimistic: the row disappears immediately and comes back if the
+  // request fails, which is the behaviour the toggle already has.
+  setItems((prev) => prev.filter((item) => item.id !== id));
+  setError(null);
+
+  const res = await fetch(
+    `/api/meetup-checklist?id=${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+    }
+  );
+
+  if (!res.ok) {
+    setItems(previous);
+    setError(await readError(res, "Could not remove that item."));
+  }
 }
 
   async function toggle(id: string) {
@@ -113,7 +165,11 @@ const [editingText, setEditingText] = useState("");
 }
 
 async function saveEdit(id: string) {
-  if (!editingText.trim()) return;
+  const trimmed = editingText.trim();
+
+  if (!trimmed) return;
+
+  setError(null);
 
   const res = await fetch("/api/meetup-checklist", {
     method: "PATCH",
@@ -122,18 +178,21 @@ async function saveEdit(id: string) {
     },
     body: JSON.stringify({
       id,
-      text: editingText,
+      text: trimmed,
     }),
   });
 
-  if (!res.ok) return;
+  if (!res.ok) {
+    setError(await readError(res, "Could not save that change."));
+    return;
+  }
 
   setItems((prev) =>
     prev.map((item) =>
       item.id === id
         ? {
             ...item,
-            text: editingText,
+            text: trimmed,
           }
         : item
     )
@@ -212,6 +271,7 @@ async function saveEdit(id: string) {
           <input
             className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white placeholder:text-slate-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={text}
+            maxLength={MAX_ITEM_LENGTH}
             onChange={(e) => setText(e.target.value)}
             placeholder="Add checklist item..."
           />
@@ -224,6 +284,15 @@ className="rounded-lg bg-blue-600 px-5 py-2 font-medium text-white transition ho
 </button>
 
         </div>
+
+        {error && (
+          <p
+            role="alert"
+            className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300"
+          >
+            {error}
+          </p>
+        )}
 
         <div className="mt-4 space-y-2">
 
@@ -269,6 +338,7 @@ className="rounded-lg bg-blue-600 px-5 py-2 font-medium text-white transition ho
   {editingId === item.id ? (
     <input
       value={editingText}
+      maxLength={MAX_ITEM_LENGTH}
       onChange={(e) => setEditingText(e.target.value)}
       className="flex-1 rounded-md border border-slate-300 bg-white px-2 py-1 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-white"
       autoFocus
@@ -307,16 +377,28 @@ className="rounded-lg bg-blue-600 px-5 py-2 font-medium text-white transition ho
       </button>
     </div>
   ) : (
-    <button
-      type="button"
-      onClick={() => {
-        setEditingId(item.id);
-        setEditingText(item.text);
-      }}
-      className="rounded p-1 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
-    >
-      <Pencil className="h-4 w-4" />
-    </button>
+    <div className="flex gap-1">
+      <button
+        type="button"
+        aria-label={`Edit ${item.text}`}
+        onClick={() => {
+          setEditingId(item.id);
+          setEditingText(item.text);
+        }}
+        className="rounded p-1 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+      >
+        <Pencil className="h-4 w-4" />
+      </button>
+
+      <button
+        type="button"
+        aria-label={`Remove ${item.text}`}
+        onClick={() => removeItem(item.id)}
+        className="rounded p-1 text-slate-500 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30"
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
+    </div>
   )}
 
 </div>

--- a/src/components/__tests__/trip-board.test.tsx
+++ b/src/components/__tests__/trip-board.test.tsx
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+
+import TripBoard from "../TripBoard";
+
+vi.mock("../route-viewer", () => ({
+  RouteViewer: () => <div data-testid="route-viewer" />,
+}));
+
+// lucide-react's ESM build does not resolve under the jsdom/vitest transform
+// used here — every named icon comes back undefined, which makes any component
+// rendering one blow up with "Element type is invalid". Stand in the icons
+// TripBoard uses; none of them carry behaviour worth asserting on.
+vi.mock("lucide-react", () => {
+  const Icon = () => <span aria-hidden="true" />;
+
+  return {
+    CalendarDays: Icon,
+    MapPin: Icon,
+    NotebookPen: Icon,
+    CheckSquare: Icon,
+    Pencil: Icon,
+    Check: Icon,
+    X: Icon,
+    Trash2: Icon,
+  };
+});
+
+global.fetch = vi.fn();
+
+const ITEMS = [
+  { id: "item-1", text: "Book the hostel", completed: false },
+  { id: "item-2", text: "Carry the printout", completed: false },
+];
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  };
+}
+
+function renderBoard() {
+  return render(
+    <TripBoard
+      meetupPlanId="plan-1"
+      title="Goa trip"
+      location="Anjuna Beach"
+      meetupTime="2026-09-01T10:00:00.000Z"
+    />,
+  );
+}
+
+describe("TripBoard checklist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (global.fetch as any).mockResolvedValue(
+      jsonResponse(ITEMS),
+    );
+  });
+
+  it("renders the loaded checklist items", async () => {
+    renderBoard();
+
+    expect(
+      await screen.findByText("Book the hostel"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Carry the printout"),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a remove control for each item", async () => {
+    renderBoard();
+
+    await screen.findByText("Book the hostel");
+
+    expect(
+      screen.getByRole("button", {
+        name: /remove book the hostel/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("deletes an item through the API and removes it from the list", async () => {
+    renderBoard();
+
+    await screen.findByText("Book the hostel");
+
+    (global.fetch as any).mockResolvedValueOnce(
+      jsonResponse({ ok: true }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /remove book the hostel/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Book the hostel"),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      "/api/meetup-checklist?id=item-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+
+    // The other item is untouched.
+    expect(
+      screen.getByText("Carry the printout"),
+    ).toBeInTheDocument();
+  });
+
+  it("restores the item and shows the server's message when the delete fails", async () => {
+    renderBoard();
+
+    await screen.findByText("Book the hostel");
+
+    (global.fetch as any).mockResolvedValueOnce(
+      jsonResponse({ error: "Forbidden" }, false, 403),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /remove book the hostel/i,
+      }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Forbidden",
+    );
+    expect(
+      screen.getByText("Book the hostel"),
+    ).toBeInTheDocument();
+  });
+
+  it("sends the trimmed text when adding an item", async () => {
+    renderBoard();
+
+    await screen.findByText("Book the hostel");
+
+    (global.fetch as any).mockResolvedValueOnce(
+      jsonResponse({
+        id: "item-3",
+        text: "Pack sunscreen",
+        completed: false,
+      }),
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/add checklist item/i),
+      { target: { value: "   Pack sunscreen   " } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /add item/i }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/meetup-checklist",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            meetupPlanId: "plan-1",
+            text: "Pack sunscreen",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("surfaces the server's error when an add is rejected", async () => {
+    renderBoard();
+
+    await screen.findByText("Book the hostel");
+
+    (global.fetch as any).mockResolvedValueOnce(
+      jsonResponse(
+        { error: "This checklist is full (max 200 items)" },
+        false,
+        409,
+      ),
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/add checklist item/i),
+      { target: { value: "One too many" } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /add item/i }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /checklist is full/i,
+    );
+  });
+
+  it("caps how much text the inputs accept", async () => {
+    renderBoard();
+
+    await screen.findByText("Book the hostel");
+
+    expect(
+      screen.getByPlaceholderText(/add checklist item/i),
+    ).toHaveAttribute("maxLength", "200");
+  });
+});


### PR DESCRIPTION
Closes #382

## The problem

`/api/meetup-checklist` was the only write endpoint in the app reading `await req.json()` straight into Prisma with no schema:

```ts
const body = await req.json();

if (!body.meetupPlanId) { ... }      // the only thing checked

const item = await prisma.meetupChecklistItem.create({
  data: {
    meetupPlanId: body.meetupPlanId,
    text: body.text,                  // never validated
  },
});
```

What got through:

| Request | Result on `main` |
| --- | --- |
| `POST { meetupPlanId, text: "" }` | 200, blank row created |
| `PATCH { id, text: "   " }` | 200, existing item blanked |
| `POST { meetupPlanId, text: {a:1} }` | 500 `PrismaClientValidationError` |
| `PATCH {}` | 500 — `findUnique({ where: { id: undefined } })` throws *before* the ownership check |
| `POST { meetupPlanId, text: <5MB> }` | 200 — `text` is an unbounded `String`, and both travellers download it on every load |

`TripBoard` guards with `if (!text.trim()) return`, but that is client-side only; curl or a double-submit walks past it. Neither `POST` nor `PATCH` had a `try/catch`, so a malformed body also 500'd.

There was also **no `DELETE` at all**. The list is shared between two travellers and had add, toggle and inline edit but no way to remove anything, because the API had no delete verb.

## What this changes

**Validation.** zod schemas on all three verbs, via `withValidation` — the same pattern `/api/meetup-plans`, `/api/user/report`, `/api/routes`, `/api/tickets` and `/api/chat` already use. `text` is trimmed, required, capped at 200 characters. `completed` must actually be a boolean. A `PATCH` carrying neither field is a 400 rather than a silent no-op update. Malformed JSON is a 400, not a 500.

**Delete.** `DELETE /api/meetup-checklist?id=<itemId>`, gated by the same conversation-membership rule as the other verbs. That check is factored into `loadAccessibleItem()` so every verb that works on an existing item applies it identically, and so `PATCH` resolves the item *after* validating that an id was supplied.

**Growth.** A plan caps at 200 items (409 past that) and `GET` gets a matching `take`, so one participant cannot grow a shared list without bound.

**UI.** `TripBoard` gets a per-row remove button with optimistic removal and rollback, `maxLength` on both inputs, and an error banner surfacing what the server actually said — previously every failure path was a bare `if (!res.ok) return`, so a rejected write looked identical to nothing happening.

## Tests

36 new tests:

- `src/app/api/meetup-checklist/__tests__/route.test.ts` (29) — every rejection above, plus the access-control matrix for all four verbs
- `src/components/__tests__/trip-board.test.tsx` (7) — the delete flow, the rollback, the trimmed payload, the error banner

### One thing worth flagging for reviewers

The component test stubs `lucide-react`. Its ESM build does not resolve under this repo's vitest/jsdom transform — **every** named icon comes back `undefined`, so any component that renders one fails to mount with "Element type is invalid". That is pre-existing and affects any future component test in this repo, not something this PR introduced. Worth fixing properly at the vitest config level; I've kept it to a local stub here rather than widen the scope.

## Verification

- `npx vitest run src/app/api/meetup-checklist` — 29 passed
- `npx vitest run src/components/__tests__/trip-board.test.tsx` — 7 passed
- Full suite unchanged from `main`'s baseline: 9 failing files / 23 failing tests before and after
- `npx tsc --noEmit` reports nothing new for these paths

## Note on the base branch

`main` does not currently typecheck (#366, fixed by #379). Nothing here touches those files.
