### PR TITLE
fix(avatar): delete previous Cloudinary avatar asset when updating avatar

### DIFF
--- a/src/app/api/user/avatar/__tests__/avatar-cleanup.test.ts
+++ b/src/app/api/user/avatar/__tests__/avatar-cleanup.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/cloudinary-upload", () => ({
+  uploadFileToCloudinary: vi.fn(),
+}));
+
+vi.mock("@/lib/cloudinary-delete", () => ({
+  extractCloudinaryPublicId: vi.fn(),
+  deleteCloudinaryAsset: vi.fn(),
+}));
+
+import { POST } from "../route";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { uploadFileToCloudinary } from "@/lib/cloudinary-upload";
+import {
+  extractCloudinaryPublicId,
+  deleteCloudinaryAsset,
+} from "@/lib/cloudinary-delete";
+
+describe("POST /api/user/avatar - old asset cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createFormDataRequest = (file: any) => {
+    const formData = new Map();
+    if (file) formData.set("file", file);
+
+    return {
+      headers: new Headers(),
+      formData: async () => formData,
+    } as any;
+  };
+
+  it("deletes previous Cloudinary avatar asset when uploading a new avatar", async () => {
+    (auth as any).mockResolvedValue({
+      user: { email: "user@example.com" },
+    });
+
+    const oldAvatarUrl =
+      "https://res.cloudinary.com/demo/image/upload/v12345/travellers/avatars/old_avatar.jpg";
+    const newAvatarUrl =
+      "https://res.cloudinary.com/demo/image/upload/v67890/travellers/avatars/new_avatar.jpg";
+
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: "user-1",
+      image: oldAvatarUrl,
+    });
+
+    (uploadFileToCloudinary as any).mockResolvedValue({
+      url: newAvatarUrl,
+      publicId: "travellers/avatars/new_avatar",
+    });
+
+    (prisma.user.update as any).mockResolvedValue({
+      id: "user-1",
+      image: newAvatarUrl,
+    });
+
+    (extractCloudinaryPublicId as any).mockReturnValue(
+      "travellers/avatars/old_avatar",
+    );
+    (deleteCloudinaryAsset as any).mockResolvedValue(undefined);
+
+    const file = new File(["dummy content"], "avatar.jpg", {
+      type: "image/jpeg",
+    });
+    const req = createFormDataRequest(file);
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.image).toBe(newAvatarUrl);
+
+    expect(extractCloudinaryPublicId).toHaveBeenCalledWith(oldAvatarUrl);
+    expect(deleteCloudinaryAsset).toHaveBeenCalledWith(
+      "travellers/avatars/old_avatar",
+    );
+  });
+});

--- a/src/app/api/user/avatar/route.ts
+++ b/src/app/api/user/avatar/route.ts
@@ -2,6 +2,10 @@ import { NextResponse, NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { uploadFileToCloudinary } from "@/lib/cloudinary-upload";
+import {
+  deleteCloudinaryAsset,
+  extractCloudinaryPublicId,
+} from "@/lib/cloudinary-delete";
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -35,19 +39,39 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const uploaded = await uploadFileToCloudinary(
-  file,
-  "travellers/avatars"
-);
+    const existingUser = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { id: true, image: true },
+    });
 
-const updatedUser = await prisma.user.update({
-  where: {
-    email: session.user.email,
-  },
-  data: {
-    image: uploaded.url,
-  },
-});
+    const uploaded = await uploadFileToCloudinary(
+      file,
+      "travellers/avatars"
+    );
+
+    const updatedUser = await prisma.user.update({
+      where: {
+        email: session.user.email,
+      },
+      data: {
+        image: uploaded.url,
+      },
+    });
+
+    if (existingUser?.image && existingUser.image !== uploaded.url) {
+      const oldPublicId = extractCloudinaryPublicId(existingUser.image);
+      if (oldPublicId) {
+        try {
+          await deleteCloudinaryAsset(oldPublicId);
+        } catch (cleanupError) {
+          console.error(
+            "Failed to delete previous avatar asset from Cloudinary:",
+            cleanupError
+          );
+        }
+      }
+    }
+
     return NextResponse.json({ ok: true, image: updatedUser.image });
   } catch (error) {
     console.error("Avatar upload error:", error);


### PR DESCRIPTION
Fixes #373

### Summary
When a user uploads a new profile avatar, \POST /api/user/avatar\ now fetches the user's previous \image\ URL, extracts its Cloudinary public ID via \extractCloudinaryPublicId()\, and deletes the previous asset using \deleteCloudinaryAsset()\. This prevents orphaned media files from accumulating on Cloudinary.

### Verification
Added unit test in \src/app/api/user/avatar/__tests__/avatar-cleanup.test.ts\ verifying old Cloudinary asset extraction and deletion on avatar update.