### PR TITLE
fix: rate limiting bypassable via spoofed leftmost X-Forwarded-For (#410)

### DIFF
--- a/src/lib/__tests__/client-ip.test.ts
+++ b/src/lib/__tests__/client-ip.test.ts
@@ -10,12 +10,21 @@ function requestWithHeaders(
 }
 
 describe("getClientIp", () => {
-  it("uses the first valid forwarded address", () => {
+  it("uses the rightmost (nearest-hop) forwarded address, not the spoofable leftmost", () => {
     const request = requestWithHeaders({
       "x-forwarded-for": "203.0.113.5, 10.0.0.2",
     });
 
-    expect(getClientIp(request)).toBe("203.0.113.5");
+    expect(getClientIp(request)).toBe("10.0.0.2");
+  });
+
+  it("prefers trusted platform headers over a spoofable X-Forwarded-For", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "1.2.3.4",
+      "x-real-ip": "198.51.100.7",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.7");
   });
 
   it("falls back to platform IP headers", () => {

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -36,17 +36,9 @@ function normalizeIp(value: string | null | undefined): string | null {
  * Raw header values are never used directly as Redis keys.
  */
 export function getClientIp(request: NextRequest): string {
-  const forwardedFor = request.headers.get("x-forwarded-for");
-
-  if (forwardedFor) {
-    for (const value of forwardedFor.split(",")) {
-      const parsed = normalizeIp(value);
-      if (parsed) {
-        return parsed;
-      }
-    }
-  }
-
+  // Prefer platform-set headers first: a CDN/proxy (Vercel, Cloudflare, Fly)
+  // overwrites these, so — unlike the client-supplied X-Forwarded-For — they
+  // can't be spoofed by the caller.
   const platformHeaders = [
     request.headers.get("x-real-ip"),
     request.headers.get("cf-connecting-ip"),
@@ -57,6 +49,22 @@ export function getClientIp(request: NextRequest): string {
     const parsed = normalizeIp(value);
     if (parsed) {
       return parsed;
+    }
+  }
+
+  // Fall back to X-Forwarded-For, taking the RIGHTMOST valid entry — the hop
+  // closest to the server. The leftmost entry is the attacker-controllable end
+  // of the chain; keying rate limits on it let a caller rotate it per request
+  // and never trip the limit.
+  const forwardedFor = request.headers.get("x-forwarded-for");
+
+  if (forwardedFor) {
+    const parts = forwardedFor.split(",");
+    for (let i = parts.length - 1; i >= 0; i -= 1) {
+      const parsed = normalizeIp(parts[i]);
+      if (parsed) {
+        return parsed;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #410

### Problem
`getClientIp` (`src/lib/client-ip.ts`) returned the **first (leftmost)** valid `X-Forwarded-For` entry *before* falling back to platform headers. The leftmost entry is the client-controllable end of the chain, so an attacker could rotate `X-Forwarded-For: <random>` per request — each value hashing to a fresh Redis bucket — and never trip the per-IP limits (auth brute-force via `authSignin`/`authForgotPassword`/`authVerifyOtp`, and the unauthenticated `chat` Gemini cost-abuse limit).

### Fix
- **Prefer the platform-set headers first** (`x-real-ip` / `cf-connecting-ip` / `fly-client-ip`) — a CDN/proxy overwrites these, so the caller can’t spoof them.
- Only then fall back to `X-Forwarded-For`, taking the **rightmost** (nearest-hop) valid entry instead of the leftmost.

### Tests
Updated `client-ip.test.ts`: the forwarded case now expects the rightmost address, and a new test asserts platform headers win over a spoofed `X-Forwarded-For`. (4 pass.)

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._