### PR TITLE
fix(connections): apply the block filter to GET and paginate the list

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -220,6 +220,65 @@ Fetch a single route belonging to the authenticated user.
 
 Delete a saved route owned by the authenticated user.
 
+## Connection endpoints
+
+### `GET /api/connections`
+
+Return the caller's pending requests in both directions plus a page of their
+accepted connections.
+
+Query parameters:
+
+| Name | Default | Notes |
+| --- | --- | --- |
+| `limit` | `20` | Page size for `connections`. Capped at `100`. |
+| `cursor` | — | Opaque cursor from a previous `pagination.nextCursor`. |
+
+Response:
+
+```json
+{
+  "incoming": [],
+  "outgoing": [],
+  "connections": [
+    {
+      "requestId": "req-1",
+      "user": { "id": "user-2", "name": "Asha", "image": null, "bio": null, "location": "Delhi" },
+      "connectedAt": "2026-08-01T12:00:00.000Z"
+    }
+  ],
+  "pagination": {
+    "limit": 20,
+    "nextCursor": "eyJ2ZXJzaW9uIjox...",
+    "hasMore": false
+  }
+}
+```
+
+`incoming` and `outgoing` are the pending requests, newest first, bounded at
+100 each. `connections` is the cursor-paginated accepted list.
+
+Users on either side of a `Block` are excluded from all three lists, matching
+the behaviour of `GET /api/conversations` and the guards `POST
+/api/connections` already applies to `send` and `accept`.
+
+`400` is returned for a malformed `limit` or `cursor`.
+
+### `POST /api/connections`
+
+Send, accept or decline a connection request.
+
+```json
+{
+  "action": "send",
+  "userId": "user-2"
+}
+```
+
+`action` is one of `send`, `accept`, `decline`. Accepting creates the
+conversation between the two users. All three are rate limited and refuse to
+act across a block.
+
 ## Match discovery endpoint
 
 ### `GET /api/matches?destination=<name>&date=<YYYY-MM-DD>`

--- a/src/app/api/connections/__tests__/route.test.ts
+++ b/src/app/api/connections/__tests__/route.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from "next/server";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
@@ -44,29 +45,278 @@ function postRequest(body: any) {
   };
 }
 
+function getRequest(query = "") {
+  return new NextRequest(
+    `http://localhost/api/connections${query}`,
+  );
+}
+
+/**
+ * `getBlockedUserIds` reads Block rows in both directions and reduces them to
+ * the counterpart ids. Driving it through the prisma mock rather than stubbing
+ * the helper keeps the real symmetry logic under test.
+ */
+function blockedWith(...counterpartIds: string[]) {
+  (prisma.block.findMany as any).mockResolvedValue(
+    counterpartIds.map((id, index) =>
+      index % 2 === 0
+        ? { blockerId: "user-1", blockedId: id }
+        : { blockerId: id, blockedId: "user-1" },
+    ),
+  );
+}
+
+/**
+ * The three findMany calls run inside one Promise.all, in the order
+ * incoming, outgoing, accepted.
+ */
+function callArgs(index: 0 | 1 | 2) {
+  return (prisma.connectionRequest.findMany as any).mock.calls[
+    index
+  ][0] as { where: any; orderBy: any; take: number };
+}
+
+function acceptedRow(
+  id: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    senderId: "user-1",
+    receiverId: "user-2",
+    status: "ACCEPTED",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    sender: { id: "user-1", name: "Me" },
+    receiver: { id: "user-2", name: "Them" },
+    ...overrides,
+  };
+}
+
 describe("Connections API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (auth as any).mockResolvedValue({ user: { id: "user-1", name: "User 1" } });
     // Default: neither user has blocked the other.
     (prisma.block.findFirst as any).mockResolvedValue(null);
+    (prisma.block.findMany as any).mockResolvedValue([]);
+    (prisma.connectionRequest.findMany as any).mockResolvedValue([]);
   });
 
   describe("GET /api/connections", () => {
     it("returns 401 if unauthorized", async () => {
       (auth as any).mockResolvedValue(null);
-      const res = await GET({} as any);
+      const res = await GET(getRequest());
       expect(res.status).toBe(401);
+      expect(
+        prisma.connectionRequest.findMany,
+      ).not.toHaveBeenCalled();
     });
 
     it("returns connection lists", async () => {
-      (prisma.connectionRequest.findMany as any).mockResolvedValue([]);
-      const res = await GET({} as any);
+      const res = await GET(getRequest());
       const data = await res.json();
       expect(res.status).toBe(200);
       expect(data).toHaveProperty("incoming");
       expect(data).toHaveProperty("outgoing");
       expect(data).toHaveProperty("connections");
+    });
+
+    it("resolves the block set once, not per row", async () => {
+      blockedWith("blocked-1", "blocked-2");
+
+      await GET(getRequest());
+
+      expect(prisma.block.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("adds no block filter when nothing is blocked", async () => {
+      await GET(getRequest());
+
+      expect(callArgs(0).where).toEqual({
+        receiverId: "user-1",
+        status: "PENDING",
+      });
+      expect(callArgs(1).where).toEqual({
+        senderId: "user-1",
+        status: "PENDING",
+      });
+      expect(callArgs(2).where.OR).toEqual([
+        { senderId: "user-1" },
+        { receiverId: "user-1" },
+      ]);
+    });
+
+    it("hides incoming requests from a blocked sender", async () => {
+      blockedWith("blocked-1");
+
+      await GET(getRequest());
+
+      expect(callArgs(0).where).toEqual({
+        receiverId: "user-1",
+        status: "PENDING",
+        senderId: { notIn: ["blocked-1"] },
+      });
+    });
+
+    it("hides outgoing requests to a blocked receiver", async () => {
+      blockedWith("blocked-1");
+
+      await GET(getRequest());
+
+      expect(callArgs(1).where).toEqual({
+        senderId: "user-1",
+        status: "PENDING",
+        receiverId: { notIn: ["blocked-1"] },
+      });
+    });
+
+    it("hides accepted connections on either side of a block", async () => {
+      blockedWith("blocked-1");
+
+      await GET(getRequest());
+
+      // The filter has to sit inside each OR branch: the counterpart is the
+      // receiver when the caller sent the request and the sender when they
+      // received it.
+      expect(callArgs(2).where.OR).toEqual([
+        {
+          senderId: "user-1",
+          receiverId: { notIn: ["blocked-1"] },
+        },
+        {
+          receiverId: "user-1",
+          senderId: { notIn: ["blocked-1"] },
+        },
+      ]);
+    });
+
+    it("covers blocks in both directions with one id list", async () => {
+      // blockedWith alternates the direction of each Block row, so this
+      // asserts the symmetry getBlockedUserIds is responsible for.
+      blockedWith("i-blocked-them", "they-blocked-me");
+
+      await GET(getRequest());
+
+      expect(callArgs(2).where.OR[0].receiverId.notIn).toEqual([
+        "i-blocked-them",
+        "they-blocked-me",
+      ]);
+    });
+
+    it("runs the three queries concurrently rather than serially", async () => {
+      let resolveFirst: (value: unknown) => void = () => {};
+      let started = 0;
+
+      (prisma.connectionRequest.findMany as any).mockImplementation(
+        () => {
+          started += 1;
+
+          if (started === 1) {
+            return new Promise((resolve) => {
+              resolveFirst = resolve;
+            });
+          }
+
+          return Promise.resolve([]);
+        },
+      );
+
+      const pending = GET(getRequest());
+
+      // Let the handler get past its `await getBlockedUserIds(...)` and reach
+      // the Promise.all. All three are then in flight even though the first
+      // has not settled — the serial version would sit at one.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(started).toBe(3);
+
+      resolveFirst([]);
+      await pending;
+    });
+
+    it("bounds the pending lists", async () => {
+      await GET(getRequest());
+
+      expect(callArgs(0).take).toBe(100);
+      expect(callArgs(1).take).toBe(100);
+    });
+
+    it("paginates the accepted list with a stable ordering", async () => {
+      await GET(getRequest("?limit=5"));
+
+      expect(callArgs(2).take).toBe(6);
+      expect(callArgs(2).orderBy).toEqual([
+        { updatedAt: "desc" },
+        { id: "desc" },
+      ]);
+    });
+
+    it("returns a cursor when more connections exist", async () => {
+      (prisma.connectionRequest.findMany as any).mockImplementation(
+        async (args: any) =>
+          args.where.status === "ACCEPTED"
+            ? [
+                acceptedRow("req-1"),
+                acceptedRow("req-2"),
+                acceptedRow("req-3"),
+              ]
+            : [],
+      );
+
+      const res = await GET(getRequest("?limit=2"));
+      const data = await res.json();
+
+      expect(data.connections).toHaveLength(2);
+      expect(data.pagination.hasMore).toBe(true);
+      expect(data.pagination.nextCursor).toBeTruthy();
+    });
+
+    it("maps each accepted row to the other participant", async () => {
+      (prisma.connectionRequest.findMany as any).mockImplementation(
+        async (args: any) =>
+          args.where.status === "ACCEPTED"
+            ? [
+                acceptedRow("req-1"),
+                acceptedRow("req-2", {
+                  senderId: "user-3",
+                  receiverId: "user-1",
+                  sender: { id: "user-3", name: "Sender" },
+                  receiver: { id: "user-1", name: "Me" },
+                }),
+              ]
+            : [],
+      );
+
+      const res = await GET(getRequest());
+      const data = await res.json();
+
+      expect(data.connections[0].user.id).toBe("user-2");
+      expect(data.connections[1].user.id).toBe("user-3");
+    });
+
+    it("returns 400 for a malformed cursor", async () => {
+      const res = await GET(getRequest("?cursor=nonsense"));
+
+      expect(res.status).toBe(400);
+      expect(
+        prisma.connectionRequest.findMany,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for a malformed limit", async () => {
+      const res = await GET(getRequest("?limit=-3"));
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 500 when a query fails", async () => {
+      (prisma.connectionRequest.findMany as any).mockRejectedValue(
+        new Error("db down"),
+      );
+
+      const res = await GET(getRequest());
+
+      expect(res.status).toBe(500);
     });
   });
 

--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -1,10 +1,52 @@
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
-import { isBlockedBetween } from "@/lib/blocking";
+import {
+  getBlockedUserIds,
+  isBlockedBetween,
+} from "@/lib/blocking";
+import {
+  buildTimestampCursorWhere,
+  createPaginatedResponse,
+  PaginationError,
+  parsePaginationParams,
+} from "@/lib/pagination";
 import { rateLimitExceededResponse } from "@/lib/rate-limit";
 import { enforceRateLimit } from "@/lib/rate-limit-rules";
 import { triggerPusher } from "@/lib/pusher";
+
+/**
+ * The profile fields shown on a connection card. Matches the projection
+ * /api/conversations and /api/users use.
+ */
+const CONNECTION_USER_SELECT = {
+  id: true,
+  name: true,
+  image: true,
+  bio: true,
+  location: true,
+} as const;
+
+/**
+ * Cap on the two pending-request lists. Pending requests are inherently
+ * short-lived — you accept or decline them — so this is a safety bound rather
+ * than a paging window.
+ */
+const MAX_PENDING_REQUESTS = 100;
+
+/**
+ * Excludes rows where the counterpart is somebody the caller may not interact
+ * with. Blocking is symmetric, so `blockedUserIds` already covers both the
+ * people the caller blocked and the people who blocked them.
+ */
+function excludeBlockedCounterparts(
+  field: "senderId" | "receiverId",
+  blockedUserIds: string[],
+) {
+  return blockedUserIds.length > 0
+    ? { [field]: { notIn: blockedUserIds } }
+    : {};
+}
 
 export async function GET(req: NextRequest) {
   const session = await auth();
@@ -15,82 +57,122 @@ export async function GET(req: NextRequest) {
   const userId = session.user.id;
 
   try {
-    const incoming = await prisma.connectionRequest.findMany({
-      where: {
-        receiverId: userId,
-        status: "PENDING",
-      },
-      include: {
-        sender: {
-          select: {
-            id: true,
-            name: true,
-            image: true,
-            bio: true,
-            location: true,
+    const { limit, cursor } = parsePaginationParams(
+      req.nextUrl.searchParams,
+    );
+    const cursorWhere = buildTimestampCursorWhere(
+      "updatedAt",
+      cursor,
+    );
+
+    // Resolve the block set once. POST already refuses to create or accept a
+    // request across a block; GET was still handing the blocked user back with
+    // their name, photo, bio and location, so the sidebar hid the thread while
+    // the connections page kept rendering the person.
+    const blockedUserIds = await getBlockedUserIds(userId);
+
+    // None of these three depend on each other, so there is no reason to make
+    // the second wait for the first.
+    const [incoming, outgoing, accepted] = await Promise.all([
+      prisma.connectionRequest.findMany({
+        where: {
+          receiverId: userId,
+          status: "PENDING",
+          ...excludeBlockedCounterparts(
+            "senderId",
+            blockedUserIds,
+          ),
+        },
+        include: {
+          sender: {
+            select: CONNECTION_USER_SELECT,
           },
         },
-      },
-      orderBy: { createdAt: "desc" },
-    });
-
-    const outgoing = await prisma.connectionRequest.findMany({
-      where: {
-        senderId: userId,
-        status: "PENDING",
-      },
-      include: {
-        receiver: {
-          select: {
-            id: true,
-            name: true,
-            image: true,
-            bio: true,
-            location: true,
-          },
-        },
-      },
-      orderBy: { createdAt: "desc" },
-    });
-
-    const accepted = await prisma.connectionRequest.findMany({
-      where: {
-        status: "ACCEPTED",
-        OR: [
-          { senderId: userId },
-          { receiverId: userId },
+        orderBy: [
+          { createdAt: "desc" },
+          { id: "desc" },
         ],
-      },
-      include: {
-        sender: {
-          select: {
-            id: true,
-            name: true,
-            image: true,
-            bio: true,
-            location: true,
+        take: MAX_PENDING_REQUESTS,
+      }),
+
+      prisma.connectionRequest.findMany({
+        where: {
+          senderId: userId,
+          status: "PENDING",
+          ...excludeBlockedCounterparts(
+            "receiverId",
+            blockedUserIds,
+          ),
+        },
+        include: {
+          receiver: {
+            select: CONNECTION_USER_SELECT,
           },
         },
-        receiver: {
-          select: {
-            id: true,
-            name: true,
-            image: true,
-            bio: true,
-            location: true,
+        orderBy: [
+          { createdAt: "desc" },
+          { id: "desc" },
+        ],
+        take: MAX_PENDING_REQUESTS,
+      }),
+
+      prisma.connectionRequest.findMany({
+        where: {
+          status: "ACCEPTED",
+          OR: [
+            {
+              senderId: userId,
+              ...excludeBlockedCounterparts(
+                "receiverId",
+                blockedUserIds,
+              ),
+            },
+            {
+              receiverId: userId,
+              ...excludeBlockedCounterparts(
+                "senderId",
+                blockedUserIds,
+              ),
+            },
+          ],
+          ...(cursorWhere ?? {}),
+        },
+        include: {
+          sender: {
+            select: CONNECTION_USER_SELECT,
+          },
+          receiver: {
+            select: CONNECTION_USER_SELECT,
           },
         },
-      },
-      orderBy: { updatedAt: "desc" },
-    });
+        // `updatedAt` alone is not a stable sort — two rows accepted in the
+        // same transaction can swap places between requests, which would make
+        // the cursor skip or repeat a row.
+        orderBy: [
+          { updatedAt: "desc" },
+          { id: "desc" },
+        ],
+        take: limit + 1,
+      }),
+    ]);
+
+    const acceptedPage = createPaginatedResponse(
+      accepted,
+      limit,
+      "updatedAt",
+    );
 
     // Map accepted requests to connection objects representing the other user
-    const connections = accepted.map((req) => {
-      const otherUser = req.senderId === userId ? req.receiver : req.sender;
+    const connections = acceptedPage.items.map((request) => {
+      const otherUser =
+        request.senderId === userId
+          ? request.receiver
+          : request.sender;
+
       return {
-        requestId: req.id,
+        requestId: request.id,
         user: otherUser,
-        connectedAt: req.updatedAt,
+        connectedAt: request.updatedAt,
       };
     });
 
@@ -98,8 +180,16 @@ export async function GET(req: NextRequest) {
       incoming,
       outgoing,
       connections,
+      pagination: acceptedPage.pagination,
     });
   } catch (error) {
+    if (error instanceof PaginationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 },
+      );
+    }
+
     console.error("Fetch connections error:", error);
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }


### PR DESCRIPTION
Closes #383

## The problem

Blocking is only half-applied on this endpoint. `POST` does the right thing — `isBlockedBetween()` guards both `send` and `accept`. `GET` never consulted `src/lib/blocking.ts` at all.

So after A blocks B:

- `GET /api/conversations` correctly drops the thread
- `GET /api/connections` still returns B under `connections`, with name, photo, bio and location
- a pending request from B still sits in A's `incoming` list, and accepting it 403s — which just looks broken
- B still sees A in *their* list too, because blocking is symmetric here

The sidebar hides the person while the connections page keeps rendering them, which defeats the point of the feature and is confusing on both sides.

The same handler also ran three unbounded `findMany` calls **serially**, each with `include`d user records, on every dashboard load.

## What this changes

**Block filter.** `getBlockedUserIds()` resolved once, applied to all three lists. For the accepted list the filter has to sit inside each `OR` branch, because the counterpart is the *receiver* when the caller sent the request and the *sender* when they received it:

```ts
OR: [
  { senderId: userId,   receiverId: { notIn: blockedUserIds } },
  { receiverId: userId, senderId:   { notIn: blockedUserIds } },
]
```

**Concurrency.** The three queries don't depend on each other, so they run in one `Promise.all` instead of each `await` blocking the next.

**Bounds.** The two pending lists cap at 100. The accepted list is cursor-paginated with the shared `src/lib/pagination.ts` helpers.

**Stable ordering.** `orderBy: { updatedAt: "desc" }` alone is not a stable sort — two rows accepted in the same transaction can swap places between requests, which would make the new cursor skip or repeat a row. Adds an `id` tiebreaker, matching what `/api/messages` and `/api/routes` do.

## Backwards compatibility

`incoming`, `outgoing` and `connections` keep their shapes and their keys, so `ChatInterface` and `DashboardMatches` need no changes. `pagination` is additive — a follow-up can wire a "load more" onto it.

## Tests

The existing file was for `GET` (2 cases) and `POST` (4 cases). The `POST` cases are unchanged; the two `GET` cases now pass a real `NextRequest`, since the handler reads `searchParams`. 14 new `GET` cases on top.

Worth noting: the block tests drive `prisma.block.findMany` rather than stubbing `getBlockedUserIds`, so the real symmetry logic stays under test — `blockedWith()` alternates the direction of each `Block` row on purpose.

The concurrency test holds the first query's promise open and asserts all three have started, which fails against the serial version.

## Verification

- `npx vitest run src/app/api/connections` — 20 passed (4 pre-existing POST cases + 16)
- Full suite unchanged from `main`'s baseline: 9 failing files / 23 failing tests before and after
- `npx tsc --noEmit` reports nothing new for this path

## Note on the base branch

`main` does not currently typecheck (#366, fixed by #379). Nothing here touches those files.
