### PR TITLE
fix: green the test suite and run vitest in CI (#318)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: npm run lint -- --no-cache
       - name: Type check
         run: npx tsc --noEmit
+      - name: Test
+        run: npm test
       - name: Build
-        
+
         run: npx next build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.18.0'
+          node-version: '22'
           cache: 'npm'
       - name: Show versions
         run: |

--- a/src/app/api/auth/__tests__/forgot-password.test.ts
+++ b/src/app/api/auth/__tests__/forgot-password.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextResponse } from "next/server";
 
 vi.mock("@/lib/prisma", () => ({
   default: {
@@ -24,11 +25,14 @@ import { POST } from "../forgot-password/route";
 import prisma from "@/lib/prisma";
 import { sendPasswordResetEmail } from "@/lib/email";
 import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config";
+// Import the mocked module as a namespace instead of rateLimit,
+// which vitest can't resolve at runtime (the @ alias is transform-time only).
+import * as rateLimit from "@/lib/rate-limit";
 
 beforeEach(() => {
   vi.clearAllMocks();
   
-  const { checkRateLimit } = require("@/lib/rate-limit");
+  const { checkRateLimit } = rateLimit;
   vi.mocked(checkRateLimit).mockResolvedValue({
     allowed: true,
     limit: RATE_LIMIT_CONFIG.auth.forgotPassword.limit,
@@ -98,7 +102,7 @@ describe("POST /api/auth/forgot-password", () => {
   });
 
   it("uses configured rate limits for password reset", async () => {
-    const { checkRateLimit } = require("@/lib/rate-limit");
+    const { checkRateLimit } = rateLimit;
     
     vi.mocked(checkRateLimit).mockResolvedValue({
       allowed: true,
@@ -122,7 +126,7 @@ describe("POST /api/auth/forgot-password", () => {
   });
 
   it("returns 429 when password reset rate limit is exceeded", async () => {
-    const { checkRateLimit, rateLimitExceededResponse } = require("@/lib/rate-limit");
+    const { checkRateLimit, rateLimitExceededResponse } = rateLimit;
     
     vi.mocked(checkRateLimit).mockResolvedValue({
       allowed: false,
@@ -133,10 +137,12 @@ describe("POST /api/auth/forgot-password", () => {
       bypassed: false,
     });
 
-    vi.mocked(rateLimitExceededResponse).mockReturnValue({
-      status: 429,
-      json: async () => ({ error: "Too many requests", retryAfter: RATE_LIMIT_CONFIG.auth.forgotPassword.windowSeconds }),
-    });
+    vi.mocked(rateLimitExceededResponse).mockReturnValue(
+      NextResponse.json(
+        { error: "Too many requests", retryAfter: RATE_LIMIT_CONFIG.auth.forgotPassword.windowSeconds },
+        { status: 429 },
+      ),
+    );
 
     const req = createRequest({ email: "test@example.com" });
     const res = await POST(req as any);

--- a/src/app/api/auth/__tests__/signin.test.ts
+++ b/src/app/api/auth/__tests__/signin.test.ts
@@ -23,6 +23,9 @@ vi.mock("@/lib/rate-limit", () => ({
 import prisma from "@/lib/prisma"
 import { compare } from "bcryptjs"
 import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config"
+// Import the mocked module as a namespace instead of rateLimit,
+// which vitest can't resolve at runtime (the @ alias is transform-time only).
+import * as rateLimit from "@/lib/rate-limit"
 
 // Replicate the authorize logic for unit-testing independently of NextAuth internals
 async function authorize(credentials: { email?: string; password?: string }) {
@@ -41,7 +44,7 @@ async function authorize(credentials: { email?: string; password?: string }) {
 beforeEach(() => {
     vi.clearAllMocks()
     
-    const { checkRateLimit } = require("@/lib/rate-limit");
+    const { checkRateLimit } = rateLimit;
     vi.mocked(checkRateLimit).mockResolvedValue({
       allowed: true,
       limit: RATE_LIMIT_CONFIG.auth.signin.limit,

--- a/src/app/api/auth/__tests__/signup.test.ts
+++ b/src/app/api/auth/__tests__/signup.test.ts
@@ -5,7 +5,7 @@ import {
   it,
   vi,
 } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 const { hashMock } = vi.hoisted(() => ({
   hashMock: vi.fn(),
@@ -26,6 +26,7 @@ vi.mock("@/lib/prisma", () => ({
 
 vi.mock("@/lib/otp", () => ({
   generateOTP: vi.fn(() => "123456"),
+  hashOTP: vi.fn((otp) => otp),
   isValidOTPFormat: vi.fn(() => true),
 }));
 
@@ -47,6 +48,9 @@ vi.mock("@/lib/rate-limit", () => ({
 import prisma from "@/lib/prisma";
 import { POST } from "../signup/route";
 import { RATE_LIMIT_CONFIG } from "@/lib/rate-limit-config";
+// Import the mocked module as a namespace instead of rateLimit,
+// which vitest can't resolve at runtime (the @ alias is transform-time only).
+import * as rateLimit from "@/lib/rate-limit";
 
 const createRequest = (
   data: Record<string, string>,
@@ -69,7 +73,7 @@ describe("POST /api/auth/signup", () => {
 
     hashMock.mockResolvedValue("mock-password-hash");
     
-    const { checkRateLimit } = require("@/lib/rate-limit");
+    const { checkRateLimit } = rateLimit;
     vi.mocked(checkRateLimit).mockResolvedValue({
       allowed: true,
       limit: RATE_LIMIT_CONFIG.auth.signup.limit,
@@ -200,7 +204,7 @@ describe("POST /api/auth/signup", () => {
   });
 
   it("uses configured rate limits from environment", async () => {
-    const { checkRateLimit } = require("@/lib/rate-limit");
+    const { checkRateLimit } = rateLimit;
     
     vi.mocked(checkRateLimit).mockResolvedValue({
       allowed: true,
@@ -239,7 +243,7 @@ describe("POST /api/auth/signup", () => {
   });
 
   it("returns 429 when rate limit is exceeded", async () => {
-    const { checkRateLimit, rateLimitExceededResponse } = require("@/lib/rate-limit");
+    const { checkRateLimit, rateLimitExceededResponse } = rateLimit;
     
     vi.mocked(checkRateLimit).mockResolvedValue({
       allowed: false,
@@ -250,10 +254,12 @@ describe("POST /api/auth/signup", () => {
       bypassed: false,
     });
 
-    vi.mocked(rateLimitExceededResponse).mockReturnValue({
-      status: 429,
-      json: async () => ({ error: "Too many requests", retryAfter: RATE_LIMIT_CONFIG.auth.signup.windowSeconds }),
-    });
+    vi.mocked(rateLimitExceededResponse).mockReturnValue(
+      NextResponse.json(
+        { error: "Too many requests", retryAfter: RATE_LIMIT_CONFIG.auth.signup.windowSeconds },
+        { status: 429 },
+      ),
+    );
 
     const request = createRequest({
       name: "Test User",

--- a/src/app/api/tickets/__tests__/tickets.test.ts
+++ b/src/app/api/tickets/__tests__/tickets.test.ts
@@ -10,6 +10,10 @@ vi.mock("@/lib/prisma", () => ({
         },
         ticket: {
             create: vi.fn(),
+            // Route now checks for an existing ticket before creating; default
+            // to "no duplicate" so the create path is exercised.
+            findMany: vi.fn(() => Promise.resolve([])),
+            findFirst: vi.fn(() => Promise.resolve(null)),
         },
     },
 }))
@@ -133,7 +137,7 @@ describe("POST /api/tickets", () => {
         const res = await POST(makeNextRequest(body) as any)
         const data = await res.json()
 
-        expect(res.status).toBe(200)
+        expect(res.status).toBe(201)
         expect(data.ok).toBe(true)
         expect(prisma.ticket.create).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/src/components/__tests__/ticket-upload-form.test.tsx
+++ b/src/components/__tests__/ticket-upload-form.test.tsx
@@ -1,5 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Stub the lucide-react icons — under vitest's ESM resolution they can come
+// through as `undefined`, which makes rendering the icons throw "Element type
+// is invalid". They're purely decorative here, so render nothing.
+vi.mock("lucide-react", () => ({
+  CloudUpload: () => null,
+  CheckCircle2: () => null,
+  AlertCircle: () => null,
+  Loader2: () => null,
+}));
+
 import TicketUploadForm from "../ticket-upload-form";
 
 global.fetch = vi.fn();

--- a/src/components/ticket-upload-form.tsx
+++ b/src/components/ticket-upload-form.tsx
@@ -12,6 +12,9 @@ export default function TicketUploadForm() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const fileRef = useRef<HTMLInputElement | null>(null);
+  // Synchronous re-entry guard: the `loading` state is async, so rapid
+  // repeated submits can all fire before it flips. This blocks them.
+  const submittingRef = useRef(false);
 const [dragActive, setDragActive] = useState(false);
 const [fileName, setFileName] = useState<string | null>(null);
 
@@ -47,6 +50,8 @@ function handleDrop(e: React.DragEvent) {
 
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     setLoading(true);
     setError(null);
     setSuccess(false);
@@ -61,6 +66,7 @@ function handleDrop(e: React.DragEvent) {
         "Idempotency-Key": idempotencyKey,
       },
     });
+    submittingRef.current = false;
     setLoading(false);
 
     if (!res.ok) {
@@ -84,7 +90,7 @@ function handleDrop(e: React.DragEvent) {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-6">
+    <form onSubmit={onSubmit} aria-label="Upload ticket" className="space-y-6">
       <div className="space-y-4">
         <div>
           <label htmlFor="destination" className="block text-sm font-medium">Destination city</label>
@@ -97,7 +103,7 @@ function handleDrop(e: React.DragEvent) {
 
         
        <div>
-  <label className="block text-sm font-medium">Ticket (PDF or image)</label>
+  <label htmlFor="file-upload" className="block text-sm font-medium">Ticket (PDF or image)</label>
 
   <div
     onDragOver={handleDragOver}


### PR DESCRIPTION
Closes #318

### Problem
The test suite was red and CI never ran vitest, so regressions could land unnoticed.

### Root causes & fixes
**Auth suites (signup / signin / forgot-password)** — the real cause of the red tests:
- They did `require("@/lib/rate-limit")` at runtime, but the `@` path alias is only resolved at transform time (via `vite-tsconfig-paths`), so it threw `Cannot find module`. Replaced with a namespace `import * as rateLimit from "@/lib/rate-limit"` of the (mocked) module.
- Added the missing `hashOTP` mock (the signup route imports it).
- The `rateLimitExceededResponse` mocks returned a plain `{status:429}` object; `withValidation` then calls `withRequestId(response)` which sets a header → threw (500). Return real `NextResponse` objects.

**tickets test** — the route now checks for a duplicate before creating, so it calls `prisma.ticket.findMany` (missing from the mock → 500). Added it, and updated the assertion to `201 Created` (the route’s actual, correct status).

**ticket-upload-form** — the icons from `lucide-react` resolve to `undefined` under vitest’s ESM resolution, so rendering threw "Element type is invalid". Stubbed them in the test. Also fixed two real gaps in the component that the tests (correctly) rely on:
- `aria-label` on the `<form>` and `htmlFor` on the file `<label>` (a11y — and makes `getByRole("form")` / `getByLabelText` work).
- A **synchronous `submittingRef` guard** so rapid repeated submits fire the request only once — the `loading` state is async and can’t prevent synchronous re-entry (the test fired 3 submits → 3 requests).

**CI** — added a `Test` step (`npm test`) so vitest runs on every push/PR.

### Result
**All 329 tests pass across 52 files**, and CI now runs the suite.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._

---

**Follow-up (CI):** the new Test step first failed on CI with `ERR_REQUIRE_ESM` — the workflow pinned Node **18.18.0**, which is EOL and can't `require()` the now ESM-only `vite` that vitest 3 loads. Bumped the workflow to Node **22** (current LTS, matches where the suite is validated). Lint and Type check were already green on this branch.
