### PR TITLE
fix(connections): persist in-app notifications on connection request and acceptance

### DIFF
--- a/src/app/api/connections/__tests__/connection-notifications.test.ts
+++ b/src/app/api/connections/__tests__/connection-notifications.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@prisma/client", () => ({
+  NotificationType: {
+    CONNECTION_REQUEST: "CONNECTION_REQUEST",
+    CONNECTION_ACCEPTED: "CONNECTION_ACCEPTED",
+    MATCH_FOUND: "MATCH_FOUND",
+    TICKET_VERIFIED: "TICKET_VERIFIED",
+    TICKET_REJECTED: "TICKET_REJECTED",
+    ACCOUNT_VERIFIED: "ACCOUNT_VERIFIED",
+    MESSAGE: "MESSAGE",
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    connectionRequest: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    conversation: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/blocking", () => ({
+  isBlockedBetween: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/lib/pusher", () => ({
+  triggerPusher: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  createNotification: vi.fn().mockResolvedValue({ id: "notif-1" }),
+}));
+
+vi.mock("@/lib/rate-limit-rules", () => ({
+  enforceRateLimit: vi.fn().mockResolvedValue({
+    allowed: true,
+    limit: 20,
+    remaining: 19,
+    resetSeconds: 60,
+    bypassed: false,
+  }),
+}));
+
+import { POST } from "../route";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { createNotification } from "@/lib/notifications";
+import { NotificationType } from "@prisma/client";
+
+describe("POST /api/connections - notification persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createRequest = (body: any) => {
+    return {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => body,
+    } as any;
+  };
+
+  it("persists CONNECTION_REQUEST notification when sending connection request", async () => {
+    (auth as any).mockResolvedValue({
+      user: { id: "user-1", name: "Alice" },
+    });
+    (prisma.connectionRequest.findFirst as any).mockResolvedValue(null);
+    (prisma.connectionRequest.create as any).mockResolvedValue({
+      id: "req-1",
+      senderId: "user-1",
+      receiverId: "user-2",
+      status: "PENDING",
+    });
+
+    const req = createRequest({ action: "send", userId: "user-2" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-2",
+        type: NotificationType.CONNECTION_REQUEST,
+        title: "New connection request",
+        content: "Alice sent you a connection request.",
+      }),
+    );
+  });
+
+  it("persists CONNECTION_ACCEPTED notification when accepting connection request", async () => {
+    (auth as any).mockResolvedValue({
+      user: { id: "user-2", name: "Bob" },
+    });
+    (prisma.connectionRequest.findUnique as any).mockResolvedValue({
+      id: "req-1",
+      senderId: "user-1",
+      receiverId: "user-2",
+      status: "PENDING",
+    });
+    (prisma.connectionRequest.update as any).mockResolvedValue({
+      id: "req-1",
+      status: "ACCEPTED",
+    });
+    (prisma.conversation.findFirst as any).mockResolvedValue({ id: "conv-1" });
+
+    const req = createRequest({ action: "accept", userId: "user-1" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        type: NotificationType.CONNECTION_ACCEPTED,
+        title: "Connection accepted",
+        content: "Bob accepted your connection request.",
+      }),
+    );
+  });
+});

--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -2,9 +2,11 @@ import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 import { isBlockedBetween } from "@/lib/blocking";
+import { createNotification } from "@/lib/notifications";
 import { rateLimitExceededResponse } from "@/lib/rate-limit";
 import { enforceRateLimit } from "@/lib/rate-limit-rules";
 import { triggerPusher } from "@/lib/pusher";
+import { NotificationType } from "@prisma/client";
 
 export async function GET(req: NextRequest) {
   const session = await auth();
@@ -190,6 +192,15 @@ export async function POST(req: NextRequest) {
             request: updated,
           });
 
+          await createNotification({
+            userId,
+            type: NotificationType.CONNECTION_REQUEST,
+            title: "New connection request",
+            content: `${session.user.name || "A traveller"} sent you a connection request.`,
+            link: "/dashboard",
+            dedupeKey: `conn-req:${currentUserId}:${userId}`,
+          });
+
           return NextResponse.json({ success: true, request: updated });
         }
       }
@@ -209,6 +220,15 @@ export async function POST(req: NextRequest) {
 
       await triggerPusher(`private-user-${userId}`, "connection-request", {
         request: newRequest,
+      });
+
+      await createNotification({
+        userId,
+        type: NotificationType.CONNECTION_REQUEST,
+        title: "New connection request",
+        content: `${session.user.name || "A traveller"} sent you a connection request.`,
+        link: "/dashboard",
+        dedupeKey: `conn-req:${currentUserId}:${userId}`,
       });
 
       return NextResponse.json({ success: true, request: newRequest });
@@ -273,6 +293,15 @@ export async function POST(req: NextRequest) {
           id: currentUserId,
           name: session.user.name || "A traveler",
         },
+      });
+
+      await createNotification({
+        userId,
+        type: NotificationType.CONNECTION_ACCEPTED,
+        title: "Connection accepted",
+        content: `${session.user.name || "A traveller"} accepted your connection request.`,
+        link: "/dashboard",
+        dedupeKey: `conn-accept:${currentUserId}:${userId}`,
       });
 
       return NextResponse.json({ success: true, conversationId: conversation.id });


### PR DESCRIPTION
Fixes #400

### Summary
Calls \createNotification()\ when sending a connection request (\NotificationType.CONNECTION_REQUEST\) and when accepting a request (\NotificationType.CONNECTION_ACCEPTED\). This ensures that recipient users receive in-app notifications in their database notification inbox even when offline.

### Verification
Added unit tests in \src/app/api/connections/__tests__/connection-notifications.test.ts\ verifying that notifications are created in database for both connection actions.