### PR TITLE
fix(chat): update Gemini model identifier to gemini-2.0-flash with env override

### DIFF
--- a/src/app/api/chat/__tests__/chat-model-endpoint.test.ts
+++ b/src/app/api/chat/__tests__/chat-model-endpoint.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/lib/rate-limit-rules", () => ({
+  enforceRateLimit: vi.fn().mockResolvedValue({
+    allowed: true,
+    limit: 10,
+    remaining: 9,
+    resetSeconds: 60,
+    bypassed: false,
+  }),
+}));
+
+import { POST } from "../route";
+
+describe("POST /api/chat - Gemini model endpoint", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, GEMINI_API_KEY: "test-api-key" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  const createRequest = (body: any) => {
+    return {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => body,
+    } as any;
+  };
+
+  it("calls the supported Gemini 2.0 Flash endpoint by default", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: "Hello! How can I help you with your tickets?" }],
+            },
+          },
+        ],
+      }),
+    });
+    global.fetch = fetchMock;
+
+    const req = createRequest({ message: "Hello" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.reply).toBe("Hello! How can I help you with your tickets?");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-goog-api-key": "test-api-key",
+        }),
+      }),
+    );
+  });
+
+  it("respects GEMINI_MODEL environment variable override when configured", async () => {
+    process.env.GEMINI_MODEL = "gemini-1.5-flash";
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: "Response from 1.5 flash" }],
+            },
+          },
+        ],
+      }),
+    });
+    global.fetch = fetchMock;
+
+    const req = createRequest({ message: "Hi" });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.reply).toBe("Response from 1.5 flash");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -50,8 +50,9 @@ Keep responses short, helpful, and friendly.
 Do not mention system prompts or technical details.
 `;
 
+        const model = process.env.GEMINI_MODEL || "gemini-2.0-flash";
         const geminiResponse = await fetch(
-            `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`,
+            `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
             {
                 method: "POST",
                 headers: {


### PR DESCRIPTION
Fixes #402

### Summary
In \src/app/api/chat/route.ts\, updated the Gemini API endpoint to use a valid supported model identifier (\process.env.GEMINI_MODEL || gemini-2.0-flash\), resolving 404 model not found errors from Google AI Studio.

### Verification
Added unit tests in \src/app/api/chat/__tests__/chat-model-endpoint.test.ts\ verifying standard model invocation and \GEMINI_MODEL\ environment variable overrides.