### PR TITLE
fix: match-cache invalidation misses substring searches (#409)

### DIFF
--- a/src/lib/__tests__/match-cache.test.ts
+++ b/src/lib/__tests__/match-cache.test.ts
@@ -159,9 +159,7 @@ describe("cache invalidation", () => {
       "2026-08-15",
     )) {
       await expect(
-        getMatchCacheVersion(
-          "goa",
-          date,
+        getMatchCacheVersion(date,
           store,
         ),
       ).resolves.toBe(1);
@@ -200,6 +198,32 @@ describe("cache invalidation", () => {
     expect(after).not.toBe(before);
   });
 
+  it("invalidates substring-destination searches after a superstring ticket is verified (#409)", async () => {
+    const store = new MemoryStore();
+
+    // A user searches for "Paris" (matched by substring against ticket destinations).
+    const searchInput = {
+      destination: "Paris",
+      date: "2026-08-15",
+      userId: "search-user",
+    };
+    const before = await buildMatchCacheKey(searchInput, store);
+    expect(before).toContain(":v0");
+
+    // A ticket to "Paris, France" (same date) is verified — it satisfies the
+    // "Paris" substring search, so that search's cache must be invalidated even
+    // though the ticket's full destination differs from the query.
+    await invalidateMatchCachesForTicket(
+      { destination: "Paris, France", departureDate: "2026-08-15" },
+      null,
+      store,
+    );
+
+    const after = await buildMatchCacheKey(searchInput, store);
+    expect(after).toContain(":v1");
+    expect(after).not.toBe(before);
+  });
+
   it("invalidates old and new windows after destination or date changes", async () => {
     const store = new MemoryStore();
 
@@ -216,16 +240,12 @@ describe("cache invalidation", () => {
     );
 
     await expect(
-      getMatchCacheVersion(
-        "Goa",
-        "2026-08-15",
+      getMatchCacheVersion("2026-08-15",
         store,
       ),
     ).resolves.toBe(1);
     await expect(
-      getMatchCacheVersion(
-        "Mumbai",
-        "2026-09-10",
+      getMatchCacheVersion("2026-09-10",
         store,
       ),
     ).resolves.toBe(1);
@@ -259,9 +279,7 @@ describe("cache invalidation", () => {
       .mockImplementation(() => undefined);
 
     await expect(
-      getMatchCacheVersion(
-        "Goa",
-        "2026-08-15",
+      getMatchCacheVersion("2026-08-15",
         broken,
       ),
     ).resolves.toBe(0);

--- a/src/lib/match-cache.ts
+++ b/src/lib/match-cache.ts
@@ -66,13 +66,13 @@ export function normalizeMatchDate(
   return date.toISOString().slice(0, 10);
 }
 
-function versionKey(
-  destination: string,
-  date: string,
-): string {
-  return `matches-version:${normalizeMatchDestination(
-    destination,
-  )}:${normalizeMatchDate(date)}`;
+function versionKey(date: string): string {
+  // Keyed by date only. Match search filters destinations by SUBSTRING, so a
+  // ticket's full destination can satisfy many different search queries — a
+  // per-destination version could never invalidate those substring searches
+  // (a verified "Paris, France" ticket never bumped the "Paris" search's key).
+  // A single per-date version invalidates every destination search for the date.
+  return `matches-version:${normalizeMatchDate(date)}`;
 }
 
 function filterFingerprint(
@@ -98,7 +98,6 @@ function filterFingerprint(
 }
 
 export async function getMatchCacheVersion(
-  destination: string,
   date: string,
   store: MatchCacheStore | null = redis as unknown as MatchCacheStore | null,
 ): Promise<number> {
@@ -107,9 +106,7 @@ export async function getMatchCacheVersion(
   }
 
   try {
-    const raw = await store.get(
-      versionKey(destination, date),
-    );
+    const raw = await store.get(versionKey(date));
     const parsed = Number(raw);
 
     return Number.isSafeInteger(parsed) && parsed >= 0
@@ -131,11 +128,7 @@ export async function buildMatchCacheKey(
   const destination =
     normalizeMatchDestination(input.destination);
   const date = normalizeMatchDate(input.date);
-  const version = await getMatchCacheVersion(
-    destination,
-    date,
-    store,
-  );
+  const version = await getMatchCacheVersion(date, store);
 
   return [
     "matches",
@@ -224,11 +217,10 @@ export function getAffectedMatchDates(
 }
 
 async function incrementVersion(
-  destination: string,
   date: string,
   store: MatchCacheStore,
 ): Promise<void> {
-  const key = versionKey(destination, date);
+  const key = versionKey(date);
   await store.incr(key);
 
   // Prevent permanent accumulation of version keys while retaining a
@@ -249,32 +241,24 @@ export async function invalidateMatchCachesForTicket(
     (value): value is TicketCacheIdentity =>
       Boolean(value),
   );
-  const keys = new Set<string>();
+  // Collect the affected dates across the old and new ticket windows. Versions
+  // are keyed by date only, so bumping each date invalidates every destination
+  // search for that date (including substring matches).
+  const dates = new Set<string>();
 
   for (const identity of identities) {
-    const destination =
-      normalizeMatchDestination(
-        identity.destination,
-      );
-
     for (const date of getAffectedMatchDates(
       identity.departureDate,
     )) {
-      keys.add(`${destination}\u0000${date}`);
+      dates.add(date);
     }
   }
 
   try {
     await Promise.all(
-      [...keys].map((entry) => {
-        const [destination, date] =
-          entry.split("\u0000");
-        return incrementVersion(
-          destination,
-          date,
-          store,
-        );
-      }),
+      [...dates].map((date) =>
+        incrementVersion(date, store),
+      ),
     );
   } catch (error) {
     console.warn(


### PR DESCRIPTION
Fixes #409

### Problem
Match search filters tickets by **substring** (`destination: { contains: query }`), but the cache **version** was keyed by the ticket’s **full normalized destination**. A search for `"Paris"` read `matches-version:paris:<date>`, while verifying a `"Paris, France"` ticket only bumped `matches-version:paris, france:<date>` — so the `"Paris"` search kept serving **stale** results (omitting the newly-verified traveller) until the 5-min TTL. Every partial/substring search (the common case) was affected; only exact-string searches invalidated correctly.

### Fix
Key the cache version by **date only**, so verifying a ticket for a date invalidates *every* destination search for that date (substring or not). The cache key itself still includes the destination — only the version dimension drops it. `getMatchCacheVersion` / `incrementVersion` / `invalidateMatchCachesForTicket` are updated accordingly (scoped to the same ±window of affected dates as before).

### Tests
Updated the existing version tests to the date-only signature and added a regression test: a `"Paris, France"` ticket now invalidates a `"Paris"` substring search (`v0 → v1`). It fails on the old lib and passes now (9/9).

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._