### PR TITLE
fix: /api/matches caps total at 100 (magic number) — raise + make deterministic

### DIFF
--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -15,6 +15,13 @@ import {
 import { apiError, apiJson } from "@/lib/api-response";
 import { getRequestId } from "@/lib/request-id";
 
+// Upper bound on candidate tickets pulled for a destination/date window before
+// relevance scoring + pagination. Was a magic `100`, which made `total`/`hasMore`
+// wrong and hid every match past #100 once a window had more than 100 tickets.
+// The full candidate set is needed to rank by relevance, so this is a safety
+// cap (not a page size) — raise it if popular windows legitimately exceed it.
+const MAX_MATCH_CANDIDATES = 500;
+
 function calculateRelevance(
   currentUser: any,
   matchedUser: any,
@@ -344,7 +351,8 @@ export async function GET(req: NextRequest) {
 
     const matches = await prisma.ticket.findMany({
       where: whereClause,
-      take: 100,
+      take: MAX_MATCH_CANDIDATES,
+      orderBy: { departureDate: "asc" },
       select: {
         id: true,
         destination: true,


### PR DESCRIPTION
Closes #320

### Problem
`prisma.ticket.findMany` used a magic `take: 100`. Since `total = scoredMatches.length` and pagination slices that in-memory set, once a destination/date window had more than 100 matching verified tickets:
- `total` / `hasMore` were wrong, and
- any match past #100 was unreachable,
- and the capped 100 were selected in arbitrary DB order.

### Fix
- Replace the magic `100` with a documented, named `MAX_MATCH_CANDIDATES = 500` safety cap. The full candidate set has to be fetched to rank by relevance (so this is a candidate bound, not a page size); 500 gives correct `total`/`hasMore` for realistic windows. The constant is commented so the maintainer can tune it.
- Add `orderBy: { departureDate: "asc" }` so that *when* the cap is hit, the selected candidates are deterministic (closest departures first) rather than arbitrary.

> Note: like the other open travellers PRs, `build-and-lint` stays red until the base-branch fixes (#379 duplicate `rateLimit`, #378 admin `PATCH`) land — this change is isolated to the matches query.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._