### PR TITLE
fix(user/block): remove all connection requests when blocking a user

### DIFF
--- a/src/app/api/user/block/__tests__/block-accepted-connection.test.ts
+++ b/src/app/api/user/block/__tests__/block-accepted-connection.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    block: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    connectionRequest: {
+      deleteMany: vi.fn(),
+    },
+    $transaction: vi.fn(async (callback: any) => {
+      if (typeof callback === "function") {
+        return callback(prisma);
+      }
+      return Promise.all(callback);
+    }),
+  },
+}));
+
+import { POST } from "../route";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+
+describe("POST /api/user/block - remove all connections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createRequest = (body: any) => {
+    return {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => body,
+    } as any;
+  };
+
+  it("removes all connection requests (including ACCEPTED) when blocking a user", async () => {
+    (auth as any).mockResolvedValue({
+      user: { id: "user-1" },
+    });
+
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: "user-2",
+      isDeleted: false,
+    });
+
+    (prisma.block.findUnique as any).mockResolvedValue(null);
+
+    const req = createRequest({ blockedId: "user-2" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.success).toBe(true);
+
+    expect(prisma.connectionRequest.deleteMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { senderId: "user-1", receiverId: "user-2" },
+          { senderId: "user-2", receiverId: "user-1" },
+        ],
+      },
+    });
+  });
+});

--- a/src/app/api/user/block/route.ts
+++ b/src/app/api/user/block/route.ts
@@ -158,9 +158,9 @@ export const POST = withValidation(BlockSchema, async (request, validatedData) =
       return NextResponse.json({ success: true, message: "User is already blocked" });
     }
 
-    // Creating the block and clearing a pending connection request go together:
-    // leaving the request behind would keep the blocked user sitting in the
-    // caller's "incoming" list with no way to act on it.
+    // Creating the block and clearing all connection requests go together:
+    // leaving any connection requests (pending or accepted) behind would cause
+    // inconsistent relationship state and keep blocked users listed as connections.
     await prisma.$transaction([
       prisma.block.create({
         data: {
@@ -170,7 +170,6 @@ export const POST = withValidation(BlockSchema, async (request, validatedData) =
       }),
       prisma.connectionRequest.deleteMany({
         where: {
-          status: "PENDING",
           OR: [
             { senderId: session.user.id, receiverId: blockedId },
             { senderId: blockedId, receiverId: session.user.id },


### PR DESCRIPTION
Fixes #401

### Summary
In \src/app/api/user/block/route.ts\, updated \prisma.connectionRequest.deleteMany\ within the block transaction to remove all connection requests (both \PENDING\ and \ACCEPTED\) between the two users. This avoids leaving active connection records after a user is blocked.

### Verification
Added unit test in \src/app/api/user/block/__tests__/block-accepted-connection.test.ts\ verifying that all connection records between the users are removed upon blocking.