### PR TITLE
fix(calendar): compute DTEND using UTC timestamps in calendar event export

### DIFF
--- a/src/lib/calendar-export.ts
+++ b/src/lib/calendar-export.ts
@@ -153,12 +153,7 @@ export function createCalendarEvent(
         .map(Number);
 
       const start = new Date(
-        year,
-        month - 1,
-        day,
-        hours,
-        minutes,
-        0,
+        Date.UTC(year, month - 1, day, hours, minutes, 0),
       );
       const end = new Date(
         start.getTime() + route.durationMinutes * 60_000,
@@ -166,12 +161,12 @@ export function createCalendarEvent(
 
       lines.push(
         `DTEND:${[
-          end.getFullYear(),
-          pad(end.getMonth() + 1),
-          pad(end.getDate()),
+          end.getUTCFullYear(),
+          pad(end.getUTCMonth() + 1),
+          pad(end.getUTCDate()),
           "T",
-          pad(end.getHours()),
-          pad(end.getMinutes()),
+          pad(end.getUTCHours()),
+          pad(end.getUTCMinutes()),
           "00",
         ].join("")}`,
       );


### PR DESCRIPTION
Fixes #375

### Summary
In \createCalendarEvent()\, duration calculation for \DTEND\ now uses \Date.UTC(...)\ and \getUTCFullYear()\, \getUTCHours()\, etc. instead of local system timezone getters. This prevents local timezone offset mismatches and DST boundary errors when exporting \.ics\ calendar files.

### Verification
Verified via unit test suite \src/lib/__tests__/calendar-export.test.ts\ ensuring accurate \DTSTART\ and \DTEND\ generation.