### PR TITLE
fix: PATCH /api/user/profile leaks passwordHash + live reset token (#408)

### DIFF
--- a/src/app/api/user/__tests__/profile-expansion.test.ts
+++ b/src/app/api/user/__tests__/profile-expansion.test.ts
@@ -172,6 +172,9 @@ const res = await profileGET(
           gender: undefined,
           travelStyle: undefined,
         },
+        // PATCH now returns a non-sensitive projection (excludes passwordHash,
+        // otp, resetToken, ...) — the exact fields aren't asserted here.
+        select: expect.any(Object),
       });
     });
   });

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -173,6 +173,28 @@ export async function PATCH(request: NextRequest) {
             ? body.travelStyle
             : undefined,
       },
+      // Return only non-sensitive columns — Prisma's default update returns the
+      // whole row (passwordHash, otp, resetToken, ...). Mirror the GET projection.
+      select: {
+        name: true,
+        email: true,
+        bio: true,
+        location: true,
+        image: true,
+        homeLocation: true,
+        phone: true,
+        emailVerified: true,
+        createdAt: true,
+        languages: true,
+        travelInterests: true,
+        accommodationPrefs: true,
+        budgetRange: true,
+        socialLinks: true,
+        age: true,
+        gender: true,
+        travelStyle: true,
+        isDeleted: true,
+      },
     });
 
     return apiJson(updatedUser, requestId);


### PR DESCRIPTION
Fixes #408

### Problem
`PATCH /api/user/profile` did `prisma.user.update({ where, data })` with **no `select`/`omit`** and returned the result via `apiJson(updatedUser, requestId)`. Prisma’s `update` returns the full row, so the JSON response included `passwordHash`, `otp`, `otpExpires`, `resetToken`, `resetTokenExpires`, `emailVerified`, `role`, `isDeleted`.

A logged-in user with an in-flight password reset who edits any field (e.g. bio) got their bcrypt hash **and still-valid `resetToken`** in the 200 body — an account-takeover credential exposed to browser history, client telemetry, XSS, or proxies. (The sibling `GET` already uses an explicit `select`; `PATCH` didn’t.)

### Fix
Added an explicit `select` to the `update`, mirroring the `GET` projection, so only non-sensitive fields are returned. Updated the one `profile-expansion` assertion that pinned the exact `update()` args.

### Note on CI
Three profile tests fail on **current `main` independently of this change** — `profile-social-links` (×2) and `profile-expansion` "returns profile with rich fields" — because their `prisma.user.findUnique` mock predates the `isDeleted` guard the PATCH/GET handlers now run (they get `404` instead of `200`). I confirmed they fail on a clean checkout without this PR. Happy to fix the suite in a separate PR if you’d like.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._